### PR TITLE
Bf/fnirt

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Release 0.3.4 (FUTURE)
 * ENH: Added distance and dissimilarity measurements
 
 * BF: Diffusion toolkit gets installed 
+* BF: Changed FNIRT interface to accept flexible lists (rather than 4-tuples)
+      on all options specific to different subsampling levels
 
 Release 0.3.3 (Sep 16, 2010)
 ============================

--- a/nipype/interfaces/fsl/tests/test_preprocess.py
+++ b/nipype/interfaces/fsl/tests/test_preprocess.py
@@ -350,12 +350,14 @@ def test_fnirt():
     fnirt = fsl.FNIRT()
     yield assert_equal, fnirt.cmd, 'fnirt'
 
-    # Test tuple parameters
-    params = [('subsampling_scheme', '--subsamp', (4,2,2,1),'4,2,2,1'),
-              ('max_nonlin_iter', '--miter', (4,4,4,2),'4,4,4,2'),
-              ('ref_fwhm', '--reffwhm', (4,2,2,0),'4,2,2,0'),
-              ('in_fwhm', '--infwhm', (4,2,2,0),'4,2,2,0'),
-              ('regularization_lambda', '--lambda', 0.5, '0.500000')]
+    # Test list parameters
+    params = [('subsampling_scheme', '--subsamp', [4,2,2,1],'4,2,2,1'),
+              ('max_nonlin_iter', '--miter', [4,4,4,2],'4,4,4,2'),
+              ('ref_fwhm', '--reffwhm', [4,2,2,0],'4,2,2,0'),
+              ('in_fwhm', '--infwhm', [4,2,2,0],'4,2,2,0'),
+              ('apply_refmask', '--applyrefmask', [0,0,1,1],'0,0,1,1'),
+              ('apply_inmask', '--applyinmask', [0,0,0,1],'0,0,0,1'),
+              ('regularization_lambda', '--lambda', [0.5,0.75],'0.5,0.75')]
     for item, flag, val, strval in params:
         fnirt = fsl.FNIRT(in_file = infile,
                           ref_file = reffile,
@@ -373,6 +375,15 @@ def test_fnirt():
                   '--in=%s %s=%s '\
                   '--ref=%s --iout=%s' % (cout, infile, flag,
                                           strval,reffile, iout)
+        elif item.startswith('apply'):
+            cmd = 'fnirt %s=%s '\
+                  '--cout=%s '\
+                  '--in=%s '\
+                  '--ref=%s --iout=%s' % (flag,strval,
+                                                cout, infile,
+                                                reffile,
+                                                iout)
+
         else:
             cmd = 'fnirt --cout=%s '\
                   '--in=%s '\


### PR DESCRIPTION
FNIRT has some options that (on the command line) take a comma-separated list of options, where each item applies to that subsampling level.  In our FNIRT interface, these were hardcoded in as 4-tuples.  However, these can be any length (the length just has to match the subsampling scheme, and you can specify as many levels of subsampling as you want).

I changed these to accept lists of ints/floats, and updated the appropriate tests.

FNIRT still has a bug where, even though you can set the name of the output files, it raises a FileNotFound error after execution if you explicitly set the name to something other than the nipype default.  I couldn't quite follow what's going in in the FNIRT output aggregation, though, so I didn't want to mess around with that.  
