### PR TITLE
Enh/matlab

### DIFF
--- a/nipype/interfaces/matlab.py
+++ b/nipype/interfaces/matlab.py
@@ -34,6 +34,7 @@ class MatlabInputSpec(CommandLineInputSpec):
     prescript = traits.List(["ver,","try,"], usedefault=True,
                             desc='prescript to be added before code')
     postscript = traits.List(["\n,catch ME,",
+                              "fprintf(2,'MATLAB code threw an exception:\\n');",
                               "fprintf(2,'%s\\n',ME.message);",
                               "if length(ME.stack) ~= 0, fprintf(2,'File:%s\\nName:%s\\nLine:%d\\n',ME.stack.file,ME.stack.name,ME.stack.line);, end;",
                               "end;"], desc='script added after code', usedefault = True)
@@ -109,7 +110,7 @@ class MatlabCommand(CommandLine):
 
     def _run_interface(self,runtime):
         runtime = super(MatlabCommand, self)._run_interface(runtime)
-        if runtime.stderr != '':
+        if 'MATLAB code threw an exception' in runtime.stderr:
             runtime.returncode = 1
         return runtime
 


### PR DESCRIPTION
noticeable changes:
- mfile defaults to True, because this way of calling matlab code is more reliable and easier to debug
- when mfile == False code is stripped of comments and all new lines are replaced with commas - this prevents from stalling (when for example you run matlab -nodesktop -nosplash -singleCompThread -r "ver; %dfsdfs exit;" it will open MATLAB console and wait forever)
- cleaned up error reporting: messages are printed only once, stack is not printed when it's empty
- runtime error code is set to 1 not only when you get an exception but each time anything is printed to stderr
