### PR TITLE
improve debug and info output generated by substitutions

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -197,16 +197,23 @@ class DataSink(IOBase):
         return dst
 
     def _substitute(self, pathstr):
+        pathstr_ = pathstr
         if isdefined(self.inputs.substitutions):
             for key, val in self.inputs.substitutions:
-                iflogger.debug(str((pathstr, key, val)))
+                _ = pathstr
                 pathstr = pathstr.replace(key, val)
-                iflogger.debug('new: ' + pathstr)
+                if pathstr != _:
+                    iflogger.debug('sub.str: %s -> %s using %r -> %r'
+                                   % (_, pathstr, key, val))
         if isdefined(self.inputs.regexp_substitutions):
             for key, val in self.inputs.regexp_substitutions:
-                iflogger.debug(str((pathstr, "regexp:" + key, val)))
+                _ = pathstr
                 pathstr, _ = re.subn(key, val, pathstr)
-                iflogger.debug('new: ' + pathstr)
+                if pathstr != _:
+                    iflogger.debug('sub.regexp: %s -> %s using %r -> %r'
+                                   % (_, pathstr, key, val))
+        if pathstr_ != pathstr:
+            iflogger.info('sub: %s -> %s' % (pathstr_, pathstr))
         return pathstr
 
     def _list_outputs(self):


### PR DESCRIPTION
all those debug messages are actually useful while trying to figure out what substitutions did take place and how file names got changed.  For non-debug (INFO) mode it seems sensible to report the final result of such a substitution while at debug level it would be useful to report all substitutions which actually took place
