### PR TITLE
BF: allow sourced functions to be indented -- dedent before pickling

### DIFF
--- a/nipype/utils/misc.py
+++ b/nipype/utils/misc.py
@@ -7,12 +7,13 @@ import inspect
 
 from distutils.version import LooseVersion
 import numpy as np
+from textwrap import dedent
 
 from nipype.interfaces.traits import _Undefined
 
 def getsource(function):
     """Returns the source code of a function"""
-    src = dumps(inspect.getsource(function))
+    src = dumps(dedent(inspect.getsource(function)))
     return src
 
 def create_function_from_source(function_source):

--- a/nipype/utils/tests/test_misc.py
+++ b/nipype/utils/tests/test_misc.py
@@ -2,7 +2,8 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from nipype.testing import assert_equal, assert_true
 
-from nipype.utils.misc import container_to_string
+from nipype.utils.misc import container_to_string, \
+     getsource, create_function_from_source
 
 def test_cont_to_str():
     # list
@@ -24,3 +25,17 @@ def test_cont_to_str():
     # int.  Integers are not the main intent of this function, but see
     # no reason why they shouldn't work.
     yield assert_equal, container_to_string(123), '123'
+
+def _func1(x):
+    return x**3
+
+def test_func_to_str():
+
+    def func1(x):
+        return x**2
+
+    # Should be ok with both functions!
+    for f in _func1, func1:
+        f_src = getsource(f)
+        f_recreated = create_function_from_source(f_src)
+        yield assert_equal, f(2.3), f_recreated(2.3)


### PR DESCRIPTION
otherwise

```
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/nose/loader.py", line 224, in generate
    for test in g():
  File "/home/yoh/deb/gits/pkg-exppsy/nipype/nipype/utils/tests/test_misc.py", line 40, in test_func_to_str
    f_recreated = create_function_from_source(f_src)
  File "/home/yoh/deb/gits/pkg-exppsy/nipype/nipype/utils/misc.py", line 31, in create_function_from_source
    raise RuntimeError(msg)
RuntimeError: unexpected indent (<string>, line 1)
Error executing function:
 S'    def func1(x):\n        return x**2\n'
.
Functions in connection strings have to be standalone.
They cannot be declared either interactively or inside
another function or inline in the connect string. Any
imports should be done inside the function
```
