### PR TITLE
store graph by default under workflow's directory

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -387,6 +387,7 @@ class Workflow(WorkflowBase):
                     base_dir = os.path.join(base_dir, self.name)
             else:
                 base_dir = os.getcwd()
+        base_dir = make_output_dir(base_dir)
         if graph2use == 'hierarchical':
             dotfilename = os.path.join(base_dir, dotfilename)
             self.write_hierarchical_dotfile(dotfilename=dotfilename)


### PR DESCRIPTION
there is no reason to pollute base_dir imho
