### PR TITLE
Moved networkx dev detection to debug log level

### DIFF
--- a/nipype/pipeline/utils.py
+++ b/nipype/pipeline/utils.py
@@ -23,7 +23,7 @@ try:
     dfs_preorder = nx.dfs_preorder
 except AttributeError:
     dfs_preorder = nx.dfs_preorder_nodes
-    logger.info('networkx 1.4 dev or higher detected')
+    logger.debug('networkx 1.4 dev or higher detected')
 
 try:
     from os.path import relpath


### PR DESCRIPTION
this is super small-bore, but it's pretty nitty-gritty information and it was annoying getting that message printed every time i imported nipype
