### PR TITLE
fix: changed depidx to user sparse matrices enh: single subnode mapnodes 

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -1186,6 +1186,7 @@ class MapNode(Node):
         self._inputs = self._create_dynamic_traits(self._interface.inputs,
                                                    fields=self.iterfield)
         self._inputs.on_trait_change(self._set_mapnode_input)
+        self._got_inputs = False
 
     def _create_dynamic_traits(self, basetraits, fields=None, nitems=None):
         """Convert specific fields of a trait to accept multiple inputs
@@ -1319,8 +1320,16 @@ class MapNode(Node):
                                                                 '\n'.join(msg)))
 
     def get_subnodes(self):
-        self._get_inputs()
+        if not self._got_inputs:
+            self._get_inputs()
+            self._got_inputs = True
         return [node for _, node in self._make_nodes()]
+    
+    def num_subnodes(self):
+        if not self._got_inputs:
+            self._get_inputs()
+            self._got_inputs = True
+        return len(filename_to_list(getattr(self.inputs, self.iterfield[0])))
     
     def _run_interface(self, execute=True, updatehash=False):
         """Run the mapnode interface

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -14,6 +14,7 @@ from time import strftime, sleep
 from traceback import format_exception
 
 import numpy as np
+import scipy.sparse as ssp
 
 from ..utils import (nx, dfs_preorder, config)
 from ..engine import MapNode
@@ -174,13 +175,16 @@ class DistributedPluginBase(PluginBase):
         self.mapnodes.append(jobid)
         mapnodesubids = self.procs[jobid].get_subnodes()
         numnodes = len(mapnodesubids)
+        logger.info('Adding %d jobs for mapnode %s'%(numnodes, self.procs[jobid]._id))
         for i in range(numnodes):
             self.mapnodesubids[self.depidx.shape[0]+i] = jobid
         self.procs.extend(mapnodesubids)
-        self.depidx = np.vstack((self.depidx,
-                                 np.zeros((numnodes, self.depidx.shape[1]))))
-        self.depidx = np.hstack((self.depidx,
-                                 np.zeros((self.depidx.shape[0], numnodes))))
+        self.depidx = ssp.vstack((self.depidx,
+                                  ssp.lil_matrix(np.zeros((numnodes, self.depidx.shape[1])))),
+                                 'lil')
+        self.depidx = ssp.hstack((self.depidx,
+                                  ssp.lil_matrix(np.zeros((self.depidx.shape[0], numnodes)))),
+                                 'lil')
         self.depidx[-numnodes:, jobid] = 1
         self.proc_done = np.concatenate((self.proc_done,
                                          np.zeros(numnodes, dtype=bool)))
@@ -194,12 +198,13 @@ class DistributedPluginBase(PluginBase):
         while np.any(self.proc_done == False):
             # Check to see if a job is available
             jobids = np.flatnonzero((self.proc_done == False) & \
-                                    np.all(self.depidx==0, axis=0))
+                                        (self.depidx.sum(axis=0)==0).__array__())
             if len(jobids)>0:
                 # send all available jobs
                 logger.info('Submitting %d jobs' % len(jobids))
                 for jobid in jobids:
-                    if isinstance(self.procs[jobid], MapNode):
+                    if isinstance(self.procs[jobid], MapNode) and \
+                            self.procs[jobid].num_subnodes()>1:
                         submit = self._submit_mapnode(jobid)
                         if not submit:
                             continue
@@ -228,15 +233,15 @@ class DistributedPluginBase(PluginBase):
         # update the job dependency structure
         self.depidx[jobid, :] = 0.
         if jobid not in self.mapnodesubids:
-            self.refidx[np.nonzero(self.refidx[:,jobid]>0)[0],jobid] = 0
+            self.refidx[self.refidx[:,jobid].nonzero()[0],jobid] = 0
 
     def _generate_dependency_list(self, graph):
         """ Generates a dependency list for a list of graphs.
         """
         self.procs = graph.nodes()
-        self.depidx = nx.adj_matrix(graph).__array__()
-        self.refidx = deepcopy(self.depidx>0)
-        self.refidx.dtype = np.int8
+        self.depidx = ssp.lil_matrix(nx.adj_matrix(graph).__array__())
+        self.refidx = deepcopy(self.depidx)
+        self.refidx.astype = np.int
         self.proc_done    = np.zeros(len(self.procs), dtype=bool)
         self.proc_pending = np.zeros(len(self.procs), dtype=bool)
 
@@ -254,7 +259,7 @@ class DistributedPluginBase(PluginBase):
         """Removes directories whose outputs have already been used up
         """
         if config.getboolean('execution', 'remove_node_directories'):
-            for idx in np.nonzero(np.all(self.refidx==0,axis=1))[0]:
+            for idx in np.nonzero((self.refidx.sum(axis=1)==0).__array__())[0]:
                 if idx in self.mapnodesubids:
                     continue
                 if self.proc_done[idx] and (not self.proc_pending[idx]):


### PR DESCRIPTION
fix: changed depidx to use sparse matrices 
enh: single subnode mapnodes do not get submitted separately as two tasks, but as a single task
