### PR TITLE
Modified freesurfer.GLMFit inputs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ Release 0.4 (FUTURE)
 * API: fsl FILMGLS input "autocorr_estimate" is now called "autocorr_estimate_only"
 * API: fsl ContrastMgr now requires access to specific files (no longer accepts
        the result directory)
+* API: freesurfer.GLMFit input "surf" is now a boolean with three corresponding
+       inputs -- subject_id, hemi, and surf_geo
 
 * ENH: All commandline interfaces display stdout and stderr
 * ENH: All interfaces raise exceptions on error with an option to suppress

--- a/nipype/interfaces/freesurfer/model.py
+++ b/nipype/interfaces/freesurfer/model.py
@@ -181,10 +181,12 @@ class GLMFitInputSpec(FSTraitedSpec):
                                desc='save residual error (eres)')
     save_res_corr_mtx = traits.Bool(argstr='--eres-scm',
        desc='save residual error spatial correlation matrix (eres.scm). Big!')
-    surf = traits.Tuple(traits.Str, traits.Enum('lh', 'rh'),
-                        traits.Enum('white','pial','smoothwm','inflated'),
-                        argstr='--surf %s %s %s',
-                        desc='needed for some flags (uses white by default)')
+    surf = traits.Bool(argstr="--surf %s %s %s", requires=["subject_id", "hemi"],
+                       desc="analysis is on a surface mesh")
+    subject_id = traits.Str(desc="subject id for surface geometry")
+    hemi = traits.Enum("lh", "rh", desc="surface hemisphere")
+    surf_geo = traits.Str("white", usedefault=True,
+                          desc="surface geometry name (e.g. white, pial)")
     simulation = traits.Tuple(traits.Enum('perm','mc-full','mc-z'),
                               traits.Int(min=1), traits.Float, traits.Str,
                               argstr='--sim %s %d %f %s',
@@ -259,7 +261,13 @@ class GLMFit(FSCommand):
     _cmd = 'mri_glmfit'
     input_spec = GLMFitInputSpec
     output_spec = GLMFitOutputSpec
-    
+
+    def _format_arg(self, name, spec, value):
+        if name == "surf":
+            _si = self.inputs
+            return spec.argstr%(_si.subject_id, _si.hemi, _si.surf_geo)
+        return super(GLMFit, self)._format_arg(name, spec, value)
+
     def _list_outputs(self):
         outputs = self.output_spec().get()
         # Get the top-level output directory

--- a/nipype/interfaces/freesurfer/tests/test_model.py
+++ b/nipype/interfaces/freesurfer/tests/test_model.py
@@ -113,7 +113,7 @@ def test_glmfit():
                      sim_sign = dict(argstr='--sim-sign %s',),
                      simulation = dict(argstr='--sim %s %d %f %s',),
                      subjects_dir = dict(),
-                     surf = dict(),
+                     surf = dict(argstr="--surf %s %s %s"),
                      synth = dict(argstr='--synth',),
                      uniform = dict(argstr='--uniform %f %f',),
                      var_fwhm = dict(argstr='--var-fwhm %f',),


### PR DESCRIPTION
Previously, the surf input took a tuple (subject_id, hemi, surface),
which, as both subject_id and hemi are often runtime information,
required some awkward acrobatics to format properly.  I changed surf
to a bool, and then added three individual string inputs to correspond
to the arguments.
