### PR TITLE
Added convience option to fsl.ExtractROI

### DIFF
--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -155,7 +155,7 @@ class ExtractROIInputSpec(FSLCommandInputSpec):
     t_size = traits.Int(argstr="%d", position=9)
     _crop_xor = ['x_min', 'x_size', 'y_min', 'y_size', 'z_min', 'z_size', 't_min', 't_size']
     crop_list = traits.List(traits.Tuple(traits.Int, traits.Int),
-                            argstr="%s", position=2,
+                            argstr="%s", position=2, xor=_crop_xor,
                             help="list of two tuples specifying crop options")
 
 class ExtractROIOutputSpec(TraitedSpec):


### PR DESCRIPTION
Added an option to take a list of tuples specifying min/size across the axes. This will make it easier to hook up the output of some function that determines a cropping without having to make 6-8 connections.
