### PR TITLE
fix: closes gh-#197 - allows nodes with empty outputs when showing output

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -709,7 +709,7 @@ window.onload=beginrefresh
             outputdict.add_trait(node.name, traits.Instance(TraitedSpec))
             if isinstance(node, Workflow):
                 setattr(outputdict, node.name, node.outputs)
-            else:
+            elif node.outputs:
                 outputs = TraitedSpec()
                 for key, _ in node.outputs.items():
                     outputs.add_trait(key, traits.Any(node=node))


### PR DESCRIPTION
fix: closes gh-#197 - allows nodes with empty outputs when showing outputs
