### PR TITLE
changed spm.Normalise jobtype='estimate' to 'est'

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -327,8 +327,8 @@ class NormalizeInputSpec(SPMCommandInputSpec):
                             desc='file to normalize to template',
                             xor=['parameter_file'],
                             mandatory=True, copyfile=True)
-    jobtype = traits.Enum('estwrite', 'estimate', 'write',
-                          desc='one of: estimate, write, estwrite (opt, estwrite)',
+    jobtype = traits.Enum('estwrite', 'est', 'write',
+                          desc='one of: est, write, estwrite (opt, estwrite)',
                           usedefault=True)
     apply_to_files = InputMultiPath(File(exists=True), field='subj.resample',
                                desc='files to apply transformation to (opt)', copyfile=True)


### PR DESCRIPTION
it seems that spm.Normalise jobtype cannot be "estimate" the job structure being for spm5:
jobs{1}.spatial{1}.normalise{1}.est.*
and for spm8:
matlabbatch{1}.spm.spatial.normalise.est.*
then "est" is the parameter for estimate.
