### PR TITLE
scipy sparse matrix type bugfix

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -319,7 +319,7 @@ class DistributedPluginBase(PluginBase):
         """ Generates a dependency list for a list of graphs.
         """
         self.procs = graph.nodes()
-        self.depidx = nx.to_scipy_sparse_matrix(graph)
+        self.depidx = nx.to_scipy_sparse_matrix(graph, format='lil')
         self.refidx = deepcopy(self.depidx)
         self.refidx.astype = np.int
         self.proc_done = np.zeros(len(self.procs), dtype=bool)


### PR DESCRIPTION
the commit:
https://github.com/nipy/nipype/commit/060ad24af52320647031d1ff811a2d141fc4bea2
changed the scipy sparse matrix from lil to csr format that does not support the getrowview method

see : https://groups.google.com/d/topic/nipy-user/BTTo3DYF8OI/discussion
