### PR TITLE
Fix/clustermpl

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -462,8 +462,8 @@ from nipype.utils.filemanip import loadpkl, savepkl
                      "matplotlib" in node.inputs.function_str)
 
         if does_plot:
-            cmdstr += "import matplotlib"
-            cmdstr += "matplotlib.use('Agg')"
+            cmdstr += "import matplotlib\n"
+            cmdstr += "matplotlib.use('Agg')\n"
 
         cmdstr += """
 traceback=None


### PR DESCRIPTION
We were having problems where Function interfaces that used matplotlib were failing on a headless PBS cluster even though the matplotlib backend was getting set in the parent nipype script. I _think_ this fix should address this problem without requiring a call to matplotlib.use in any function that might end up geting executed in a PBS context, but I'm treading in strange waters inthe SGElike plugin so please take a look.  (I also don't really have access to a PBS cluster to test this myself).
