### PR TITLE
Spm prefix

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -138,7 +138,7 @@ class RealignInputSpec(SPMCommandInputSpec):
     write_mask = traits.Bool(field='roptions.mask',
                              desc='True/False mask output image')
     out_prefix = traits.String('r', field='prefix', usedefault=True,
-                               desc = 'slicetimed output prefix')
+                               desc = 'realigned output prefix')
 
 
 class RealignOutputSpec(TraitedSpec):


### PR DESCRIPTION
Just added prefix traits to the spm preprocessing interfaces which have this option in the spm_jobman settings: SliceTiming, Realign, Coregister, Normalize, Smooth.
Can help to have meaningful filenames if same interface with different options are ran in a pipeline (yes I do ran this kind of exotic pipelines).
