### PR TITLE
Fsl randomise

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -1505,16 +1505,16 @@ class Randomise(FSLCommand):
         if prefix:
             outputs['t_p_files'] = glob.glob(os.path.join(
                 os.getcwd(),
-                '%s_%s_p_tstat*.nii'%(self.inputs.base_name,prefix))
+                '%s_%s_p_tstat*.nii'%(self.inputs.base_name,prefix) ))
             outputs['t_corrected_p_files'] = glob.glob(os.path.join(
                 os.getcwd(),
-                '%s_%s_corrp_tstat*.nii'%(self.inputs.base_name,prefix))
+                '%s_%s_corrp_tstat*.nii'%(self.inputs.base_name,prefix)))
 
             outputs['f_p_files'] = glob.glob(os.path.join(
                 os.getcwd(),
-                '%s_%s_p_fstat*.nii'%(self.inputs.base_name,prefix))
+                '%s_%s_p_fstat*.nii'%(self.inputs.base_name,prefix)))
             outputs['f_corrected_p_files'] = glob.glob(os.path.join(
                 os.getcwd(),
-                '%s_%s_corrp_fstat*.nii'%(self.inputs.base_name,prefix))
+                '%s_%s_corrp_fstat*.nii'%(self.inputs.base_name,prefix)))
 
         return outputs


### PR DESCRIPTION
The fix in MultipleRegression is only documentation.
For randomise, I am not an expert of the tool itself, so I tried to add the output files (for them at least not to be cleaned out).
I based this on www.fmrib.ox.ac.uk/fsl/randomise/index.html which lists the possible outputs but haven't test it yet as I do not have any case for the statistics more complex than comparing a few groups.
The thing is that for the moment it lists output files with glob but do not if it can be a problem in pipelines, otherwise it would require parsing files and doing more complex code.
