### PR TITLE
fixing implicit_masking option formating

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -785,8 +785,8 @@ class Smooth(SPMCommand):
                     return [val[0], val[0], val[0]]
                 else:
                     return val
-            if opt == 'implicit_masking':
-                return int(val)
+        if opt == 'implicit_masking':
+            return int(val)
 
         return val
 


### PR DESCRIPTION
this was nested in fwhm option
I though I had already done this fix some time ago but might have forgotten to push it...
