### PR TITLE
ENH: Wrapper for MeshFix, Updates to Tessellation tutorial/workflow

### DIFF
--- a/examples/tessellation_tutorial.py
+++ b/examples/tessellation_tutorial.py
@@ -102,7 +102,7 @@ tesspipe.base_dir = output_dir
 tesspipe.connect([(tessflow, datasink,[('outputspec.meshes', '@meshes.all')])])
 
 """
-If the surfaces are to be packaged, this will connect the CFFConverter 
+If the surfaces are to be packaged, this will connect the CFFConverter
 node to the tessellation and smoothing workflow, as well as to the datasink.
 """
 

--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -32,7 +32,7 @@ class MeshFixInputSpec(CommandLineInputSpec):
 
     x_shift = traits.Int(argstr='--smooth %d', desc="Shifts the coordinates of the vertices when saving. Output must be in FreeSurfer format")
 
-    # Cutting, decoupling, dilation 
+    # Cutting, decoupling, dilation
     cut_outer = traits.Int(argstr='--cut-outer %d', desc="Remove triangles of 1st that are outside of the 2nd shell.")
     cut_inner = traits.Int(argstr='--cut-inner %d', desc="Remove triangles of 1st that are inside of the 2nd shell. Dilate 2nd by N; Fill holes and keep only 1st afterwards.")
     decouple_inin = traits.Int(argstr='--decouple-inin %d', desc="Treat 1st file as inner, 2nd file as outer component." \
@@ -53,7 +53,7 @@ class MeshFixInputSpec(CommandLineInputSpec):
     dilation = traits.Int(argstr='--dilate %d', desc="Dilate the surface by d. d < 0 means shrinking.")
     set_intersections_to_one = traits.Bool(argstr='--intersect', desc="If the mesh contains intersections, return value = 1." \
         "If saved in gmsh format, intersections will be highlighted.")
-    
+
     in_file1 = File(exists=True, argstr="%s", position=1, mandatory=True)
     in_file2 = File(exists=True, argstr="%s", position=2)
     output_type = traits.Enum('off', ['stl', 'msh', 'wrl', 'vrml', 'fs', 'off'], usedefault=True, desc='The output type to save the file as.')
@@ -100,7 +100,7 @@ class MeshFix(CommandLine):
             path, name, ext = split_filename(self.inputs.out_filename)
             ext = ext.replace('.', '')
             out_types = ['stl', 'msh', 'wrl', 'vrml', 'fs', 'off']
-            # Make sure that the output filename uses one of the possible file types        
+            # Make sure that the output filename uses one of the possible file types
             if any(ext == out_type.lower() for out_type in out_types):
                 outputs['mesh_file'] = op.abspath(self.inputs.out_filename)
             else:

--- a/nipype/workflows/smri/freesurfer/utils.py
+++ b/nipype/workflows/smri/freesurfer/utils.py
@@ -365,7 +365,7 @@ def create_tessellation_flow(name='tessellate', out_format='stl'):
 
     outputnode = pe.Node(niu.IdentityInterface(fields=["meshes"]),
                          name="outputspec")
-           
+
     if out_format == 'gii':
         tessflow.connect([
             (smoother, stl_to_gifti, [("mesh_file", "in_file")]),


### PR DESCRIPTION
This PR wraps the program MeshFix by Marco Attene, Mirko Windhoff, Axel Thielscher.

Relevant Paper: http://www.ima.ge.cnr.it/ima/personal/attene/PersonalPage/pdf/TVC2010_preprint.pdf
Sourceforge page: http://jmeshlib.sourceforge.net
Ubuntu installation instructions: http://simnibs.de/installation/meshfixandgetfem

This is the first step in turning the set of shell scripts from the SimNibs package into Nipype pelines.

From their website:

SimNIBS is a software for the Simulation of Non-invasive Brain Stimulation. It allows for realistic calculations of the electric field induced by transcranial magnetic stimulation (TMS). Basic support for transcranial direct current stimulation (tDCS) is currently tested and will be added within the next few months.

---

The smoothing in MeshFix has now replaced mris_smooth in the tessellation workflow.

This is no longer a work-in-progress as far as I am concerned...

Example output meshes (openable in ConnectomeViewer) can be found here:
http://dl.dropbox.com/u/315714/Meshes.cff
