### PR TITLE
WIP: Structural basis for connectivity networks

### DIFF
--- a/nipype/interfaces/cmtk/__init__.py
+++ b/nipype/interfaces/cmtk/__init__.py
@@ -1,4 +1,4 @@
-from .cmtk import ROIGen, CreateMatrix, CreateNodes, TractsBetween
+from .cmtk import ROIGen, CreateMatrix, CreateNodes, TractsBetween, NetworkBasedROIFiltering
 from .nx import NetworkXMetrics, AverageNetworks
 from .parcellation import Parcellate
 from .convert import CFFConverter, MergeCNetworks


### PR DESCRIPTION
This PR adds two interfaces to the CMTK/CMP package:

TractsBetween - Given a connectivity network, a subject's ROI image, and a set of fiber tracts this interface will filter the fibers and return a new tract file containing only those tracts which bridge regions that are connected in the input network. Can be thought of as connectome mapping in reverse.

NetworkBasedROIFiltering - Removes regions-of-interest from a given volume if they are not connected in an associated connectivity matrix

---

Example: Resulting differences between two groups from the Network Based Statistics interface:
https://www.dropbox.com/s/em7uu1hp05w1y23/nbs_right.png

Structural Basis from a random subject's tracts:
https://www.dropbox.com/s/7d7tkhxw976ft2i/bdnf_recon_right.png

ROIs remaining after filtering out those that are unconnected:
https://www.dropbox.com/s/8j0hxl8rquxgboc/tracts_and_rois.png

---

Closing request, merging all the network analysis stuff into one PR
