### PR TITLE
BUG: Fix for datasink input raise_on_empty

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -278,7 +278,7 @@ class DataSink(IOBase):
                 else:
                     raise(inst)
         for key, files in self.inputs._outputs.items():
-            if not isdefined(files):
+            if not isdefined(files) or isinstance(files, bool):
                 continue
             iflogger.debug("key: %s files: %s"%(key, str(files)))
             files = filename_to_list(files)


### PR DESCRIPTION
I just tried to run a datasink node using the raise_on_empty input as False and ran into a problem.

I was getting "NoneType is not iterable" on the line:

for src in filename_to_list(files):

because "files" was defined as "False" for the key "raise_on_empty"

I'm not sure this is the best way of fixing the issue, but I figured I'd submit my solution anyway...
