### PR TITLE
Add Siemans PAR options to dcm2nii + small bug fixes

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -8,7 +8,7 @@ from nipype.utils.filemanip import split_filename
 import re
 
 class Dcm2niiInputSpec(CommandLineInputSpec):
-    source_names = InputMultiPath(File(exists=True), argstr="%s", position=9, mandatory=True)
+    source_names = InputMultiPath(File(exists=True), argstr="%s", position=10, mandatory=True)
     gzip_output = traits.Bool(False, argstr='-g', position=0, usedefault=True)
     nii_output = traits.Bool(True, argstr='-n', position=1, usedefault=True)
     anonymize = traits.Bool(argstr='-a', position=2)
@@ -18,6 +18,7 @@ class Dcm2niiInputSpec(CommandLineInputSpec):
     output_dir = Directory(exists=True, argstr='-o %s', genfile=True, position=6)
     config_file = File(exists=True, argstr="-b %s", genfile=True, position=7)
     convert_all_pars = traits.Bool(argstr='-v', position=8)
+    args = traits.Str(argstr='%s', desc='Additional parameters to the command', position=9)
 
 class Dcm2niiOutputSpec(TraitedSpec):
     converted_files = OutputMultiPath(File(exists=True))


### PR DESCRIPTION
This pull request includes a few small bug fixes and option enhancement for the dcm2nii interface.

Specifically, the 'reorient' and 'reorient_and_crop' options were not included in the list of options to check for conversation to the type of argstr that dcm2nii expects (a switch with a 'y' or 'n' after it), and were producing value errors when trying to be formatted properly. (See a358215ac0dabd65c941c56b54bdf4c4a8c39283 for error).

Additionally, it adds an option for the '-v' flag in dcm2nii, which switches off the default behavior of converting all PAR/REC files in a directory. Without this option, dcm2nii will attempt to convert all files in a directory even when given an explicit list of only 1 or a few. Since some of the series may be bad (incomplete, etc) this can cause the entire conversion process to fail.

This also adds an option in the _parse_stdout outfile parser to search for filenames directly after the "-->" indicator, which is the syntax returned when dcm2nii converts PAR/REC files instead of "Saving" or "Cropping". Without the additional line, no output files are put into the output trait "converted_files", which stops the pipeline cold. I'm not sure my solution is the best one (it imports the whole of re) but I couldn't think of a quicker / easier one.

Finally, the generic 'args' argument allowing for any user-generated arguments to be inserted into the command line was being inherited from CommandLineInputSpec. However, the dcm2nii CLI ignores any arguments it finds after the list of files, making any args added via `.inputs.args = ''` essentially useless. I've explicitly included args in the dcm2nii input spec and given them a position prior to the list of images.
