### PR TITLE
fix a bug in tbss_all: change 'skeleton_file4' in outputnode to 'skeleto...

### DIFF
--- a/nipype/workflows/dmri/fsl/tbss.py
+++ b/nipype/workflows/dmri/fsl/tbss.py
@@ -453,7 +453,7 @@ def create_tbss_all(name='tbss_all', estimate_skeleton=True):
                                     ('outputnode.skeleton_file', 'skeleton_file3'),
                                     ]),
                 (tbss4, outputnode, [('outputnode.projectedfa_file', 'projectedfa_file'),
-                                    ('outputnode.skeleton_file', 'skeleton_file4'),
+                                    ('outputnode.skeleton_file', 'skeleton_file'),
                                     ('outputnode.skeleton_mask', 'skeleton_mask'),
                                     ('outputnode.distance_map', 'distance_map'),
                                     ]),


### PR DESCRIPTION
fix a bug in tbss_all: change 'skeleton_file4' in outputnode to 'skeleton_file'.
