### PR TITLE
BUG: Process Directories as data sinks

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -221,6 +221,9 @@ class DataSink(IOBase):
         self.inputs.trait_set(trait_change_notify=False, **undefined_traits)
 
     def _get_dst(self, src):
+        ## If path is directory with trailing os.path.sep,
+        ## then remove that for a more robust behavior
+        src = src.rstrip(os.path.sep)
         path, fname = os.path.split(src)
         if self.inputs.parameterization:
             dst = path


### PR DESCRIPTION
In cases where a DataSink was specified as
a directory with a trailing '/' (i.e. os.path.sep)
the dst resulted in an empty string and triggered
an error:

File
  "/tmp/nipype/nipype/interfaces/io.py", line 243, in _get_dst
      if dst[0] == os.path.sep:
      IndexError: string index out of range

DEBUGING OUTPUTS
HACK: src='/tmp/small_EXP_CACHE/BAW_20120730/WF_subj001/TissueClassify/BABC/'
HACK: path='/tmp/small_EXP_CACHE/BAW_20120730/WF_subj001/TissueClassify/BABC'
HACK: fname=''
HACK: dst=''
