### PR TITLE
attempt to fix inline function bug

### DIFF
--- a/nipype/interfaces/utility.py
+++ b/nipype/interfaces/utility.py
@@ -356,7 +356,7 @@ class Function(IOBase):
                     raise Exception('Interface Function does not accept ' \
                                         'function objects defined interactively in a python session')
             elif isinstance(function, str):
-                self.inputs.function_str = function
+                self.inputs.function_str = dumps(function)
             else:
                 raise Exception('Unknown type of function')
         self.inputs.on_trait_change(self._set_function_string, 'function_str')


### PR DESCRIPTION
I am not sure if this will fix the bug when inline function are specified in constructor causing the following error, as the loads function is called on not dumped string:

RuntimeError: could not find MARK
Error executing function:
 def f(a): return a*2
Functions in connection strings have to be standalone.
They cannot be declared either interactively or inside
another function or inline in the connect string. Any
imports should be done inside the function
Interface Function failed to run.
