### PR TITLE
BUG: subprocess.Popen requres list of arguments to be strings

### DIFF
--- a/nipype/pipeline/plugins/pbs.py
+++ b/nipype/pipeline/plugins/pbs.py
@@ -36,7 +36,8 @@ class PBSPlugin(SGELikeBatchManagerBase):
         super(PBSPlugin, self).__init__(template, **kwargs)
 
     def _is_pending(self, taskid):
-        proc = subprocess.Popen(["qstat", taskid],
+        #  subprocess.Popen requires taskid to be a string
+        proc = subprocess.Popen(["qstat", str(taskid)],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         _, e = proc.communicate()

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -37,7 +37,8 @@ class SGEPlugin(SGELikeBatchManagerBase):
         super(SGEPlugin, self).__init__(template, **kwargs)
 
     def _is_pending(self, taskid):
-        proc = subprocess.Popen(["qstat", '-j', taskid],
+        #  subprocess.Popen requires taskid to be a string
+        proc = subprocess.Popen(["qstat", '-j', str(taskid)],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         o, _ = proc.communicate()


### PR DESCRIPTION
-        proc = subprocess.Popen(["qstat", '-j', taskid],
-        #  subprocess.Popen requires taskid to be a string
-        proc = subprocess.Popen(["qstat", '-j', str(taskid)],
                                                                           ^^^^^^^^^^

TypeError: execv() arg 2 must contain only strings

This was causing nodes to crash when using SGE.

Simply typecast the integer to a string and the nodes pass.
