### PR TITLE
Adding Notebook tutorials to quickstart

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -17,9 +17,12 @@ Beginner's guide
 
 Introductory slides. `Available here`__
 
+Beginner's tutorials (IPython Notebooks). `Availible here`__
+
 Michael Notter's guide. `Available here`__
 
 __ http://satra.github.com/intro2nipype
+__ https://github.com/mwaskom/nipype_concepts
 __ http://miykael.github.com/nipype-beginner-s-guide/index.html
 
 User guides


### PR DESCRIPTION
A wee little pull request.

I have a sneaking suspicion that we shall soon see a Sphinx plugin to embed static HTML renderings of Notebooks into a typical Sphinx site (this may even already exist). For the time being, I think it's best to keep just a simple link to my github, but I will either turn my stuff into a Sphinx site and host it on github-pages or fold it into the nipype docs themselves soon.
