### PR TITLE
Update legacy.py - buildtemplateparallel.sh

### DIFF
--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -205,7 +205,7 @@ class buildtemplateparallel(ANTSCommand):
     def _format_arg(self, opt, spec, val):
         if opt == 'num_cores':
             if self.inputs.parallelization == 2:
-                return '-j ' + val
+                return '-j ' + str(val)
             else:
                 return ''
         if opt == 'in_files':


### PR DESCRIPTION
The value of 'j' has to be changed into a string, otherwise you'll end up with "TypeError: cannot concatenate 'str' and 'int' objects" and the command can't be passed on to the console.
