### PR TITLE
buildtemplateparallel.sh - issue with input files

### DIFF
--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -213,7 +213,7 @@ class buildtemplateparallel(ANTSCommand):
                 start = '-z '
             else:
                 start = ''
-            return start + ' '.join([os.path.split(name)[1] for name in val])
+            return start + ' '.join(name for name in val)
         return super(buildtemplateparallel, self)._format_arg(opt, spec, val)
 
     def _list_outputs(self):


### PR DESCRIPTION
If I have an array of inputs like: 

in_files = ['~/data/subject_1/struct.nii','~/data/subject_2/struct.nii','~/data/subject_3/struct.nii']

The current code would turn this into the command:

buildtemplateparallel.sh -d 3 -n 1 -g 0.250000 -i 3 -m 30x90x20 -j 4 -o PREFIX -c 2 -r 1 -s PR -t GR struct.nii struct.nii struct.nii

Like this, I'm not able to run the buildtemplateparallel interface. I think it crashes because it can't find the files. My commit changes the command to the following:

buildtemplateparallel.sh -d 3 -n 1 -g 0.250000 -i 3 -m 30x90x20 -j 4 -o PREFIX -c 2 -r 1 -s PR -t GR ~/data/subject_1/struct.nii ~/data/subject_2/struct.nii ~/data/subject_3/struct.nii

Like this the full path to structural images is passed on to the command and the script runs perfectly.
