### PR TITLE
Bug fix rotate bvec

### DIFF
--- a/nipype/workflows/dmri/fsl/dti.py
+++ b/nipype/workflows/dmri/fsl/dti.py
@@ -554,12 +554,12 @@ def _rotate_bvecs(in_bvec, in_matrix):
         name, _ = os.path.splitext(name)
     out_file = os.path.abspath('./%s_rotated.bvec' % name)
     bvecs = np.loadtxt(in_bvec)
-    new_bvecs = [bvecs[:, 0]]
+    new_bvecs = np.zeros(shape=bvecs.T.shape) #pre-initialise array, 3 col format
 
-    for i, vol_matrix in enumerate(in_matrix[1::]):
+    for i, vol_matrix in enumerate(in_matrix[0::]): #start index at 0
         bvec = np.matrix(bvecs[:, i])
         rot = np.matrix(np.loadtxt(vol_matrix)[0:3, 0:3])
-        new_bvecs.append((np.array(rot * bvec.T).T)[0])
+        new_bvecs[i] = (np.array(rot * bvec.T).T)[0] #fill each volume with x,y,z as we go along
     np.savetxt(out_file, np.array(new_bvecs).T, fmt='%0.15f')
     return out_file
 


### PR DESCRIPTION
noted issues: FA files looked funny after processing with this pipeline, the first two entries in the rotated_bvec files were 0,0,0 when the bvalues of the first two files were 0 and 1000. 

Plotting the original bvec against the rotated bvec (X component) showed what appeared to be a single volume offset (see black and red traces in attached plot)

code issue:  _rotate_bvec code initialised its output bvec array with the first entry of the input bvec array and then looped through FLIRT matrices starting at 1st position, but used a 0-based index for selecting the input from the bvec array

solution    :  initialise output array filled with zeros, loop through FLIRT matrices from 0, use 0-based indexing for selecting input from the bvec array, set consecutive elements appropriately

testing      : nothing, other than plotting the X component for one subject

I attached the plot, where black = original bvec, red = rotated bvec, green = rotated bvec with my solution. The other thing that you can see in this plot is that there are regularly spaced x=0s in both the original and my version where the b=0 volumes were collected (7 in total).

(This also includes the changes that I made in the previous pull request.)
![_rotate_bvec_issues](https://f.cloud.github.com/assets/2734273/327466/c362bf9e-9b74-11e2-84b5-97c3381674a9.png)
