### PR TITLE
allow similarity computation without mask

### DIFF
--- a/nipype/interfaces/nipy/utils.py
+++ b/nipype/interfaces/nipy/utils.py
@@ -73,24 +73,20 @@ class Similarity(BaseInterface):
         vol2_nii = nb.load(self.inputs.volume2)
 
         if isdefined(self.inputs.mask1):
-            mask1_nii = nb.load(self.inputs.mask1)
-            mask1_nii = nb.Nifti1Image(nb.load(self.inputs.mask1).get_data() == 1, mask1_nii.get_affine(),
-                                       mask1_nii.get_header())
+            mask1 = nb.load(self.inputs.mask1).get_data() == 1
         else:
-            mask1_nii = None
+            mask1 = None
 
         if isdefined(self.inputs.mask2):
-            mask2_nii = nb.load(self.inputs.mask2)
-            mask2_nii = nb.Nifti1Image(nb.load(self.inputs.mask2).get_data() == 1, mask2_nii.get_affine(),
-                                       mask2_nii.get_header())
+            mask2 = nb.load(self.inputs.mask2).get_data() == 1
         else:
-            mask2_nii = None
+            mask2 = None
 
         histreg = HistogramRegistration(from_img = vol1_nii,
                                         to_img = vol2_nii,
                                         similarity=self.inputs.metric,
-                                        from_mask = mask1_nii,
-                                        to_mask = mask2_nii)
+                                        from_mask = mask1,
+                                        to_mask = mask2)
         self._similarity = histreg.eval(Affine())
 
         return runtime


### PR DESCRIPTION
regarding the _run_interface() it seems that mask could be not necessary to metric computation,
subsidiary question for documentation, is that also necessary that "Both volumes have to be in  the same coordinate system, same space within that coordinate system and with the same voxel dimensions" as the documentation states? It seems that the HistogramRegistration handles the resampling?
