### PR TITLE
BF - Added FSL output type NIFTI to dmri mrtrix example

### DIFF
--- a/examples/dmri_mrtrix_dti.py
+++ b/examples/dmri_mrtrix_dti.py
@@ -27,6 +27,8 @@ import nipype.interfaces.fsl as fsl
 import nipype.algorithms.misc as misc
 import os, os.path as op                     # system functions
 
+fsl.FSLCommand.set_default_output_type('NIFTI')
+
 """
 This needs to point to the fdt folder you can find after extracting
 


### PR DESCRIPTION
Addresses https://github.com/nipy/nipype/issues/559 and https://github.com/nipy/nipype/issues/420
