### PR TITLE
interfaces.afni 3drefit was not running

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -166,8 +166,8 @@ class RefitInputSpec(AFNICommandInputSpec):
                    exists=True,
                    copyfile=True)
 
-    out_file = File("%s_refit", desc='output image file name',
-                    argstr='-prefix %s', name_source="in_file", usedefault=True)
+    out_file = File("%s_refit", desc='output image file name, should be the same as input',
+                    argstr='%s', name_source="in_file", usedefault=True)
 
     deoblique = traits.Bool(desc='replace current transformation' +
                             ' matrix with cardinal matrix',


### PR DESCRIPTION
removed the "-prefix outfile" part, since 3drefit works only on the inputfile itself and does not allow this option.

now it will work if you give the same out_file name as in_file name
however if you give no out filename it might not work if your
infile is a .nii or .nii.gz since afni will make briks. So still not perfect....
