### PR TITLE
Correct Class Segment in spm.preprocess

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -518,16 +518,17 @@ class SegmentInputSpec(SPMCommandInputSpec):
 
 
 class SegmentOutputSpec(TraitedSpec):
-    native_gm_image = File(exists=True, desc='native space grey probability map')
-    normalized_gm_image = File(exists=True, desc='normalized grey probability map',)
-    modulated_gm_image = File(exists=True, desc='modulated, normalized grey probability map')
-    native_wm_image = File(exists=True, desc='native space white probability map')
-    normalized_wm_image = File(exists=True, desc='normalized white probability map')
-    modulated_wm_image = File(exists=True, desc='modulated, normalized white probability map')
-    native_csf_image = File(exists=True, desc='native space csf probability map')
-    normalized_csf_image = File(exists=True, desc='normalized csf probability map')
-    modulated_csf_image = File(exists=True, desc='modulated, normalized csf probability map')
-    bias_corrected_image = File(exists=True, desc='bias-corrected version of input image')
+    native_gm_image = File(desc='native space grey probability map')
+    normalized_gm_image = File(desc='normalized grey probability map',)
+    modulated_gm_image = File(desc='modulated, normalized grey probability map')
+    native_wm_image = File(desc='native space white probability map')
+    normalized_wm_image = File(desc='normalized white probability map')
+    modulated_wm_image = File(desc='modulated, normalized white probability map')
+    native_csf_image = File(desc='native space csf probability map')
+    normalized_csf_image = File(desc='normalized csf probability map')
+    modulated_csf_image = File(desc='modulated, normalized csf probability map')
+    modulated_input_image = File(deprecated='0.10', new_name='bias_corrected_image', desc='bias-corrected version of input image') 
+    bias_corrected_image = File(desc='bias-corrected version of input image')   
     transformation_mat = File(exists=True, desc='Normalization transformation')
     inverse_transformation_mat = File(exists=True, desc='Inverse normalization info')
 


### PR DESCRIPTION
The spm Segment module (spm_preproc) does not include a modulated version of the structural image input in its outputs, however the NiPype Segment warper expected such an output.

This led to a systematic error being thrown at execution about the modulated file being missing. I corrected this error by removing references to the modulated structural image in the associated Segment code.
