### PR TITLE
Error generated by Automask in nipype.interfaces.afni

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -403,8 +403,6 @@ class FLIRTInputSpec(FSLCommandInputSpec):
     in_matrix_file = File(argstr='-init %s', desc='input 4x4 affine matrix')
     apply_xfm = traits.Bool(argstr='-applyxfm', requires=['in_matrix_file'],
                             desc='apply transformation supplied by in_matrix_file')
-    apply_isoxfm = traits.Float(argstr='-applyisoxfm %f',
-                                desc='as applyxfm but forces isotropic resampling')
     datatype = traits.Enum('char', 'short', 'int', 'float', 'double',
                            argstr='-datatype %s',
                            desc='force output data type')


### PR DESCRIPTION
Function Automask raises error due to string '-apply_prefix <undefined>' generated in the 3dAutomask command
