### PR TITLE
Add missing option apply_isoxfm to FSL Flirt wrapper

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -403,7 +403,7 @@ class FLIRTInputSpec(FSLCommandInputSpec):
     in_matrix_file = File(argstr='-init %s', desc='input 4x4 affine matrix')
     apply_xfm = traits.Bool(argstr='-applyxfm', requires=['in_matrix_file'],
                             desc='apply transformation supplied by in_matrix_file')
-    apply_isoxfm = traits.Float(argstr='-applyisoxfm %f',
+    apply_isoxfm = traits.Float(argstr='-applyisoxfm %f', xor=['apply_xfm'],
                                 desc='as applyxfm but forces isotropic resampling')
     datatype = traits.Enum('char', 'short', 'int', 'float', 'double',
                            argstr='-datatype %s',


### PR DESCRIPTION
Before creating the function IsotropicReslicer, would it be possible to merge this quick fix which add the missing option apply_isoxfm to FSL Flirt wrapper?
