### PR TITLE
FIX broken MapNode doctest

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -1669,8 +1669,8 @@ class MapNode(Node):
     >>> from nipype import MapNode, fsl
     >>> realign = MapNode(fsl.MCFLIRT(), 'in_file', 'realign')
     >>> realign.inputs.in_file = ['functional.nii',
-                                  'functional2.nii',
-                                  'functional3.nii']
+    ...                           'functional2.nii',
+    ...                           'functional3.nii']
     >>> realign.run() # doctest: +SKIP
 
     """


### PR DESCRIPTION
Cleaning up the doctest for MapNode inadvertently broke it...this should fix.
