### PR TITLE
Changed FNIRT Inputspec config_file to take string instead of enum type.

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -785,9 +785,10 @@ class FNIRTInputSpec(FSLCommandInputSpec):
                                           'to intensity mapping', hash_files=False)
     log_file = File(argstr='--logout=%s',
                              desc='Name of log-file', genfile=True, hash_files=False)
-    config_file = traits.Either(
-        traits.Enum("T1_2_MNI152_2mm", "FA_2_FMRIB58_1mm"), File(exists=True), argstr='--config=%s',
+    
+    config_file = traits.String(argstr='--config=%s',
                        desc='Name of config file specifying command line arguments')
+    
     refmask_file = File(exists=True, argstr='--refmask=%s',
                         desc='name of file with mask in reference space')
     inmask_file = File(exists=True, argstr='--inmask=%s',


### PR DESCRIPTION
Changed the config_file input parameter under FNIRT Inputspec to accept a String instead of an Enum type. This way a custom FSL FNIRT config file can be used.
