### PR TITLE
fix: check only the last line in the sge qsub stdout

### DIFF
--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import re
 import subprocess
 from time import sleep
 
@@ -109,7 +110,8 @@ class SGEPlugin(SGELikeBatchManagerBase):
         iflogger.setLevel(oldlevel)
         # retrieve sge taskid
         lines = [line for line in result.runtime.stdout.split('\n') if line]
-        taskid = int(lines[-1].split(' ')[2])
+        taskid = int(re.match("Your job ([0-9]*) .* has been submitted",
+                              lines[-1]).groups()[0])
         self._pending[taskid] = node.output_dir()
         logger.debug('submitted sge task: %d for node %s' % (taskid, node._id))
         return taskid


### PR DESCRIPTION
@hjmjohnson: could you take a look to see if this would fail on sge?

i ran into a situation with @poldrack sge cluster on tacc, which inserts a whole lot of custom echos into stdout. this fixes the issue - but i don't know if this heuristic is sufficient.

```
-----------------------------------------------------------------
-- Welcome to the Lonestar4 Westmere/QDR IB Linux Cluster --
-----------------------------------------------------------------
--> Checking that you specified -V...
--> Checking that you specified a time limit...
--> Checking that you specified a queue...
--> Setting project...
--> Checking that you specified a parallel environment...
--> Checking that you specified a valid parallel environment name...
--> Checking that the number of PEs requested is valid...
--> Ensuring absence of dubious h_vmem,h_data,s_vmem,s_data limits...
--> Requesting valid memory configuration (23.4G)...
--> Verifying HOME file-system availability...
--> Verifying WORK file-system availability...
--> Verifying SCRATCH file-system availability...
--> Checking ssh setup...
--> Checking that you didn't request more cores than the maximum...
--> Checking that you don't already have the maximum number of jobs...
--> Checking that your time limit isn't over the maximum...
--> Checking available allocation...
--> Submitting job...

Your job 1314126 ("initAvg.antsRegistrationTemplateBuilder.satra") has been submitted
```
