### PR TITLE
Mesh algorithms

### DIFF
--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -63,7 +63,7 @@ class P2PDistance(BaseInterface):
     input_spec = P2PDistanceInputSpec
     output_spec = P2PDistanceOutputSpec
 
-    def _triangle_area(A, B, C):
+    def _triangle_area(self, A, B, C):
         ABxAC = euclidean(A,B) *  euclidean(A,C)
         prod = np.dot(np.array(B)-np.array(A),np.array(C)-np.array(A))
         angle = np.arccos( prod / ABxAC )


### PR DESCRIPTION
I'm not completely sure that I should push this here.

My idea is to add some methodologies for surface-based computation. So far I provide with an interface to compute point-to-point euclidean distance in two vtk triangularized meshes. I will be adding some new features (e.g. Haussdorf distance between surfaces).

Requires tvtk for reading the meshes.
