### PR TITLE
without this, line 151 tries to call a module

### DIFF
--- a/nipype/interfaces/nipy/model.py
+++ b/nipype/interfaces/nipy/model.py
@@ -20,7 +20,7 @@ except Exception, e:
     warnings.warn('nipy not installed')
 else:
     import nipy.modalities.fmri.design_matrix as dm
-    import nipy.labs.glm as GLM
+    import nipy.labs.glm.glm as GLM
 
 if have_nipy:
     try:


### PR DESCRIPTION
Found at the tail end of duplicating the pipeline demonstrated in http://nipy.org/nipype/users/examples/fmri_nipy_glm.html with my own data. Model estimation, I think, would fail. I can send along a repro if you want, but looking at the code, at this line, and at line 151, it's clear that line 151 would attempt to call a module... no bueno.
