### PR TITLE
Fix for FUGUE interface

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -1316,7 +1316,7 @@ class FUGUE(FSLCommand):
         return None
 
     def _parse_inputs(self, skip=None):
-        if skip == None:
+        if skip is None:
             skip = []
 
         if not isdefined(self.inputs.save_shift) or not self.inputs.save_shift:


### PR DESCRIPTION
Run autopep8 on preprocess.py. autopep8 would not correct some error
though (those that might change code's behaviour, like breaklines)
Note: I had a broken fork of nipype, disregard previous reference from
commit.

Close nipy/nipype#642.
