### PR TITLE
fix:total_seconds_python2.6

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -998,7 +998,7 @@ class BaseInterface(Interface):
             runtime.endTime = dt.isoformat(dt.utcnow())
             timediff = parseutc(runtime.endTime) - parseutc(runtime.startTime)
             runtime.duration = timediff.days * 86400 + timediff.seconds + \
-                timediff..microseconds/100000.
+                timediff.microseconds/100000.
             results = InterfaceResult(interface, runtime,
                                       inputs=self.inputs.get_traitsfree(),
                                       outputs=outputs)
@@ -1008,7 +1008,7 @@ class BaseInterface(Interface):
             runtime.endTime = dt.isoformat(dt.utcnow())
             timediff = parseutc(runtime.endTime) - parseutc(runtime.startTime)
             runtime.duration = timediff.days * 86400 + timediff.seconds + \
-                timediff..microseconds/100000.
+                timediff.microseconds/100000.
             if len(e.args) == 0:
                 e.args = ("")
 


### PR DESCRIPTION
fix proposition for datetime.timedelta.total_seconds in python 2.6 
see issue https://github.com/nipy/nipype/issues/651
