### PR TITLE
spm wants a two-item array here

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -264,8 +264,9 @@ class CoregisterInputSpec(SPMCommandInputSpec):
                 'nmi' - Normalised Mutual Information,
                 'ecc' - Entropy Correlation Coefficient,
                 'ncc' - Normalised Cross Correlation""")
-    fwhm = traits.Float(field='eoptions.fwhm',
-                        desc='gaussian smoothing kernel width (mm)')
+    fwhm = traits.List(traits.Float(), minlen=2, maxlen=2,
+                       field='eoptions.fwhm',
+                       desc='gaussian smoothing kernel width (mm)')
     separation = traits.List(traits.Float(), field='eoptions.sep',
                              desc='sampling separation in mm')
     tolerance = traits.List(traits.Float(), field='eoptions.tol',


### PR DESCRIPTION
Hey folks,

In the SPM GUI, there's a note about this field: "An 1-by-2 array must be entered."

In the data structure that the SPM GUI creates, we see a 1-by-2 array.

In the nipype interface, however, we have a simple float, and it is passed to SPM as such in the generated .m file.

This fixes that, and runs fine.
