### PR TITLE
Set Matplotlib backend robustly during distributed execution

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -109,8 +109,11 @@ def create_pyscript(node, updatehash=False, store_exception=True):
     # create python script to load and trap exception
     cmdstr = """import os
 import sys
-import matplotlib
-matplotlib.use('%s')
+try:
+    import matplotlib
+    matplotlib.use('%s')
+except ImportError:
+    pass
 from nipype import config, logging
 from nipype.utils.filemanip import loadpkl, savepkl
 from socket import gethostname


### PR DESCRIPTION
To motivate this, the problem is that `import nipype` now can execute code that imports matplotlib without setting the backend properly. The result of this is that interfaces that used matplotlib were failing when run in a distributed case (e.g. with SGE on headless nodes).

This adds a bit of cruft to the pyscript files that control distributed execution, but I cannot think of a cleaner way to get the backend set that is robust. This approach accepts the configurable value.

The first commit here attempted to set the backend by writing a matplotlibrc to the batch directory, but it turns out that the batch directory is not local for SGE execution so that doesn't actually get picked up. I reverted those changes, but if that is a more appealing route it could be paired with a larger change to the distribution routine.

Otherwise this works fine for me.
