### PR TITLE
new files need their own dir

### DIFF
--- a/nipype/interfaces/spm/utils.py
+++ b/nipype/interfaces/spm/utils.py
@@ -371,7 +371,7 @@ class DicomImportInputSpec(SPMCommandInputSpec):
         field='root',
         usedefault=True,
         desc='directory structure for the output.')
-    output_dir = traits.Str('./',
+    output_dir = traits.Str('./converted_dicom',
         field='outdir',
         usedefault=True,
         desc='output directory.')


### PR DESCRIPTION
without this, list_outputs collect all of the files generated by the node... not what we want.

just ran a test batch with this change, fixed a crasher.
