### PR TITLE
fix: make sure mandatory=False items are displayed

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -779,12 +779,14 @@ class BaseInterface(Interface):
             return helpstr
 
         manhelpstr = ['', '\t[Mandatory]']
-        for name, spec in sorted(inputs.traits(mandatory=True).items()):
+        mandatory_items = inputs.traits(mandatory=True)
+        for name, spec in sorted(mandatory_items.items()):
             manhelpstr += cls._get_trait_desc(inputs, name, spec)
 
         opthelpstr = ['', '\t[Optional]']
-        for name, spec in sorted(inputs.traits(mandatory=None,
-                                               transient=None).items()):
+        for name, spec in sorted(inputs.traits(transient=None).items()):
+            if spec in mandatory_items:
+                continue
             opthelpstr += cls._get_trait_desc(inputs, name, spec)
 
         if manhelpstr:

--- a/nipype/interfaces/tests/test_base.py
+++ b/nipype/interfaces/tests/test_base.py
@@ -245,10 +245,10 @@ def test_BaseInterface():
     yield assert_equal, nib.BaseInterface.help(), None
     yield assert_equal, nib.BaseInterface._get_filecopy_info(), []
 
-
     class InputSpec(nib.TraitedSpec):
         foo = nib.traits.Int(desc='a random int')
         goo = nib.traits.Int(desc='a random int', mandatory=True)
+        moo = nib.traits.Int(desc='a random int', mandatory=False)
         hoo = nib.traits.Int(desc='a random int', usedefault=True)
         zoo = nib.File(desc='a file', copyfile=False)
         woo = nib.File(desc='a file', copyfile=True)
@@ -258,6 +258,7 @@ def test_BaseInterface():
         input_spec = InputSpec
 
     yield assert_equal, DerivedInterface.help(), None
+    yield assert_true, 'moo' in ''.join(DerivedInterface._inputs_help())
     yield assert_equal, DerivedInterface()._outputs(), None
     yield assert_equal, DerivedInterface._get_filecopy_info()[0]['key'], 'woo'
     yield assert_true, DerivedInterface._get_filecopy_info()[0]['copy']


### PR DESCRIPTION
@mick-d this patch fixes help output when `mandatory=False`

but `mandatory=False` should really not be used. we will put it into a separate checker that helps developers to make sure their input/outputspecs have the appropriate metadata.
