### PR TITLE
Update FSL Merge to Support TR Parameter

### DIFF
--- a/nipype/interfaces/fsl/tests/test_utils.py
+++ b/nipype/interfaces/fsl/tests/test_utils.py
@@ -203,6 +203,7 @@ def test_fslmerge():
     merger.inputs.in_files = filelist
     merger.inputs.merged_file = 'foo_merged.nii'
     merger.inputs.dimension = 't'
+    merger.inputs.output_type = 'NIFTI'
     yield assert_equal, merger.cmdline, 'fslmerge -t foo_merged.nii %s' % ' '.join(filelist)
 
     # verify that providing a tr value updates the dimension to tr
@@ -213,6 +214,7 @@ def test_fslmerge():
     merger2 = fsl.Merge(in_files=filelist,
                         merged_file='foo_merged.nii',
                         dimension='t',
+                        output_type='NIFTI',
                         tr=2.25)
 
     yield assert_equal, merger2.cmdline, \

--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -129,13 +129,17 @@ class Smooth(FSLCommand):
 
 
 class MergeInputSpec(FSLCommandInputSpec):
-    in_files = traits.List(File(exists=True), argstr="%s", position=2, mandatory=True)
+    in_files = traits.List(File(exists=True), argstr="%s", position=2,
+                           mandatory=True)
     dimension = traits.Enum('t', 'x', 'y', 'z', 'a', argstr="-%s", position=0,
-                            desc="dimension along which to merge, optionally set tr input when dimension is t",
+                            desc=("dimension along which to merge, optionally "
+                                  "set tr input when dimension is t"),
                             mandatory=True)
     tr = traits.Float(position=-1, argstr='%.2f',
-                      desc='use to specify TR in seconds (default is 1.00 sec), overrides dimension and sets it to tr')
-    merged_file = File(argstr="%s", position=1, name_source='in_files', name_template='%s_merged', hash_files=False)
+                      desc=('use to specify TR in seconds (default is 1.00 '
+                            'sec), overrides dimension and sets it to tr'))
+    merged_file = File(argstr="%s", position=1, name_source='in_files',
+                       name_template='%s_merged', hash_files=False)
 
 
 class MergeOutputSpec(TraitedSpec):
@@ -145,26 +149,25 @@ class MergeOutputSpec(TraitedSpec):
 class Merge(FSLCommand):
     """Use fslmerge to concatenate images
 
-    Images can be concatenated across time, x, y, or z dimensions. Across the time (t)
-    dimension the TR is set by default to 1 sec.
+    Images can be concatenated across time, x, y, or z dimensions. Across the
+    time (t) dimension the TR is set by default to 1 sec.
 
-    Note: to set the TR to a different value, specify 't' for dimension and specify
-    the TR value in seconds for the tr input. The dimension will be automatically
-    updated to 'tr'.
+    Note: to set the TR to a different value, specify 't' for dimension and
+    specify the TR value in seconds for the tr input. The dimension will be
+    automatically updated to 'tr'.
 
     Examples
     --------
     >>> from nipype.interfaces.fsl import Merge
-    >>> from nipype.testing import funcfile
     >>> merger = Merge()
-    >>> merger.inputs.in_files = ['functional.nii', 'functional.nii']
+    >>> merger.inputs.in_files = ['functional2.nii', 'functional3.nii']
     >>> merger.inputs.dimension = 't'
-    >>> merger.inputs.merged_file = "functional_merged.nii.gz"
+    >>> merger.inputs.output_type = 'NIFTI_GZ'
     >>> merger.cmdline
-    'fslmerge -t functional_merged.nii.gz functional.nii functional.nii'
+    'fslmerge -t functional2_merged.nii.gz functional2.nii functional3.nii'
     >>> merger.inputs.tr = 2.25
     >>> merger.cmdline 
-    'fslmerge -tr functional_merged.nii.gz functional.nii functional.nii 2.25'
+    'fslmerge -tr functional2_merged.nii.gz functional2.nii functional3.nii 2.25'
     """
 
     _cmd = 'fslmerge'


### PR DESCRIPTION
The issue of a missing TR paramerter for FSL Merge was raised on the mailing list by Falko. I've modified the input_spec `dimension` input to take "tr" as an option, and added a `tr` input to specify the TR.

One issue: with "tr" listed as the value for `dimension` the "tr" input is required, but I wasn't sure how to make this input Mandatory only when `dimension` is set to "tr". I included info in the docs and examples to explain this.
