### PR TITLE
Allow ArtifactDetect to correctly handle AFNI motion correction parameters generated with -dfile or -1Dfile

### DIFF
--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -46,11 +46,8 @@ def _get_affine_matrix(params, source):
     """
     if source == 'FSL':
         params = params[[3, 4, 5, 0, 1, 2]]
-    elif source == 'AFNI':
-        params = params[[4, 5, 3, 1, 2, 0]]
-        params[3:] = params[3:] * np.pi / 180.
-    elif source == 'FSFAST':
-        params = params[[5, 6, 4, 2, 3, 1]]
+    elif source in ('AFNI', 'FSFAST'):
+        params = params[np.asarray([4, 5, 3, 1, 2, 0]) + (len(params) > 6)]
         params[3:] = params[3:] * np.pi / 180.
     if source == 'NIPY':
         # nipy does not store typical euler angles, use nipy to convert


### PR DESCRIPTION
AFNI's 3dvolreg can produce 6 or 9 column motion parameter files with -1Dfile and -dfile, respectively. This commit checks the number of columns to determine which column set to utilize. This PR leaves intact the 'FSFAST' parameter source, for ease of users coming from that environment, but makes it use the 'AFNI' code branches.
