### PR TITLE
Fixed AttributeError in Refit

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -748,7 +748,6 @@ class FNIRTInputSpec(FSLCommandInputSpec):
     config_file = traits.Either(
         traits.Enum("T1_2_MNI152_2mm", "FA_2_FMRIB58_1mm"), File(exists=True), argstr='--config=%s',
         desc='Name of config file specifying command line arguments')
-
     refmask_file = File(exists=True, argstr='--refmask=%s',
                         desc='name of file with mask in reference space')
     inmask_file = File(exists=True, argstr='--inmask=%s',


### PR DESCRIPTION
Before these changes I was getting this:

131113-10:53:15,735 workflow INFO:
     Running: 3drefit -deoblique /tmp/tmp0nwzz7/func_preproc/func_deoblique/rest_calc.nii.gz...

.../lib/python2.7/site-packages/nipype/interfaces/afni/preprocess.py", line 200, in _list_outputs
    self.outputs["out_file"] = os.path.abspath(self.inputs.in_file)
AttributeError: 'Refit' object has no attribute 'outputs'
Interface Refit failed to run.

The changes allow the workflow to complete successfully. Let me know your thoughts.
