### PR TITLE
BF: Fixing path issues for CMTK Parcellate dilated ROI files

### DIFF
--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -441,8 +441,6 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
 
 
 def crop_and_move_datasets(subject_id, subjects_dir, fs_dir, parcellation_name, out_roi_file,dilation):
-    import ipdb
-    ipdb.set_trace()
     fs_dir = op.join(subjects_dir, subject_id)
     cmp_config = cmp.configuration.PipelineConfiguration()
     cmp_config.parcellation_scheme = "Lausanne2008"


### PR DESCRIPTION
Addresses #591 

Some cleanup of the CMTK Parcellate interface to fix the weird output issues introduced by the dilated fMRI ROIs.

Seems that the

```
op.join(op.curdir, "blah"...
```

wasn't working properly. Just replaced it with:

```
op.abspath("blah")
```

and removed some unused variables.

Tested with:

```
import nipype.interfaces.cmtk as cmtk
import os
import nipype.pipeline.engine as pe          # pypeline engine
a = pe.Node(interface=cmtk.Parcellate(), name="testparc")
a.base_dir = "testparcnode"
a.inputs.subject_id = "bert"
a.inputs.subjects_dir = os.environ["SUBJECTS_DIR"]
a.inputs.dilation = False
a.inputs.parcellation_name = "scale33"
a.run()
```

There shouldn't be any differences in outputs for the other parcellation scales.

Should give a report.rest with inputs/outputs like this (github markdown seems to hide < undefined >):
## Original Inputs
- dilation : True
- freesurfer_dir : <undefined>
- ignore_exception : False
- out_roi_file : <undefined>
- parcellation_name : scale33
- subject_id : bert
- subjects_dir : /Applications/freesurfer/subjects
## Execution Inputs
- dilation : True
- freesurfer_dir : <undefined>
- ignore_exception : False
- out_roi_file : <undefined>
- parcellation_name : scale33
- subject_id : bert
- subjects_dir : /Applications/freesurfer/subjects
## Execution Outputs
- aseg_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/aseg.nii.gz
- cc_unknown_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/cc_unknown.nii.gz
- dilated_roi_file_in_structural_space : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/ROIv_HR_th.nii.gz
- ribbon_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/ribbon.nii.gz
- roi_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/ROI_scale33.nii.gz
- roi_file_in_structural_space : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/ROI_HR_th.nii.gz
- roiv_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/ROIv_scale33.nii.gz
- white_matter_mask_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc/fsmask_1mm.nii.gz
# For no Dilation:
## Original Inputs
- dilation : False
- freesurfer_dir : <undefined>
- ignore_exception : False
- out_roi_file : <undefined>
- parcellation_name : scale33
- subject_id : bert
- subjects_dir : /Applications/freesurfer/subjects
## Execution Inputs
- dilation : False
- freesurfer_dir : <undefined>
- ignore_exception : False
- out_roi_file : <undefined>
- parcellation_name : scale33
- subject_id : bert
- subjects_dir : /Applications/freesurfer/subjects
## Execution Outputs
- aseg_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/aseg.nii.gz
- cc_unknown_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/cc_unknown.nii.gz
- dilated_roi_file_in_structural_space : <undefined>
- ribbon_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/ribbon.nii.gz
- roi_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/ROI_scale33.nii.gz
- roi_file_in_structural_space : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/ROI_HR_th.nii.gz
- roiv_file : <undefined>
- white_matter_mask_file : /Users/erik/Dropbox/Testing/testparc/testparcnode/testparc_nodil/fsmask_1mm.nii.gz
