### PR TITLE
ENH: Add support for spm MCR configuration via environment

### DIFF
--- a/doc/users/spmmcr.rst
+++ b/doc/users/spmmcr.rst
@@ -19,6 +19,18 @@ you can test by calling:
 
     spm.SPMCommand().version
 
+If you want to enforce the standalone MCR version of spm for nipype globally,
+you can do so by setting the following environment variables:
+
+*SPMMCRCMD*
+    Specifies the command to use to run the spm standalone MCR version. You
+    may still override the command as described above.
+
+*FORCE_SPMMCR*
+    Set this to any value in order to enforce the use of spm standalone MCR
+    version in nipype globally. Technically, this sets the `use_mcr` flag of
+    the spm interface to True.
+
 Information about the MCR version of SPM8 can be found at:
 
 http://en.wikibooks.org/wiki/SPM/Standalone

--- a/nipype/interfaces/spm/base.py
+++ b/nipype/interfaces/spm/base.py
@@ -129,11 +129,17 @@ class Info(object):
 
         Parameters
         ----------
-        matlab_cmd : String specifying default matlab command
-
-            default None, will look for environment variable MATLABCMD
-            and use if found, otherwise falls back on MatlabCommand
-            default of 'matlab -nodesktop -nosplash'
+        matlab_cmd: str
+            Sets the default matlab command. If None, the value of the
+            environment variable SPMMCRCMD will be used if set and use_mcr
+            is True or the environment variable FORCE_SPMMCR is set.
+            If one of FORCE_SPMMCR or SPMMCRCMD is not set, the existence
+            of the environment variable MATLABCMD is checked and its value
+            is used as the matlab command if possible.
+            If none of the above was successful, the fallback value of
+            'matlab -nodesktop -nosplash' will be used.
+        paths : str
+        use_mcr : bool
 
         Returns
         -------
@@ -141,6 +147,13 @@ class Info(object):
 
             returns None of path not found
         """
+        if use_mcr or 'FORCE_SPMMCR' in os.environ:
+            use_mcr = True
+            if matlab_cmd is None:
+                try:
+                    matlab_cmd = os.environ['SPMMCRCMD']
+                except KeyError:
+                    pass
         if matlab_cmd is None:
             try:
                 matlab_cmd = os.environ['MATLABCMD']


### PR DESCRIPTION
This patches add support for enforcing and configuring the spm MCR standalone
version via environment variables. The respected environment variables are:
- FORCE_SPMMCR: any value, sets `use_mcr` to True
- SPMMCRCMD: command to use when running spm MCR, if `use_mcr` is True

See also: https://groups.google.com/forum/#!topic/nipy-user/3woo0zStl3M

Additionally, this PR contains two small code improvements in separate commits.
I can remove them, if you want me to.
