### PR TITLE
FIX: don't purge ipclient results if outstanding

### DIFF
--- a/nipype/pipeline/plugins/ipython.py
+++ b/nipype/pipeline/plugins/ipython.py
@@ -101,7 +101,8 @@ class IPythonPlugin(DistributedPluginBase):
             return report_crash(node)
 
     def _clear_task(self, taskid):
-        if IPyversion >= '0.11':
-            logger.debug("Clearing id: %d"%taskid)
+        if (IPyversion > '1.1.0' or
+                IPyversion >= '0.11' and not self.taskclient.outstanding):
+            logger.debug("Clearing id: %d" % taskid)
             self.taskclient.purge_results(self.taskmap[taskid])
             del self.taskmap[taskid]


### PR DESCRIPTION
The IPython plugin doesn't work for me with the current stable IPython (1.1.0) because it can't purge results when there are outstanding tasks, which is only supported in the current dev version, see https://github.com/ipython/ipython/commit/06a51242388de41eb0901c1438fae827c79f968f
