### PR TITLE
Check for MCR related env vars when instantiating SPMCommand

### DIFF
--- a/nipype/interfaces/spm/base.py
+++ b/nipype/interfaces/spm/base.py
@@ -237,6 +237,7 @@ class SPMCommand(BaseInterface):
                                                               'mfile',
                                                               'paths',
                                                               'use_mcr'])
+        self._find_mlab_cmd_defaults()
         self._check_mlab_inputs()
         self._matlab_cmd_update()
 
@@ -245,6 +246,17 @@ class SPMCommand(BaseInterface):
         cls._matlab_cmd = matlab_cmd
         cls._paths = paths
         cls._use_mcr = use_mcr
+
+    def _find_mlab_cmd_defaults(self):
+        # check if the user has set environment variables to enforce
+        # the standalone (MCR) version of SPM
+        if self._use_mcr or 'FORCE_SPMMCR' in os.environ:
+            self._use_mcr = True
+            if self._matlab_cmd is None:
+                try:
+                    self._matlab_cmd = os.environ['SPMMCRCMD']
+                except KeyError:
+                    pass
 
     def _matlab_cmd_update(self):
         # MatlabCommand has to be created here,

--- a/nipype/interfaces/spm/tests/test_base.py
+++ b/nipype/interfaces/spm/tests/test_base.py
@@ -68,6 +68,34 @@ def test_use_mfile():
     yield assert_true, dc.inputs.mfile
 
 
+def test_find_mlab_cmd_defaults():
+    saved_env = dict(os.environ)
+    class TestClass(spm.SPMCommand):
+        pass
+    # test without FORCE_SPMMCR, SPMMCRCMD set
+    for varname in ['FORCE_SPMMCR', 'SPMMCRCMD']:
+        try:
+            del os.environ[varname]
+        except KeyError:
+            pass
+    dc = TestClass()
+    yield assert_equal, dc._use_mcr, None
+    yield assert_equal, dc._matlab_cmd, None
+    # test with only FORCE_SPMMCR set
+    os.environ['FORCE_SPMMCR'] = '1'
+    dc = TestClass()
+    yield assert_equal, dc._use_mcr, True
+    yield assert_equal, dc._matlab_cmd, None
+    # test with both, FORCE_SPMMCR and SPMMCRCMD set
+    os.environ['SPMMCRCMD'] = 'spmcmd'
+    dc = TestClass()
+    yield assert_equal, dc._use_mcr, True
+    yield assert_equal, dc._matlab_cmd, 'spmcmd'
+    # restore environment
+    os.environ.clear();
+    os.environ.update(saved_env)
+
+
 @skipif(no_spm, "SPM not found")
 def test_cmd_update():
     class TestClass(spm.SPMCommand):


### PR DESCRIPTION
The recently added support for special environment variables, that allow
enforcing of the standalone (mcr) version of SPM, was incomplete. It only
affected requests for SPM's version information. With this patch, the
environment variables are also checked when instantiating SPMCommand.
