### PR TITLE
enh: moved api into its own file

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -72,9 +72,3 @@ try:
     del Tester
 except:
     pass
-
-
-from pipeline import Node, MapNode, JoinNode, Workflow
-from interfaces import (fsl, spm, freesurfer, afni, ants, slicer, dipy, nipy,
-                        mrtrix, camino, DataGrabber, DataSink, SelectFiles,
-                        IdentityInterface, Rename, Function, Select, Merge)

--- a/nipype/api.py
+++ b/nipype/api.py
@@ -1,0 +1,8 @@
+__author__ = 'satra'
+
+
+from pipeline import Node, MapNode, JoinNode, Workflow
+
+from .interfaces.io import DataGrabber, DataSink, SelectFiles
+from .interfaces.utility import IdentityInterface, Rename, Function, Select, Merge
+from .interfaces import fsl, spm, freesurfer, afni, ants, slicer, dipy, nipy, mrtrix, camino

--- a/nipype/interfaces/__init__.py
+++ b/nipype/interfaces/__init__.py
@@ -6,7 +6,3 @@ Package contains interfaces for using existing functionality in other packages
 Requires Packages to be installed
 """
 __docformat__ = 'restructuredtext'
-
-from io import DataGrabber, DataSink, SelectFiles
-from utility import IdentityInterface, Rename, Function, Select, Merge
-import fsl, spm, freesurfer, afni, ants, slicer, dipy, nipy, mrtrix, camino


### PR DESCRIPTION
The main aim of this PR is to move the toplevel objects and modules into an api module.
