### PR TITLE
Address large file with dcm2nii _parse_stdout

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -79,8 +79,6 @@ class Dcm2nii(CommandLine):
         return new_runtime
 
     def _parse_stdout(self, stdout):
-        import re
-        import os
         files = []
         reoriented_files = []
         reoriented_and_cropped_files = []


### PR DESCRIPTION
dcm2nii doesn't print the line `_parse_stdout` expects when it handles a very large file, which causes large files to be omitted from the output. This fixes that.

I've been using these changes for a couple of months now, with no adverse effects.
