### PR TITLE
Fix for output_name in MRtrix streamtrack

### DIFF
--- a/nipype/interfaces/mrtrix/tests/test_auto_DiffusionTensorStreamlineTrack.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_DiffusionTensorStreamlineTrack.py
@@ -79,7 +79,7 @@ def test_DiffusionTensorStreamlineTrack_inputs():
     out_file=dict(argstr='%s',
     name_source=['in_file'],
     name_template='%s_tracked.tck',
-    output_name='tracked.tck',
+    output_name='tracked',
     position=-1,
     ),
     seed_file=dict(argstr='-seed %s',

--- a/nipype/interfaces/mrtrix/tests/test_auto_ProbabilisticSphericallyDeconvolutedStreamlineTrack.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_ProbabilisticSphericallyDeconvolutedStreamlineTrack.py
@@ -77,7 +77,7 @@ def test_ProbabilisticSphericallyDeconvolutedStreamlineTrack_inputs():
     out_file=dict(argstr='%s',
     name_source=['in_file'],
     name_template='%s_tracked.tck',
-    output_name='tracked.tck',
+    output_name='tracked',
     position=-1,
     ),
     seed_file=dict(argstr='-seed %s',

--- a/nipype/interfaces/mrtrix/tests/test_auto_SphericallyDeconvolutedStreamlineTrack.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_SphericallyDeconvolutedStreamlineTrack.py
@@ -75,7 +75,7 @@ def test_SphericallyDeconvolutedStreamlineTrack_inputs():
     out_file=dict(argstr='%s',
     name_source=['in_file'],
     name_template='%s_tracked.tck',
-    output_name='tracked.tck',
+    output_name='tracked',
     position=-1,
     ),
     seed_file=dict(argstr='-seed %s',

--- a/nipype/interfaces/mrtrix/tests/test_auto_StreamlineTrack.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_StreamlineTrack.py
@@ -75,7 +75,7 @@ def test_StreamlineTrack_inputs():
     out_file=dict(argstr='%s',
     name_source=['in_file'],
     name_template='%s_tracked.tck',
-    output_name='tracked.tck',
+    output_name='tracked',
     position=-1,
     ),
     seed_file=dict(argstr='-seed %s',

--- a/nipype/interfaces/mrtrix/tracking.py
+++ b/nipype/interfaces/mrtrix/tracking.py
@@ -128,7 +128,7 @@ class StreamlineTrackInputSpec(CommandLineInputSpec):
     initial_direction = traits.List(traits.Int, desc='Specify the initial tracking direction as a vector',
         argstr='-initdirection %s', minlen=2, maxlen=2, units='voxels')
     out_file = File(argstr='%s', position= -1, name_source = ['in_file'], name_template='%s_tracked.tck', 
-                    output_name='tracked.tck', desc='output data file')
+                    output_name='tracked', desc='output data file')
 
 class StreamlineTrackOutputSpec(TraitedSpec):
     tracked = File(exists=True, desc='output file containing reconstructed tracts')


### PR DESCRIPTION
Fixes the thing I just complained about on the mailing list. Output name referenced did not exist. 
