### PR TITLE
added mapnode argument to allow enforce serial execution

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -2009,7 +2009,8 @@ class MapNode(Node):
             paired (i.e. it does not compute a combinatorial product).
         name : alphanumeric string
             node specific name
-
+        serial : boolean
+            flag to enforce executing the jobs of the mapnode in a serial manner rather than parallel
         See Node docstring for additional keyword arguments.
         """
 

--- a/nipype/pipeline/tests/test_engine.py
+++ b/nipype/pipeline/tests/test_engine.py
@@ -630,8 +630,7 @@ def test_serial_input():
                               'crashdump_dir': wd}
     
     # test output of num_subnodes method when serial is default (False)
-    num_subnodes_default = n1.num_subnodes()
-    yield assert_equal, num_subnodes_default, len(n1.inputs.in1)
+    yield assert_equal, n1.num_subnodes(), len(n1.inputs.in1)
     
     # test running the workflow on default conditions
     error_raised = False
@@ -644,8 +643,7 @@ def test_serial_input():
     
     # test output of num_subnodes method when serial is True
     n1._serial=True
-    num_subnodes_serial = n1.num_subnodes()
-    yield assert_equal, num_subnodes_serial, 1
+    yield assert_equal, n1.num_subnodes(), 1
     
     # test running the workflow on serial conditions
     error_raised = False


### PR DESCRIPTION
Tested with 'linear' 'multiproc' and 'condor' plugins for a test workflow. works without trouble
