### PR TITLE
Not empty folder in NFS errors

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -1398,9 +1398,11 @@ class Node(WorkflowBase):
                                     'Passing the exception.') % outdir)
                         pass
                     elif ((ex.errno == errno.ENOTEMPTY) and (len(outdircont) != 0)):
-                        logger.debug(('Folder is not empty (%d items): '
+                        logger.debug(('Folder contents (%d items): '
                                      '%s') % (len(outdircont), outdircont))
-                    raise ex
+                        raise ex
+                    else:
+                        raise ex
 
             else:
                 logger.debug(("%s found and can_resume is True or Node is a "


### PR DESCRIPTION
Added a more strict condition (https://github.com/oesteban/nipype/blob/bug/fixRemoveNonEmptyDir/nipype/pipeline/engine.py#L1391) when deleting old node folders because with NFS some folders can get locked but empty and the rmtree raises exception. This happens especially when locking files (actually a specific file-locking should be used e.g. http://pythonhosted.org/flufl.lock/).
