### PR TITLE
Fix: warnings complaining about unknown IPython lexer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,9 @@ extensions = ['sphinx.ext.todo',
               'sphinx.ext.autosummary',
               'numpy_ext.numpydoc',
               'matplotlib.sphinxext.plot_directive',
-              'matplotlib.sphinxext.only_directives'
+              'matplotlib.sphinxext.only_directives',
+              'matplotlib.sphinxext.ipython_directive',
+              'ipython_console_highlighting'
               ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
When building docs, sphinx was spiting out warnings because IPython's
lexers are unknown. Added the necessary extensions to sphinx config
file.

Sample file presenting this error: https://github.com/nipy/nipype/blob/master/doc/devel/filename_generation.rst
