### PR TITLE
ENH: N4BiasFieldCorrection new arguments

### DIFF
--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -243,7 +243,8 @@ class N4BiasFieldCorrectionInputSpec(ANTSCommandInputSpec):
     save_bias = traits.Bool(False, mandatory=True, usedefault=True,
                             desc=('True if the estimated bias should be saved'
                                   ' to file.'), xor=['bias_image'])
-    bias_image = File(desc=('Filename for the estimated bias.'))
+    bias_image = File(desc=('Filename for the estimated bias.'),
+                      hash_files=False)
 
 
 class N4BiasFieldCorrectionOutputSpec(TraitedSpec):

--- a/nipype/interfaces/ants/tests/test_auto_N4BiasFieldCorrection.py
+++ b/nipype/interfaces/ants/tests/test_auto_N4BiasFieldCorrection.py
@@ -5,7 +5,8 @@ from nipype.interfaces.ants.segmentation import N4BiasFieldCorrection
 def test_N4BiasFieldCorrection_inputs():
     input_map = dict(args=dict(argstr='%s',
     ),
-    bias_image=dict(),
+    bias_image=dict(hash_files=False,
+    ),
     bspline_fitting_distance=dict(argstr='--bsline-fitting [%g]',
     ),
     convergence_threshold=dict(argstr=',%g]',


### PR DESCRIPTION
Now, it is possible to save the estimated bias field, by fully supporting
the `--output` argument specification.
