### PR TITLE
HTML structure format corrections for example scripts

### DIFF
--- a/examples/dmri_camino_dti.py
+++ b/examples/dmri_camino_dti.py
@@ -8,7 +8,7 @@ Introduction
 ============
 
 This script, camino_dti_tutorial.py, demonstrates the ability to perform basic diffusion analysis
-in a Nipype pipeline.
+in a Nipype pipeline::
 
     python dmri_camino_dti.py
 

--- a/examples/dmri_connectivity.py
+++ b/examples/dmri_connectivity.py
@@ -9,7 +9,7 @@ Introduction
 
 This script, connectivity_tutorial.py, demonstrates the ability to perform connectivity mapping
 using Nipype for pipelining, Freesurfer for Reconstruction / Parcellation, Camino for tensor-fitting
-and tractography, and the Connectome Mapping Toolkit (CMTK) for connectivity analysis.
+and tractography, and the Connectome Mapping Toolkit (CMTK) for connectivity analysis::
 
     python connectivity_tutorial.py
 
@@ -26,9 +26,9 @@ A data package containing the outputs of this pipeline can be obtained from here
 
     * http://db.tt/1vx4vLeP
 
-Along with Camino (http://web4.cs.ucl.ac.uk/research/medic/camino/pmwiki/pmwiki.php?n=Main.HomePage),
-Camino-Trackvis (http://www.nitrc.org/projects/camino-trackvis/), FSL (http://www.fmrib.ox.ac.uk/fsl/),
-and Freesurfer (http://surfer.nmr.mgh.harvard.edu/), you must also have the Connectome File Format
+Along with `Camino <http://web4.cs.ucl.ac.uk/research/medic/camino/pmwiki/pmwiki.php?n=Main.HomePage>`_,
+`Camino-Trackvis <http://www.nitrc.org/projects/camino-trackvis/>`_, `FSL <http://www.fmrib.ox.ac.uk/fsl/>`_,
+and `Freesurfer <http://surfer.nmr.mgh.harvard.edu/>`_, you must also have the Connectome File Format
 library installed as well as the Connectome Mapper.
 
 These are written by Stephan Gerhard and can be obtained from:
@@ -583,7 +583,7 @@ if __name__ == '__main__':
     connectivity.write_graph(format='eps')
 
 """
-The output CFF file of this pipeline can be loaded in the Connectome Viewer (http://www.cmtk.org)
+The output CFF file of this pipeline can be loaded in the `Connectome Viewer <http://www.cmtk.org>`_.
 After loading the network into memory it can be examined in 3D or as a connectivity matrix
 using the default scripts produced by the Code Oracle.
 To compare networks, one must use the MergeCNetworks interface to merge two networks into

--- a/examples/dmri_connectivity_advanced.py
+++ b/examples/dmri_connectivity_advanced.py
@@ -9,7 +9,7 @@ Introduction
 
 This script, connectivity_tutorial_advanced.py, demonstrates the ability to perform connectivity mapping
 using Nipype for pipelining, Freesurfer for Reconstruction / Segmentation, MRtrix for spherical deconvolution
-and tractography, and the Connectome Mapping Toolkit (CMTK) for further parcellation and connectivity analysis.
+and tractography, and the Connectome Mapping Toolkit (CMTK) for further parcellation and connectivity analysis::
 
     python connectivity_tutorial_advanced.py
 

--- a/examples/dmri_fsl_dti.py
+++ b/examples/dmri_fsl_dti.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """
-===============
-dMRI [DTI, FSL]
-===============
+==============
+dMRI: DTI, FSL
+==============
 
 A pipeline example that uses several interfaces to perform analysis on
 diffusion weighted images using FSL FDT tools.

--- a/examples/dmri_group_connectivity_camino.py
+++ b/examples/dmri_group_connectivity_camino.py
@@ -8,7 +8,7 @@ Introduction
 
 This script, dmri_group_connectivity_camino.py, runs group-based connectivity analysis using
 the dmri.camino.connectivity_mapping Nipype workflow. Further detail on the processing can be
-found in :doc:`dmri_connectivity`. This tutorial can be run using:
+found in :doc:`dmri_connectivity`. This tutorial can be run using::
 
     python dmri_group_connectivity_camino.py
 

--- a/examples/dmri_group_connectivity_mrtrix.py
+++ b/examples/dmri_group_connectivity_mrtrix.py
@@ -8,7 +8,7 @@ Introduction
 
 This script, dmri_group_connectivity_mrtrix.py, runs group-based connectivity analysis using
 the dmri.mrtrix.connectivity_mapping Nipype workflow. Further detail on the processing can be
-found in :doc:`dmri_connectivity_advanced`. This tutorial can be run using:
+found in :doc:`dmri_connectivity_advanced`. This tutorial can be run using::
 
     python dmri_group_connectivity_mrtrix.py
 

--- a/examples/dmri_mrtrix_dti.py
+++ b/examples/dmri_mrtrix_dti.py
@@ -8,7 +8,7 @@ Introduction
 ============
 
 This script, dmri_mrtrix_dti.py, demonstrates the ability to perform advanced diffusion analysis
-in a Nipype pipeline.
+in a Nipype pipeline::
 
     python dmri_mrtrix_dti.py
 

--- a/examples/dmri_tbss_nki.py
+++ b/examples/dmri_tbss_nki.py
@@ -9,6 +9,7 @@ dMRI: TBSS on NKI RS data
 A pipeline to do a TBSS analysis on the NKI rockland sample data
 
 """
+
 from nipype.workflows.dmri.fsl.dti import create_eddy_correct_pipeline
 from nipype.workflows.dmri.fsl.tbss import create_tbss_non_FA, create_tbss_all
 

--- a/examples/fmri_ants_openfmri.py
+++ b/examples/fmri_ants_openfmri.py
@@ -7,7 +7,7 @@ fMRI: OpenfMRI.org data, FSL, ANTS, c3daffine
 =============================================
 
 A growing number of datasets are available on `OpenfMRI <http://openfmri.org>`_.
-This script demonstrates how to use nipype to analyze a data set.
+This script demonstrates how to use nipype to analyze a data set::
 
     python fmri_ants_openfmri.py --datasetdir ds107
 """
@@ -47,19 +47,16 @@ def create_reg_workflow(name='registration'):
 
     Parameters
     ----------
-
-    ::
-
         name : name of workflow (default: 'registration')
 
-    Inputs::
+    Inputs:
 
         inputspec.source_files : files (filename or list of filenames to register)
         inputspec.mean_image : reference image to use
         inputspec.anatomical_image : anatomical image to coregister to
         inputspec.target_image : registration target
 
-    Outputs::
+    Outputs:
 
         outputspec.func2anat_transform : FLIRT transform
         outputspec.anat2target_transform : FLIRT+FNIRT transform
@@ -68,7 +65,6 @@ def create_reg_workflow(name='registration'):
 
     Example
     -------
-
     """
 
     register = pe.Workflow(name=name)
@@ -130,6 +126,7 @@ def create_reg_workflow(name='registration'):
     register.connect(inputnode, 'anatomical_image', mean2anatbbr, 'reference')
     register.connect(mean2anat, 'out_matrix_file',
                      mean2anatbbr, 'in_matrix_file')
+
     """
     Convert the BBRegister transformation to ANTS ITK format
     """
@@ -197,6 +194,7 @@ def create_reg_workflow(name='registration'):
     """
     Transform the mean image. First to anatomical and then to target
     """
+
     warpmean = pe.Node(ants.ApplyTransforms(),
                        name='warpmean')
     warpmean.inputs.input_image_type = 3
@@ -237,6 +235,10 @@ def create_reg_workflow(name='registration'):
                      outputnode, 'anat2target_transform')
 
     return register
+
+"""
+Get info for a given subject
+"""
 
 def get_subjectinfo(subject_id, base_dir, task_id, model_id):
     """Get info for a given subject
@@ -291,6 +293,9 @@ def get_subjectinfo(subject_id, base_dir, task_id, model_id):
     TR = np.genfromtxt(os.path.join(base_dir, 'scan_key.txt'))[1]
     return run_ids[task_id - 1], conds[task_id - 1], TR
 
+"""
+Analyzes an open fmri dataset
+"""
 
 def analyze_openfmri_dataset(data_dir, subject=None, model_id=None,
                              task_id=None, output_dir=None, subj_prefix='*',
@@ -621,6 +626,7 @@ def analyze_openfmri_dataset(data_dir, subject=None, model_id=None,
     """
     Set processing parameters
     """
+
     preproc.inputs.inputspec.fwhm = fwhm
     gethighpass.inputs.hpcutoff = hpcutoff
     modelspec.inputs.high_pass_filter_cutoff = hpcutoff
@@ -633,6 +639,10 @@ def analyze_openfmri_dataset(data_dir, subject=None, model_id=None,
 
     datasink.inputs.base_directory = output_dir
     return wf
+
+"""
+The following functions run the whole workflow.
+"""
 
 if __name__ == '__main__':
     import argparse

--- a/examples/fmri_nipy_glm.py
+++ b/examples/fmri_nipy_glm.py
@@ -6,17 +6,16 @@
 fMRI: NiPy GLM, SPM
 ===================
 
-
 The fmri_nipy_glm.py integrates several interfaces to perform a first level
 analysis on a two-subject data set. It is very similar to the spm_tutorial with
 the difference of using nipy for fitting GLM model and estimating contrasts.
-The tutorial can
-be found in the examples folder. Run the tutorial from inside the
-nipype tutorial directory:
+The tutorial can be found in the examples folder. Run the tutorial from inside
+the nipype tutorial directory::
 
     python fmri_nipy_glm.py
 
 """
+
 from nipype.interfaces.nipy.model import FitGLM, EstimateContrast
 from nipype.interfaces.nipy.preprocess import ComputeMask
 

--- a/examples/fmri_openfmri.py
+++ b/examples/fmri_openfmri.py
@@ -7,7 +7,7 @@ fMRI: OpenfMRI.org data, FSL
 ============================
 
 A growing number of datasets are available on `OpenfMRI <http://openfmri.org>`_.
-This script demonstrates how to use nipype to analyze a data set.
+This script demonstrates how to use nipype to analyze a data set::
 
     python fmri_openfmri.py --datasetdir ds107
 """
@@ -420,6 +420,10 @@ def analyze_openfmri_dataset(data_dir, subject=None, model_id=None,
 
     datasink.inputs.base_directory = output_dir
     return wf
+
+"""
+The following functions run the whole workflow.
+"""
 
 if __name__ == '__main__':
     import argparse

--- a/examples/fmri_slicer_coregistration.py
+++ b/examples/fmri_slicer_coregistration.py
@@ -7,14 +7,14 @@ fMRI: Coregistration - Slicer, BRAINS
 =====================================
 
 This is currently not working and will raise an exception in release 0.3. It
-will be fixed in a later release.
+will be fixed in a later release::
 
     python fmri_slicer_coregistration.py
 
 """
+
 #raise RuntimeWarning, 'Slicer not fully implmented'
 from nipype.interfaces.slicer import BRAINSFit, BRAINSResample
-
 
 
 """Import necessary modules from nipype."""

--- a/examples/fmri_spm.py
+++ b/examples/fmri_spm.py
@@ -9,7 +9,7 @@ fMRI: SPM, FSL
 The fmri_spm.py integrates several interfaces to perform a first
 and second level analysis on a two-subject data set.  The tutorial can
 be found in the examples folder.  Run the tutorial from inside the
-nipype tutorial directory:
+nipype tutorial directory::
 
     python fmri_spm.py
 

--- a/examples/fmri_spm_auditory.py
+++ b/examples/fmri_spm_auditory.py
@@ -9,8 +9,9 @@ fMRI: SPM Auditory dataset
 Introduction
 ============
 
-The fmri_spm_auditory.py recreates the classical workflow described in the SPM8 manual (http://www.fil.ion.ucl.ac.uk/spm/doc/manual.pdf)
-using auditory dataset that can be downloaded from http://www.fil.ion.ucl.ac.uk/spm/data/auditory/:
+The fmri_spm_auditory.py recreates the classical workflow described in the
+`SPM8 manual <http://www.fil.ion.ucl.ac.uk/spm/doc/manual.pdf>`_ using auditory
+dataset that can be downloaded from http://www.fil.ion.ucl.ac.uk/spm/data/auditory/::
 
     python fmri_spm_auditory.py
 
@@ -19,7 +20,8 @@ Import necessary modules from nipype."""
 import nipype.interfaces.io as nio           # Data i/o
 import nipype.interfaces.spm as spm          # spm
 import nipype.interfaces.fsl as fsl          # fsl
-import nipype.interfaces.matlab as mlab      # how to run matlabimport nipype.interfaces.fsl as fsl          # fsl
+import nipype.interfaces.matlab as mlab      # how to run matlab
+import nipype.interfaces.fsl as fsl          # fsl
 import nipype.interfaces.utility as util     # utility
 import nipype.pipeline.engine as pe          # pypeline engine
 import nipype.algorithms.modelgen as model   # model specification

--- a/examples/fmri_spm_dartel.py
+++ b/examples/fmri_spm_dartel.py
@@ -9,7 +9,7 @@ fMRI: DARTEL, SPM
 The fmri_spm_dartel.py integrates several interfaces to perform a first
 and second level analysis on a two-subject data set.  The tutorial can
 be found in the examples folder.  Run the tutorial from inside the
-nipype tutorial directory:
+nipype tutorial directory::
 
     python fmri_spm_dartel.py
 

--- a/examples/fmri_spm_face.py
+++ b/examples/fmri_spm_face.py
@@ -9,10 +9,9 @@ fMRI: Famous vs non-famous faces, SPM
 Introduction
 ============
 
-The fmri_spm_face.py recreates the classical workflow described in the SPM8
-manual (http://www.fil.ion.ucl.ac.uk/spm/doc/manual.pdf) using auditory dataset
-that can be downloaded from
-http://www.fil.ion.ucl.ac.uk/spm/data/face_rep/face_rep_SPM5.html::
+The fmri_spm_face.py recreates the classical workflow described in the
+`SPM8 manual <http://www.fil.ion.ucl.ac.uk/spm/doc/manual.pdf>`_ using face
+dataset that can be downloaded from http://www.fil.ion.ucl.ac.uk/spm/data/face_rep/::
 
     python fmri_spm.py
 
@@ -271,7 +270,7 @@ necessary to generate an SPM design matrix.
 from nipype.interfaces.base import Bunch
 
 """We're importing the onset times from a mat file (found on
-http://www.fil.ion.ucl.ac.uk/spm/data/face_rep/face_rep_SPM5.html
+http://www.fil.ion.ucl.ac.uk/spm/data/face_rep/)
 """
 
 from scipy.io.matlab import loadmat

--- a/examples/fmri_spm_nested.py
+++ b/examples/fmri_spm_nested.py
@@ -9,7 +9,7 @@ fMRI: SPM nested workflows
 The fmri_spm.py integrates several interfaces to perform a first
 and second level analysis on a two-subject data set.  The tutorial can
 be found in the examples folder.  Run the tutorial from inside the
-nipype tutorial directory:
+nipype tutorial directory::
 
     python fmri_spm_nested.py
 

--- a/examples/smri_freesurfer.py
+++ b/examples/smri_freesurfer.py
@@ -5,7 +5,7 @@ sMRI: FreeSurfer
 ================
 
 This script, smri_freesurfer.py, demonstrates the ability to call reconall on
-a set of subjects and then make an average subject.
+a set of subjects and then make an average subject::
 
     python smri_freesurfer.py
 

--- a/examples/tessellation_tutorial.py
+++ b/examples/tessellation_tutorial.py
@@ -7,7 +7,7 @@ sMRI: Regional Tessellation and Surface Smoothing
 Introduction
 ============
 
-This script, tessellation_tutorial.py, demonstrates the use of create_tessellation_flow from nipype.workflows.smri.freesurfer, and it can be run with:
+This script, tessellation_tutorial.py, demonstrates the use of create_tessellation_flow from nipype.workflows.smri.freesurfer, and it can be run with::
 
     python tessellation_tutorial.py
 
@@ -33,6 +33,7 @@ Packages and Data Setup
 
 Import the necessary modules and workflow from nipype.
 """
+
 import nipype.pipeline.engine as pe          # pypeline engine
 import nipype.interfaces.cmtk as cmtk
 import nipype.interfaces.io as nio           # Data i/o


### PR DESCRIPTION
I just went through the examples on the homepage and looked for obvious format issues. Most corrections are minim, but the fMRI: OpenfMRI.org data, FSL, ANTS, c3daffine example (http://nipy.org/nipype/users/examples/fmri_ants_openfmri.html) will become much more readable.
