### PR TITLE
ENH: antsIntroduction handles RA and RI transformations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Next release
 ============
-
+* ENH: Updated antsIntroduction to handle RA and RI registrations (https://github.com/nipy/nipype/pull/1009)
 * ENH: Updated N4BiasCorrection input spec to include weight image and spline order. Made 
 	   argument formatting consistent. Cleaned ants.segmentation according to PEP8.
 	   (https://github.com/nipy/nipype/pull/990/files)

--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -97,7 +97,7 @@ class antsIntroduction(ANTSCommand):
         transmodel = self.inputs.transformation_model
 
         # When transform is set as 'RI'/'RA', no wrap fields will be outputed
-        if transmodel not in ['RI', 'RA']:
+        if isdefined(transmodel) and transmodel not in ['RI', 'RA']:
             outputs['warp_field'] = os.path.join(os.getcwd(),
                                  self.inputs.out_prefix +
                                  'Warp.nii.gz')

--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -96,8 +96,9 @@ class antsIntroduction(ANTSCommand):
         outputs = self._outputs().get()
         transmodel = self.inputs.transformation_model
 
-        # When transform is set as 'RI'/'RA', no wrap fields will be outputed
-        if isdefined(transmodel) and transmodel not in ['RI', 'RA']:
+        # When transform is set as 'RI'/'RA', wrap fields should not be expected 
+        # The default transformation is GR, which outputs the wrap fields
+        if not isdefined(transmodel) or (isdefined(transmodel) and transmodel not in ['RI', 'RA']):
             outputs['warp_field'] = os.path.join(os.getcwd(),
                                  self.inputs.out_prefix +
                                  'Warp.nii.gz')

--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -94,16 +94,20 @@ class antsIntroduction(ANTSCommand):
 
     def _list_outputs(self):
         outputs = self._outputs().get()
+        transmodel = self.inputs.transformation_model
+
+        # When transform is set as 'RI'/'RA', no wrap fields will be outputed
+        if transmodel not in ['RI', 'RA']:
+            outputs['warp_field'] = os.path.join(os.getcwd(),
+                                 self.inputs.out_prefix +
+                                 'Warp.nii.gz')
+            outputs['inverse_warp_field'] = os.path.join(os.getcwd(),
+                                     self.inputs.out_prefix +
+                                     'InverseWarp.nii.gz')
 
         outputs['affine_transformation'] = os.path.join(os.getcwd(),
                                                         self.inputs.out_prefix +
                                                         'Affine.txt')
-        outputs['warp_field'] = os.path.join(os.getcwd(),
-                                             self.inputs.out_prefix +
-                                             'Warp.nii.gz')
-        outputs['inverse_warp_field'] = os.path.join(os.getcwd(),
-                                                     self.inputs.out_prefix +
-                                                     'InverseWarp.nii.gz')
         outputs['input_file'] = os.path.join(os.getcwd(),
                                              self.inputs.out_prefix +
                                              'repaired.nii.gz')


### PR DESCRIPTION
when generating the _list_outputs if -t RA or -t RI is set, *_warp_field
outputs will not be required