### PR TITLE
Fix bug in Normalize with modulation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Next release
 * FIX: Corrected Freesurfer SegStats _list_outputs to avoid error if summary_file is 
 	   undefined (issue #994)(https://https://github.com/nipy/nipype/pull/996)
 * FIX: OpenfMRI support and FSL 5.0.7 changes (https://github.com/nipy/nipype/pull/1006)
+* FIX: Output prefix in SPM Normalize with modulation (https://github.com/nipy/nipype/pull/1023)
 
 Release 0.10.0 (October 10, 2014)
 ============

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -497,20 +497,24 @@ class Normalize(SPMCommand):
                 outputs['normalized_files'] = self.inputs.apply_to_files
             outputs['normalized_source'] = self.inputs.source
         elif 'write' in self.inputs.jobtype:
+            if isdefined(self.inputs.write_preserve) and self.inputs.write_preserve:
+                prefixNorm = ''.join(['m', self.inputs.out_prefix])
+            else:
+                prefixNorm = self.inputs.out_prefix
             outputs['normalized_files'] = []
             if isdefined(self.inputs.apply_to_files):
                 filelist = filename_to_list(self.inputs.apply_to_files)
                 for f in filelist:
                     if isinstance(f, list):
-                        run = [fname_presuffix(in_f, prefix=self.inputs.out_prefix) for in_f in f]
+                        run = [fname_presuffix(in_f, prefix=prefixNorm) for in_f in f]
                     else:
-                        run = [fname_presuffix(f, prefix=self.inputs.out_prefix)]
+                        run = [fname_presuffix(f, prefix=prefixNorm)]
                     outputs['normalized_files'].extend(run)
             if isdefined(self.inputs.source):
                 outputs['normalized_source'] = []
                 for imgf in filename_to_list(self.inputs.source):
                     outputs['normalized_source'].append(fname_presuffix(imgf,
-                                                        prefix=self.inputs.out_prefix))
+                                                        prefix=prefixNorm))
 
         return outputs
 


### PR DESCRIPTION
I fixed bug reported in http://neurostars.org/p/2768/, wrong prefix in case to execute 'Normalize' with modulation.
I'd appreciate it if you could reflect this change.