### PR TITLE
Fix split filename

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Next release
 ============
 
+* FIX: Fix split_filename behaviour when path has no file component (https://github.com/nipy/nipype/pull/1035)
 * ENH: Updated FSL dtifit to include option for grad non-linearities (https://github.com/nipy/nipype/pull/1032)
 * ENH: Updated Camino tracking interfaces, which can now use FSL bedpostx output.
        New options also include choice of tracker, interpolator, stepsize and 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -61,10 +61,8 @@ def split_filename(fname):
 
     special_extensions = [".nii.gz", ".tar.gz"]
 
-    if fname and fname.endswith(os.path.sep):
-        fname = fname[:-1]
-
-    pth, fname = os.path.split(fname)
+    pth = os.path.dirname(fname)
+    fname = os.path.basename(fname)
 
     ext = None
     for special_ext in special_extensions:

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -24,6 +24,8 @@ def test_split_filename():
     yield assert_equal, res, ('../usr/local', 'foo', '.nii')
     res = split_filename('/usr/local/foo.a.b.c.d')
     yield assert_equal, res, ('/usr/local', 'foo.a.b.c', '.d')
+    res = split_filename('/abs/path/')
+    yield assert_equal, res, ('/abs/path/', '', '')
 
 def test_fname_presuffix():
     fname = 'foo.nii'

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -24,8 +24,8 @@ def test_split_filename():
     yield assert_equal, res, ('../usr/local', 'foo', '.nii')
     res = split_filename('/usr/local/foo.a.b.c.d')
     yield assert_equal, res, ('/usr/local', 'foo.a.b.c', '.d')
-    res = split_filename('/abs/path/')
-    yield assert_equal, res, ('/abs/path/', '', '')
+    res = split_filename('/usr/local/')
+    yield assert_equal, res, ('/usr/local', '', '')
 
 def test_fname_presuffix():
     fname = 'foo.nii'


### PR DESCRIPTION
As mentionned [here](https://neurostars.org/p/2874/) `split_filename` doesn't work when passing path ending with `'/'`. This PR fixes that.