### PR TITLE
Git ignore add documentation.zip as ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .settings
 .pydevproject
 .idea/
+/documentation.zip


### PR DESCRIPTION
When running make in the nipype folder, documentation.zip is created. Running git status then shows this as an untracked file. 