### PR TITLE
FIX Constant column in motion regressor causes singular matrix

### DIFF
--- a/examples/rsfmri_vol_surface_preprocessing.py
+++ b/examples/rsfmri_vol_surface_preprocessing.py
@@ -542,7 +542,7 @@ def create_reg_workflow(name='registration'):
 
     warpmean = Node(ants.ApplyTransforms(), name='warpmean')
     warpmean.inputs.input_image_type = 3
-    warpmean.inputs.interpolation = 'BSpline'
+    warpmean.inputs.interpolation = 'Linear'
     warpmean.inputs.invert_transform_flags = [False, False]
     warpmean.inputs.terminal_output = 'file'
     warpmean.inputs.args = '--float'
@@ -771,7 +771,7 @@ def create_workflow(files,
     warpall = MapNode(ants.ApplyTransforms(), iterfield=['input_image'],
                       name='warpall')
     warpall.inputs.input_image_type = 3
-    warpall.inputs.interpolation = 'BSpline'
+    warpall.inputs.interpolation = 'Linear'
     warpall.inputs.invert_transform_flags = [False, False]
     warpall.inputs.terminal_output = 'file'
     warpall.inputs.reference_image = target_file

--- a/examples/rsfmri_vol_surface_preprocessing.py
+++ b/examples/rsfmri_vol_surface_preprocessing.py
@@ -230,7 +230,7 @@ def build_filter1(motion_params, comp_norm, outliers, detrend_poly=None):
             out_params = np.hstack((out_params, outlier_vector))
         if detrend_poly:
             timepoints = out_params.shape[0]
-            X = np.ones((timepoints, 1))
+            X = np.empty((timepoints, 0))
             for i in range(detrend_poly):
                 X = np.hstack((X, legendre(
                     i + 1)(np.linspace(-1, 1, timepoints))[:, None]))

--- a/examples/rsfmri_vol_surface_preprocessing_nipy.py
+++ b/examples/rsfmri_vol_surface_preprocessing_nipy.py
@@ -217,7 +217,7 @@ def build_filter1(motion_params, comp_norm, outliers, detrend_poly=None):
             out_params = np.hstack((out_params, outlier_vector))
         if detrend_poly:
             timepoints = out_params.shape[0]
-            X = np.ones((timepoints, 1))
+            X = np.empty((timepoints, 0))
             for i in range(detrend_poly):
                 X = np.hstack((X, legendre(
                     i + 1)(np.linspace(-1, 1, timepoints))[:, None]))

--- a/examples/rsfmri_vol_surface_preprocessing_nipy.py
+++ b/examples/rsfmri_vol_surface_preprocessing_nipy.py
@@ -526,7 +526,7 @@ def create_reg_workflow(name='registration'):
     """
     warpmean = Node(ants.ApplyTransforms(), name='warpmean')
     warpmean.inputs.input_image_type = 3
-    warpmean.inputs.interpolation = 'BSpline'
+    warpmean.inputs.interpolation = 'Linear'
     warpmean.inputs.invert_transform_flags = [False, False]
     warpmean.inputs.terminal_output = 'file'
     warpmean.inputs.args = '--float'
@@ -749,7 +749,7 @@ def create_workflow(files,
     warpall = MapNode(ants.ApplyTransforms(), iterfield=['input_image'],
                       name='warpall')
     warpall.inputs.input_image_type = 3
-    warpall.inputs.interpolation = 'BSpline'
+    warpall.inputs.interpolation = 'Linear'
     warpall.inputs.invert_transform_flags = [False, False]
     warpall.inputs.terminal_output = 'file'
     warpall.inputs.reference_image = target_file


### PR DESCRIPTION
The constant column in the motion regressor results in the FSL GLM reporting a SingularMatrix exception. I can not find reference to a constant (intercept) term in the ``fsl_glm`` documentation. It could potentially be a result of the ``--demean`` argument when calling the ``fsl_glm`` command. Do you have any insights into what may be causing this?

For now, I am opening the pull request to start discussion. If this seems like a reasonable fix, I will go through the other steps listed in the "contributing" document.