### PR TITLE
FIX Set type on bandpass frequency arguments.

### DIFF
--- a/examples/rsfmri_vol_surface_preprocessing.py
+++ b/examples/rsfmri_vol_surface_preprocessing.py
@@ -1003,9 +1003,11 @@ if __name__ == "__main__":
     parser.add_argument('--surf_fwhm', default=15., dest='surf_fwhm',
                         type=float, help="Spatial FWHM" + defstr)
     parser.add_argument("-l", "--lowpass_freq", dest="lowpass_freq",
-                        default=0.1, help="Low pass frequency (Hz)" + defstr)
+                        default=0.1, type=float,
+                        help="Low pass frequency (Hz)" + defstr)
     parser.add_argument("-u", "--highpass_freq", dest="highpass_freq",
-                        default=0.01, help="High pass frequency (Hz)" + defstr)
+                        default=0.01, type=float,
+                        help="High pass frequency (Hz)" + defstr)
     parser.add_argument("-o", "--output_dir", dest="sink",
                         help="Output directory base", required=True)
     parser.add_argument("-w", "--work_dir", dest="work_dir",

--- a/examples/rsfmri_vol_surface_preprocessing_nipy.py
+++ b/examples/rsfmri_vol_surface_preprocessing_nipy.py
@@ -996,9 +996,11 @@ if __name__ == "__main__":
     parser.add_argument('--surf_fwhm', default=15., dest='surf_fwhm',
                         type=float, help="Spatial FWHM" + defstr)
     parser.add_argument("-l", "--lowpass_freq", dest="lowpass_freq",
-                        default=0.1, help="Low pass frequency (Hz)" + defstr)
+                        default=0.1, type=float,
+                        help="Low pass frequency (Hz)" + defstr)
     parser.add_argument("-u", "--highpass_freq", dest="highpass_freq",
-                        default=0.01, help="High pass frequency (Hz)" + defstr)
+                        default=0.01, type=float,
+                        help="High pass frequency (Hz)" + defstr)
     parser.add_argument("-o", "--output_dir", dest="sink",
                         help="Output directory base", required=True)
     parser.add_argument("-w", "--work_dir", dest="work_dir",


### PR DESCRIPTION
This is a very minor correction, but the example resting state scripts do not correctly specify the variable type for the arguments. This causes issues with negative values. The string "-1" evaluates as true in the ``bandpass_filter`` function on the line ``if lowpass_freq > 0:``, which does not produce the intended effect of suppressing the lowpass filter.

I am happy to write tests for this, although I don't see any tests associated with the example scripts. Let me know if there is anything else I can do to help.