### PR TITLE
Updates to JoinNode

### DIFF
--- a/nipype/pipeline/engine.py
+++ b/nipype/pipeline/engine.py
@@ -1914,7 +1914,9 @@ class JoinNode(Node):
         # the new field name
         name = self._join_item_field_name(field, index)
         # make a copy of the join trait
-        trait = self._inputs.trait(field, False, True)
+        # This always returns NoneType for some reason. I replaced it by the traits Any type
+        #trait = self._inputs.trait(field, False, True)
+        trait = traits.Any
         # add the join item trait to the override traits
         self._inputs.add_trait(name, trait)
 
@@ -1965,21 +1967,23 @@ class JoinNode(Node):
         """
         Collects each override join item field into the interface join
         field input."""
+
         for field in self.inputs.copyable_trait_names():
-            if field in self.joinfield:
-                # collate the join field
-                val = self._collate_input_value(field)
-                try:
-                    setattr(self._interface.inputs, field, val)
-                except Exception as e:
-                    raise ValueError(">>JN %s %s %s %s %s: %s" % (self, field, val, self.inputs.copyable_trait_names(), self.joinfield, e))
-            elif hasattr(self._interface.inputs, field):
+            if hasattr(self._interface.inputs, field):
                 # copy the non-join field
                 val = getattr(self._inputs, field)
                 if isdefined(val):
                     setattr(self._interface.inputs, field, val)
-        logger.debug("Collated %d inputs into the %s node join fields"
-                     % (self._next_slot_index, self))
+
+        for field in self.joinfield:
+            val = self._collate_input_value(field)
+            try:
+                setattr(self._interface.inputs, field, val)
+            except Exception as e:
+                raise ValueError(">>JN %s %s %s %s %s: %s" % (self, field, val,
+                                                              self.inputs.copyable_trait_names(), self.joinfield, e))
+
+        logger.debug("Collated %d inputs into the %s node join fields" % (self._next_slot_index, self))
 
     def _collate_input_value(self, field):
         """


### PR DESCRIPTION
My use case scenario was this:

I had a class with an inputspec as follows:
```Python
class JoiningIS(DynamicTraitedSpec):
    subject_id_list = traits.List(trait=traits.Str, imandatory=True, desc="The list of subject ids")

class Joining(BaseInterface):
    input_spec = JoiningIS
    ...
```

This was wrapped in an JoinNode:
```Python
node = pe.JoinNode(Joining(), joinsource='InfoSource', name='Joining', joinfield=['subject_id_list'])
```

Whenevery I tried to run this I got the following error message:

traits.trait_errors.TraitError: The 'subject_id_listJ1' trait of a DynamicTraitedSpec instance must be an implementor of, or can be adapted to implement, NoneType or None, but a value of '000000642263' <type 'str'> was specified.

I traced this in the code to 
```Python
trait = self._inputs.trait(field, False, True)
```
in the engine.py on line 1917. This always returned a NoneType. Replacing this with a single call to:
```Python
trait = traits.Any
```
circumvented this error.

Next, I ran into the problem that my lists were not concatenated. The loop on line 1968 had:
```Python
for field in self.inputs.copyable_trait_names():
```
This did not iterate over the fields specified by the joinfields. It therefore never concatenated the results. I split the loop into two loops, to make sure it always iterates over the join fields.

The end result is that the JoinNode now works for me as expected. I now get in my interface a list of concatenated inputs.

Please let me know if you need more information about this patch.