### PR TITLE
FIX: Bug in tbss1

### DIFF
--- a/nipype/workflows/dmri/fsl/tbss.py
+++ b/nipype/workflows/dmri/fsl/tbss.py
@@ -15,6 +15,7 @@ def tbss1_op_string(in_files):
     for infile in in_files:
         img = nib.load(infile)
         dimtup = tuple([d - 2 for d in img.get_shape()])
+        dimtup = dimtup[0:3]
         op_str = '-min 1 -ero -roi 1 %d 1 %d 1 %d 0 1' % dimtup
         op_strings.append(op_str)
     return op_strings


### PR DESCRIPTION
If an image is loaded with more than 3 dimensions the function crashes.

For example, suppose we load an an image with dimensions (100, 50, 50, 1). The last dimension here is redundant, but still, it is there. This gives an tuple of length 4, which is to long for the format statement on the next line. 

By limiting it to 3 dimensions, this works again.