### PR TITLE
ENH/FIX?: Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ cache:
   - apt
 language: python
 python:
-  - 2.6
   - 2.7
 env:
   - INSTALL_DEB_DEPENDECIES=true

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Next release
 ============
+* ENH: Dropped support for now 7 years old Python 2.6 (https://github.com/nipy/nipype/pull/1069)
 * FIX: terminal_output is not mandatory anymore (https://github.com/nipy/nipype/pull/1070)
 * FIX: Fixed Camino output naming (https://github.com/nipy/nipype/pull/1061)
 * ENH: Add the average distance to ErrorMap (https://github.com/nipy/nipype/pull/1039)

--- a/doc/users/install.rst
+++ b/doc/users/install.rst
@@ -107,7 +107,7 @@ recommendations.
 Must Have
 ~~~~~~~~~
 
-Python_ 2.6 - 2.7
+Python_ 2.7
 
 Nibabel_ 1.0 - 1.4
   Neuroimaging file i/o library


### PR DESCRIPTION
Python 2.7 brings argparse and some useful testing functions
(http://stackoverflow.com/questions/17585207/python-unittest-assetraises).
Both debian stable and ubuntu LST come with Python 2.7.