### PR TITLE
SSHDataGrabber outputs now returns full path to the grabbed files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,7 +50,7 @@ Next release
 * ENH: ANTs JointFusion() (https://github.com/nipy/nipype/pull/1042)
 * ENH: Added csvReader() utility (https://github.com/nipy/nipype/pull/1044)
 * FIX: typo in nipype.interfaces.freesurfer.utils.py Tkregister2 (https://github.com/nipy/nipype/pull/1083)
-* FIX: SSHDataGrabber outputs now return full path to the grabbed/downloaded files.
+* FIX: SSHDataGrabber outputs now return full path to the grabbed/downloaded files. (https://github.com/nipy/nipype/pull/1086)
 
 Release 0.10.0 (October 10, 2014)
 ============

--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ Next release
 * ENH: ANTs JointFusion() (https://github.com/nipy/nipype/pull/1042)
 * ENH: Added csvReader() utility (https://github.com/nipy/nipype/pull/1044)
 * FIX: typo in nipype.interfaces.freesurfer.utils.py Tkregister2 (https://github.com/nipy/nipype/pull/1083)
+* FIX: SSHDataGrabber outputs now return full path to the grabbed/downloaded files.
 
 Release 0.10.0 (October 10, 2014)
 ============

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -1775,13 +1775,20 @@ class SSHDataGrabber(DataGrabber):
                         outputs[key].append(list_to_filename(outfiles))
                         if self.inputs.download_files:
                             for f in outfiles:
-                                sftp.get(os.path.join(filledtemplate_dir, f), f)
+                                try:
+                                    sftp.get(os.path.join(filledtemplate_dir, f), f)
+                                except IOError:
+                                    iflogger.info('remote file %s not found' % f)
             if any([val is None for val in outputs[key]]):
                 outputs[key] = []
             if len(outputs[key]) == 0:
                 outputs[key] = None
             elif len(outputs[key]) == 1:
                 outputs[key] = outputs[key][0]
+
+        for k, v in outputs.items():
+            outputs[k] = os.path.join(os.getcwd(), v)
+
         return outputs
 
     def _get_ssh_client(self):


### PR DESCRIPTION
Corrected an issue in which the path to the downloaded files was not returned in full. Hence the pipelines were not working