### PR TITLE
MRG: fixes to get Windows tests to run

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -6,7 +6,6 @@
 from copy import deepcopy
 from glob import glob
 import os
-import pickle
 import pwd
 import shutil
 from socket import gethostname
@@ -23,8 +22,6 @@ from ..utils import (nx, dfs_preorder, topological_sort)
 from ..engine import (MapNode, str2bool)
 
 from nipype.utils.filemanip import savepkl, loadpkl
-from nipype.interfaces.utility import Function
-
 
 from ... import logging
 logger = logging.getLogger('workflow')

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -6,7 +6,7 @@
 from copy import deepcopy
 from glob import glob
 import os
-import pwd
+import getpass
 import shutil
 from socket import gethostname
 import sys
@@ -52,7 +52,7 @@ def report_crash(node, traceback=None, hostname=None):
                                      exc_value,
                                      exc_traceback)
     timeofcrash = strftime('%Y%m%d-%H%M%S')
-    login_name = pwd.getpwuid(os.geteuid())[0]
+    login_name = getpass.getuser()
     crashfile = 'crash-%s-%s-%s.pklz' % (timeofcrash,
                                         login_name,
                                         name)

--- a/nipype/pipeline/utils.py
+++ b/nipype/pipeline/utils.py
@@ -7,28 +7,24 @@ from copy import deepcopy
 from glob import glob
 from collections import defaultdict
 import os
-import pwd
 import re
-from uuid import uuid1
 
 import numpy as np
 from nipype.utils.misc import package_check
 from nipype.external import six
 
 package_check('networkx', '1.3')
-from socket import gethostname
 
 import networkx as nx
 
 from ..utils.filemanip import (fname_presuffix, FileNotFoundError,
                                filename_to_list, get_related_files)
 from ..utils.misc import create_function_from_source, str2bool
-from ..interfaces.base import (CommandLine, isdefined, Undefined, Bunch,
+from ..interfaces.base import (CommandLine, isdefined, Undefined,
                                InterfaceResult)
 from ..interfaces.utility import IdentityInterface
 from ..utils.provenance import ProvStore, pm, nipype_ns, get_id
 
-from .. import get_info
 from .. import logging, config
 logger = logging.getLogger('workflow')
 

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -18,7 +18,8 @@ from warnings import warn
 
 from ..external import portalocker
 
-homedir = os.environ['HOME']
+# Get home directory in platform-agnostic way
+homedir = os.path.expanduser('~')
 default_cfg = """
 [logging]
 workflow_level = INFO

--- a/nipype/utils/provenance.py
+++ b/nipype/utils/provenance.py
@@ -1,7 +1,7 @@
 from cPickle import dumps
 import json
 import os
-import pwd
+import getpass
 from socket import getfqdn
 from uuid import uuid1
 from nipype.external import six
@@ -363,9 +363,8 @@ class ProvStore(object):
 
         # create agents
         user_attr = {pm.PROV["type"]: pm.PROV["Person"],
-                     pm.PROV["label"]: pwd.getpwuid(os.geteuid()).pw_name,
-                     foaf["name"]:
-                         safe_encode(pwd.getpwuid(os.geteuid()).pw_name)}
+                     pm.PROV["label"]: getpass.getuser(),
+                     foaf["name"]: safe_encode(getpass.getuser())}
         user_agent = self.g.agent(get_attr_id(user_attr), user_attr)
         agent_attr = {pm.PROV["type"]: pm.PROV["SoftwareAgent"],
                       pm.PROV["label"]: "Nipype",


### PR DESCRIPTION
The config module used `os.environ['HOME']` that is often undefined in Windows.

Sevaral places use the `pwd` package to get the login name of the user, but
`pwd` is specific to Unix.

`getpass.getuser()` seems to be a simpler and more general alternative:

http://stackoverflow.com/questions/842059/is-there-a-portable-way-to-get-the-current-username-in-python