### PR TITLE
Enh/add mkdir p

### DIFF
--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -17,6 +17,7 @@ from StringIO import StringIO
 from warnings import warn
 
 from ..external import portalocker
+from .filemanip import mkdir_p
 
 # Get home directory in platform-agnostic way
 homedir = os.path.expanduser('~')
@@ -62,8 +63,7 @@ class NipypeConfig(object):
     def __init__(self, *args, **kwargs):
         self._config = ConfigParser.ConfigParser()
         config_dir = os.path.expanduser('~/.nipype')
-        if not os.path.exists(config_dir):
-            os.makedirs(config_dir)
+        mkdir_p(config_dir)
         old_config_file = os.path.expanduser('~/.nipype.cfg')
         new_config_file = os.path.join(config_dir, 'nipype.cfg')
         # To be deprecated in two releases

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -13,11 +13,11 @@ import ConfigParser
 from json import load, dump
 import os
 import shutil
+import errno
 from StringIO import StringIO
 from warnings import warn
 
 from ..external import portalocker
-from .filemanip import mkdir_p
 
 # Get home directory in platform-agnostic way
 homedir = os.path.expanduser('~')
@@ -55,6 +55,17 @@ poll_sleep_duration = 60
 [check]
 interval = 1209600
 """ % (homedir, os.getcwd())
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
 
 class NipypeConfig(object):
     """Base nipype config class

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -13,12 +13,12 @@ import json
 import os
 import re
 import shutil
-import errno
 
 import numpy as np
 
 from ..interfaces.traits_extension import isdefined
 from .misc import is_container
+from .config import mkdir_p
 
 from .. import logging, config
 fmlogger = logging.getLogger("filemanip")
@@ -431,13 +431,3 @@ def write_rst_dict(info, prefix=''):
     for key, value in sorted(info.items()):
         out.append(prefix + '* ' + key + ' : ' + str(value))
     return '\n'.join(out)+'\n\n'
-
-
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import shutil
+import errno
 
 import numpy as np
 
@@ -430,3 +431,13 @@ def write_rst_dict(info, prefix=''):
     for key, value in sorted(info.items()):
         out.append(prefix + '* ' + key + ' : ' + str(value))
     return '\n'.join(out)+'\n\n'
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise


### PR DESCRIPTION
Add function to mimic mkdir -p in Linux. Used to correct race condition brought up in parallel execution error from #1127. 