### PR TITLE
MRG:Allow extra wait time for Xvfb if needed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,8 @@ Next release
 * ENH: Added -newgrid input to Warp in AFNI (3dWarp wrapper) (https://github.com/nipy/nipype/pull/1128)
 * FIX: Fixed AFNI Copy interface to use positional inputs as required (https://github.com/nipy/nipype/pull/1131)
 * ENH: Added a check in Dcm2nii to check if nipype created the config.ini file and remove if true (https://github.com/nipy/nipype/pull/1132)
+* ENH: Use a while loop to wait for Xvfb (up to a max wait time "xvfb_max_wait" in config file, default 10)
+       (https://github.com/nipy/nipype/pull/1142)
 
 Release 0.10.0 (October 10, 2014)
 ============

--- a/doc/users/config_file.rst
+++ b/doc/users/config_file.rst
@@ -125,6 +125,9 @@ Execution
     all pending jobs and checking for job completion. To be nice to cluster
     schedulers the default is set to 60 seconds.
 
+*xvfb_max_wait*
+    Maximum time (in seconds) to wait for Xvfb to start, if the _redirect_x parameter of an Interface is True.
+
 Example
 ~~~~~~~
 

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -994,9 +994,14 @@ class BaseInterface(Interface):
                     xvfb_proc = subprocess.Popen(xvfb_cmd,
                                                  stdout=open(os.devnull),
                                                  stderr=open(os.devnull))
-                    time.sleep(0.2)  # give Xvfb time to start
-                    if xvfb_proc.poll() is not None:
-                        raise Exception('Error: Xvfb did not start')
+                    wait_step = 0.2
+                    max_wait = 10
+                    wait_time = 0
+                    while xvfb_proc.poll() is not None:
+                        if wait_time > max_wait:  # raise Exception if past maximum wait time
+                            raise Exception('Error: Xvfb did not start')
+                        time.sleep(wait_step)  # give Xvfb time to start
+                        wait_time += wait_step
 
                     runtime.environ['DISPLAY'] = ':%s' % vdisplay_num
 

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -995,10 +995,9 @@ class BaseInterface(Interface):
                                                  stdout=open(os.devnull),
                                                  stderr=open(os.devnull))
                     wait_step = 0.2
-                    max_wait = 10
                     wait_time = 0
                     while xvfb_proc.poll() is not None:
-                        if wait_time > max_wait:  # raise Exception if past maximum wait time
+                        if wait_time > config.get('execution', 'xvfb_max_wait'):
                             raise Exception('Error: Xvfb did not start')
                         time.sleep(wait_step)  # give Xvfb time to start
                         wait_time += wait_step

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -51,6 +51,7 @@ stop_on_unknown_version = false
 write_provenance = false
 parameterize_dirs = true
 poll_sleep_duration = 60
+xvfb_max_wait = 10
 
 [check]
 interval = 1209600


### PR DESCRIPTION
Change to _redirect_x block to allow more wait time for Xvfb if needed. Max wait time could potentially be set in config. Hard coded for now. @chrisfilo, thoughts?