### PR TITLE
BUG: Restore registration interface failed multi-modal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Next release
 ============
 
+* BUG: ANTs Registration interface failed with multi-modal inputs
+    (https://github.com/nipy/nipype/pull/1176) (https://github.com/nipy/nipype/issues/1175)
 * FIX: Bug in XFibres5 (https://github.com/nipy/nipype/pull/1168)
 * ENH: Attempt to use hard links for data sink.
     (https://github.com/nipy/nipype/pull/1161)


### PR DESCRIPTION
Registration interface was failing to support
multimodal input when they are given.

ex)
nipype:
  antsWF.inputs.fixed_image=['fixed_t1.nii.gz',
                             'fixed_t2.nii.gz']
  antsWF.inputs.moving_image=['moving_t1.nii.gz',
                              'moving_t2.nii.gz']

corresponding correct commandline:
  --metric MI[\
      fixed_t1.nii.gz,\
      moving_t1.nii.gz,\ ...
  --metric MI[\
    fixed_t2.nii.gz,\
    moving_t2.nii.gz,\ ...

Modifed test to be more clear about the multi-modal state

Reported in issue: https://github.com/nipy/nipype/issues/1175