### PR TITLE
FIX: Joint Fusion multimodal Interface Fix

### DIFF
--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -83,3 +83,8 @@ class ANTSCommand(CommandLine):
         <instance>.inputs.num_threads
         """
         cls._num_threads = num_threads
+
+    def _format_xarray(self, val):
+        """ Convienence method for converting [1,2,3] -> 1x2x3 """
+        val = 'x'.join([str(x) for x in val])
+        return val

--- a/nipype/interfaces/slicer/registration/tests/test_auto_BRAINSFit.py
+++ b/nipype/interfaces/slicer/registration/tests/test_auto_BRAINSFit.py
@@ -148,6 +148,8 @@ def test_BRAINSFit_inputs():
     ),
     writeTransformOnFailure=dict(argstr='--writeTransformOnFailure ',
     ),
+    writeOutputTransformInFloat=dict(argstr='--writeOutputTransformInFloat ',
+    ),
     )
     inputs = BRAINSFit.input_spec()
 


### PR DESCRIPTION
Registration and jointFusion
interface was improved to support
multimodal input when they are given.
ex)
nipype:
  antsWF.inputs.fixed_image=['fixed_t1.nii.gz',
                             'fixed_t2.nii.gz']
  antsWF.inputs.moving_image=['moving_t1.nii.gz',
                              'moving_t2.nii.gz']
corresponding commandline:
  --metric MI[\
      fixed_t1.nii.gz,\
      moving_t1.nii.gz,\ ...
  --metric MI[\
    fixed_t2.nii.gz,\
    moving_t2.nii.gz,\ ...