### PR TITLE
FIX: Joint Fusion multimodal Interface Fix

### DIFF
--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -83,3 +83,8 @@ class ANTSCommand(CommandLine):
         <instance>.inputs.num_threads
         """
         cls._num_threads = num_threads
+
+    def _format_xarray(self, val):
+        """ Convienence method for converting [1,2,3] -> 1x2x3 """
+        val = 'x'.join([str(x) for x in val])
+        return val

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -285,13 +285,11 @@ class RegistrationInputSpec(ANTSCommandInputSpec):
     interpolation = traits.Enum(
         'Linear', 'NearestNeighbor', 'CosineWindowedSinc', 'WelchWindowedSinc',
         'HammingWindowedSinc', 'LanczosWindowedSinc', 'BSpline',
-        # 'MultiLabel',
-        # 'Gaussian',
-        # 'BSpline',
-        argstr='%s', usedefault=True)
         # MultiLabel[<sigma=imageSpacing>,<alpha=4.0>]
         # Gaussian[<sigma=imageSpacing>,<alpha=1.0>]
         # BSpline[<order=3>]
+        argstr='%s', usedefault=True)
+
     write_composite_transform = traits.Bool(
         argstr='--write-composite-transform %d',
         default=False, usedefault=True, desc='')
@@ -610,7 +608,7 @@ class Registration(ANTSCommand):
         output_filename = None
         if not inverse:
             if isdefined(self.inputs.output_warped_image) and \
-                self.inputs.output_warped_image:
+                    self.inputs.output_warped_image:
                 output_filename = self.inputs.output_warped_image
                 if isinstance(output_filename, bool):
                     output_filename = '%s_Warped.nii.gz' % self.inputs.output_transform_prefix
@@ -619,7 +617,7 @@ class Registration(ANTSCommand):
             return output_filename
         inv_output_filename = None
         if isdefined(self.inputs.output_inverse_warped_image) and \
-            self.inputs.output_inverse_warped_image:
+                self.inputs.output_inverse_warped_image:
             inv_output_filename = self.inputs.output_inverse_warped_image
             if isinstance(inv_output_filename, bool):
                 inv_output_filename = '%s_InverseWarped.nii.gz' % self.inputs.output_transform_prefix

--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -37,11 +37,13 @@ class AtroposInputSpec(ANTSCommandInputSpec):
     mrf_smoothing_factor = traits.Float(argstr="%s")
     mrf_radius = traits.List(traits.Int(), requires=['mrf_smoothing_factor'])
     icm_use_synchronous_update = traits.Bool(argstr="%s")
-    maximum_number_of_icm_terations = traits.Int(requires=['icm_use_synchronous_update'])
+    maximum_number_of_icm_terations = traits.Int(
+        requires=['icm_use_synchronous_update'])
     n_iterations = traits.Int(argstr="%s")
     convergence_threshold = traits.Float(requires=['n_iterations'])
     posterior_formulation = traits.Str(argstr="%s")
-    use_mixture_model_proportions = traits.Bool(requires=['posterior_formulation'])
+    use_mixture_model_proportions = traits.Bool(
+        requires=['posterior_formulation'])
     out_classified_image_name = File(argstr="%s", genfile=True,
                                      hash_files=False)
     save_posteriors = traits.Bool()
@@ -93,17 +95,21 @@ class Atropos(ANTSCommand):
 
     def _format_arg(self, opt, spec, val):
         if opt == 'initialization':
-            retval = "--initialization %s[%d" % (val, self.inputs.number_of_tissue_classes)
+            retval = "--initialization %s[%d" % (val,
+                                                 self.inputs.number_of_tissue_classes)
             if val == "PriorProbabilityImages":
-                _, _, ext = split_filename(self.inputs.prior_probability_images[0])
-                retval += ",priors/priorProbImages%02d" + ext + ",%g" % self.inputs.prior_weighting
+                _, _, ext = split_filename(
+                    self.inputs.prior_probability_images[0])
+                retval += ",priors/priorProbImages%02d" + \
+                    ext + ",%g" % self.inputs.prior_weighting
                 if isdefined(self.inputs.prior_probability_threshold):
                     retval += ",%g" % self.inputs.prior_probability_threshold
             return retval + "]"
         if opt == 'mrf_smoothing_factor':
             retval = "--mrf [%g" % val
             if isdefined(self.inputs.mrf_radius):
-                retval += ",%s" % 'x'.join([str(s) for s in self.inputs.mrf_radius])
+                retval += ",%s" % 'x'.join([str(s)
+                                            for s in self.inputs.mrf_radius])
             return retval + "]"
         if opt == "icm_use_synchronous_update":
             retval = "--icm [%d" % val
@@ -153,11 +159,13 @@ class Atropos(ANTSCommand):
 
     def _list_outputs(self):
         outputs = self._outputs().get()
-        outputs['classified_image'] = os.path.abspath(self._gen_filename('out_classified_image_name'))
+        outputs['classified_image'] = os.path.abspath(
+            self._gen_filename('out_classified_image_name'))
         if isdefined(self.inputs.save_posteriors) and self.inputs.save_posteriors:
             outputs['posteriors'] = []
             for i in range(self.inputs.number_of_tissue_classes):
-                outputs['posteriors'].append(os.path.abspath(self.inputs.output_posteriors_name_template % (i + 1)))
+                outputs['posteriors'].append(os.path.abspath(
+                    self.inputs.output_posteriors_name_template % (i + 1)))
         return outputs
 
 
@@ -268,7 +276,7 @@ class N4BiasFieldCorrection(ANTSCommand):
     Examples
     --------
 
-	>>> import copy
+    >>> import copy
     >>> from nipype.interfaces.ants import N4BiasFieldCorrection
     >>> n4 = N4BiasFieldCorrection()
     >>> n4.inputs.dimension = 3
@@ -282,7 +290,7 @@ class N4BiasFieldCorrection(ANTSCommand):
 --convergence [ 50x50x30x20 ] --output structural_corrected.nii \
 --shrink-factor 3'
 
-	>>> n4_2 = copy.deepcopy(n4)
+    >>> n4_2 = copy.deepcopy(n4)
     >>> n4_2.inputs.convergence_threshold = 1e-6
     >>> n4_2.cmdline
     'N4BiasFieldCorrection --bspline-fitting [ 300 ] \
@@ -328,7 +336,7 @@ class N4BiasFieldCorrection(ANTSCommand):
 
     def _format_arg(self, name, trait_spec, value):
         if ((name == 'output_image') and
-           (self.inputs.save_bias or isdefined(self.inputs.bias_image))):
+                (self.inputs.save_bias or isdefined(self.inputs.bias_image))):
             bias_image = self._gen_filename('bias_image')
             output = self._gen_filename('output_image')
             newval = '[ %s, %s ]' % (output, bias_image)
@@ -360,10 +368,12 @@ class N4BiasFieldCorrection(ANTSCommand):
 
     def _list_outputs(self):
         outputs = self._outputs().get()
-        outputs['output_image'] = os.path.abspath(self._gen_filename('output_image'))
+        outputs['output_image'] = os.path.abspath(
+            self._gen_filename('output_image'))
 
         if self.inputs.save_bias or isdefined(self.inputs.bias_image):
-            outputs['bias_image'] = os.path.abspath(self._gen_filename('bias_image'))
+            outputs['bias_image'] = os.path.abspath(
+                self._gen_filename('bias_image'))
         return outputs
 
 
@@ -386,7 +396,8 @@ class antsCorticalThicknessInputSpec(ANTSCommandInputSpec):
                           mandatory=True)
     brain_probability_mask = File(exists=True, argstr='-m %s',
                                   desc='brain probability mask in template space', copyfile=False, mandatory=True)
-    segmentation_priors = InputMultiPath(File(exists=True), argstr='-p %s', mandatory=True)
+    segmentation_priors = InputMultiPath(
+        File(exists=True), argstr='-p %s', mandatory=True)
     out_prefix = traits.Str('antsCT_', argstr='-o %s', usedefault=True,
                             desc=('Prefix that is prepended to all output'
                                   ' files (default = antsCT_)'))
@@ -458,11 +469,15 @@ class antsCorticalThicknessoutputSpec(TraitedSpec):
     BrainSegmentationPosteriors = OutputMultiPath(File(exists=True),
                                                   desc='Posterior probability images')
     CorticalThickness = File(exists=True, desc='cortical thickness file')
-    TemplateToSubject1GenericAffine = File(exists=True, desc='Template to subject affine')
+    TemplateToSubject1GenericAffine = File(
+        exists=True, desc='Template to subject affine')
     TemplateToSubject0Warp = File(exists=True, desc='Template to subject warp')
-    SubjectToTemplate1Warp = File(exists=True, desc='Template to subject inverse warp')
-    SubjectToTemplate0GenericAffine = File(exists=True, desc='Template to subject inverse affine')
-    SubjectToTemplateLogJacobian = File(exists=True, desc='Template to subject log jacobian')
+    SubjectToTemplate1Warp = File(
+        exists=True, desc='Template to subject inverse warp')
+    SubjectToTemplate0GenericAffine = File(
+        exists=True, desc='Template to subject inverse affine')
+    SubjectToTemplateLogJacobian = File(
+        exists=True, desc='Template to subject log jacobian')
     CorticalThicknessNormedToTemplate = File(exists=True,
                                              desc='Normalized cortical thickness')
     BrainVolumes = File(exists=True, desc='Brain volumes as text')
@@ -516,7 +531,8 @@ class antsCorticalThickness(ANTSCommand):
             os.makedirs(priors_directory)
         _, _, ext = split_filename(self.inputs.segmentation_priors[0])
         for i, f in enumerate(self.inputs.segmentation_priors):
-            target = os.path.join(priors_directory, 'BrainSegmentationPrior%02d' % (i + 1) + ext)
+            target = os.path.join(
+                priors_directory, 'BrainSegmentationPrior%02d' % (i + 1) + ext)
             if not (os.path.exists(target) and os.path.realpath(target) == os.path.abspath(f)):
                 copyfile(os.path.abspath(f), target)
         runtime = super(antsCorticalThickness, self)._run_interface(runtime)
@@ -566,9 +582,9 @@ class antsCorticalThickness(ANTSCommand):
                                                                'SubjectToTemplateLogJacobian.' +
                                                                self.inputs.image_suffix)
         outputs['CorticalThicknessNormedToTemplate'] = os.path.join(os.getcwd(),
-                                                    self.inputs.out_prefix +
-                                                    'CorticalThickness.' +
-                                                    self.inputs.image_suffix)
+                                                                    self.inputs.out_prefix +
+                                                                    'CorticalThickness.' +
+                                                                    self.inputs.image_suffix)
         outputs['BrainVolumes'] = os.path.join(os.getcwd(),
                                                self.inputs.out_prefix +
                                                'brainvols.csv')
@@ -619,7 +635,8 @@ class JointFusionInputSpec(ANTSCommandInputSpec):
 
 
 class JointFusionOutputSpec(TraitedSpec):
-    output_label_image = File(exists=True, desc='Output fusion label map image')
+    output_label_image = File(exists=True)
+    # TODO: optional outputs - output_posteriors, output_voting_weights
 
 
 class JointFusion(ANTSCommand):
@@ -640,16 +657,14 @@ class JointFusion(ANTSCommand):
     ...                                  'segmentation1.nii.gz',
     ...                                  'segmentation1.nii.gz']
     >>> at.inputs.target_image = 'T1.nii'
-    >>> at.inputs.patch_radius = [3,2,1]
-    >>> at.inputs.search_radius = [1,2,3]
     >>> at.cmdline
-    'jointfusion 3 1 -m Joint[0.1,2] -rp 3x2x1 -rs 1x2x3 -tg T1.nii -g im1.nii -g im2.nii -g im3.nii -l segmentation0.nii.gz -l segmentation1.nii.gz -l segmentation1.nii.gz fusion_labelimage_output.nii'
-
-    Alternately, you can specify the voting method and parameters more 'Pythonically':
+    'jointfusion 3 1 -m Joint[0.1,2] -tg T1.nii -g im1.nii -g im2.nii -g im3.nii -l segmentation0.nii.gz -l segmentation1.nii.gz -l segmentation1.nii.gz fusion_labelimage_output.nii'
 
     >>> at.inputs.method = 'Joint'
     >>> at.inputs.alpha = 0.5
     >>> at.inputs.beta = 1
+    >>> at.inputs.patch_radius = [3,2,1]
+    >>> at.inputs.search_radius = [1,2,3]
     >>> at.cmdline
     'jointfusion 3 1 -m Joint[0.5,1] -rp 3x2x1 -rs 1x2x3 -tg T1.nii -g im1.nii -g im2.nii -g im3.nii -l segmentation0.nii.gz -l segmentation1.nii.gz -l segmentation1.nii.gz fusion_labelimage_output.nii'
     """
@@ -662,13 +677,21 @@ class JointFusion(ANTSCommand):
             if '[' in val:
                 retval = '-m {0}'.format(val)
             else:
-                retval = '-m {0}[{1},{2}]'.format(self.inputs.method, self.inputs.alpha, self.inputs.beta)
+                retval = '-m {0}[{1},{2}]'.format(
+                    self.inputs.method, self.inputs.alpha, self.inputs.beta)
         elif opt == 'patch_radius':
             retval = '-rp {0}'.format(self._format_xarray(val))
         elif opt == 'search_radius':
             retval = '-rs {0}'.format(self._format_xarray(val))
         else:
             if opt == 'warped_intensity_images':
-                assert len(val) == len(self.inputs.warped_label_images), "Number of intensity images and label maps must be the same"
+                assert len(val) == self.inputs.modalities * len(self.inputs.warped_label_images), "Number of intensity images and label maps must be the same {0}!={1}".format(
+                    len(val), len(self.inputs.warped_label_images))
             return super(ANTSCommand, self)._format_arg(opt, spec, val)
         return retval
+
+    def _list_outputs(self):
+        outputs = self._outputs().get()
+        outputs['output_label_image'] = os.path.abspath(
+            self.inputs.output_label_image)
+        return outputs


### PR DESCRIPTION
Registration and jointFusion
interface was improved to support
multimodal input when they are given.
ex)
nipype:
  antsWF.inputs.fixed_image=['fixed_t1.nii.gz',
                             'fixed_t2.nii.gz']
  antsWF.inputs.moving_image=['moving_t1.nii.gz',
                              'moving_t2.nii.gz']
corresponding commandline:
  --metric MI[\
      fixed_t1.nii.gz,\
      moving_t1.nii.gz,\ ...
  --metric MI[\
    fixed_t2.nii.gz,\
    moving_t2.nii.gz,\ ...