### PR TITLE
fix FLIRT output specs with view  to applyxfm

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -510,8 +510,7 @@ class FLIRTInputSpec(FSLCommandInputSpec):
 class FLIRTOutputSpec(TraitedSpec):
     out_file = File(exists=True,
                     desc='path/name of registered file (if generated)')
-    out_matrix_file = File(exists=True,
-                           desc='path/name of calculated affine transform '
+    out_matrix_file = File(desc='path/name of calculated affine transform '
                            '(if generated)')
     out_log = File(desc='path/name of output log (if generated)')
 


### PR DESCRIPTION
Regarding the FLIRT interface, when using the applyxfm option or the Applyxfm interface no output matrix will be created (as is natural), so if in output specs the output matrix has exists=True as it stands now, the interface will fail in execution as the output matrix file will not be found
