### PR TITLE
Fix FreeSurfer RobustRegister gen out_reg_file

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -1205,7 +1205,8 @@ class RobustRegister(FSCommand):
         outputs['out_reg_file'] = self.inputs.out_reg_file
         if not isdefined(self.inputs.out_reg_file) and self.inputs.source_file:
             outputs['out_reg_file'] = fname_presuffix(self.inputs.source_file,
-                                         suffix='_robustreg.lta', use_ext=False)
+                                         suffix='_robustreg.lta', use_ext=False,
+                                         newpath=os.getcwd())
         prefices = dict(src=self.inputs.source_file, trg=self.inputs.target_file)
         suffices = dict(registered_file=("src", "_robustreg", True),
                         weights_file=("src", "_robustweights", True),


### PR DESCRIPTION
Current implementation uses the source file's path for the automatically generated file instead of the cwd. The result is that if multiple RobustRegister nodes are connected to a single source file, the resulting autogenerated files will overwrite each other.
