### PR TITLE
Fix FreeSurfer SurfaceTransform gen out_file

### DIFF
--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -355,7 +355,11 @@ class SurfaceTransform(FSCommand):
         outputs = self._outputs().get()
         outputs["out_file"] = self.inputs.out_file
         if not isdefined(outputs["out_file"]):
-            source = self.inputs.source_file
+            if isdefined(self.inputs.source_file):
+                source = self.inputs.source_file
+            else:
+                source = self.inputs.source_annot_file
+                
             # Some recon-all files don't have a proper extension (e.g. "lh.thickness")
             # so we have to account for that here
             bad_extensions = [".%s" % e for e in ["area", "mid", "pial", "avg_curv", "curv", "inflated",


### PR DESCRIPTION
SurfaceTransform may specify either a source_file or a source_annot_file (mutually exclusive). However, if out_file is not specified and source_annot_file is specified, _list_outputs will try to generate the out_file name using the source_file (which won't be defined in this case). Added an extra check to see if self.input.source_file is defined and if it's not then use self.inputs.source_annot_file instead.