### PR TITLE
FIX: Default value for sbatch_args (SLURMGraph)

### DIFF
--- a/nipype/pipeline/plugins/slurmgraph.py
+++ b/nipype/pipeline/plugins/slurmgraph.py
@@ -53,6 +53,8 @@ class SLURMGraphPlugin(GraphPluginBase):
                     self._template = open(self._template).read()
             if 'sbatch_args' in kwargs['plugin_args']:
                 self._sbatch_args = kwargs['plugin_args']['sbatch_args']
+            else:  # default argument for _sbatch_args
+                self._sbatch_args = ''
             if 'dont_resubmit_completed_jobs' in kwargs['plugin_args']:
                 self._dont_resubmit_completed_jobs = kwargs['plugin_args']['dont_resubmit_completed_jobs']
             else:

--- a/nipype/pipeline/plugins/slurmgraph.py
+++ b/nipype/pipeline/plugins/slurmgraph.py
@@ -42,6 +42,7 @@ class SLURMGraphPlugin(GraphPluginBase):
     _template = "#!/bin/bash"
 
     def __init__(self, **kwargs):
+        self._sbatch_args = ''
         if 'plugin_args' in kwargs and kwargs['plugin_args']:
             if 'retry_timeout' in kwargs['plugin_args']:
                 self._retry_timeout = kwargs['plugin_args']['retry_timeout']
@@ -53,8 +54,6 @@ class SLURMGraphPlugin(GraphPluginBase):
                     self._template = open(self._template).read()
             if 'sbatch_args' in kwargs['plugin_args']:
                 self._sbatch_args = kwargs['plugin_args']['sbatch_args']
-            else:  # default argument for _sbatch_args
-                self._sbatch_args = ''
             if 'dont_resubmit_completed_jobs' in kwargs['plugin_args']:
                 self._dont_resubmit_completed_jobs = kwargs['plugin_args']['dont_resubmit_completed_jobs']
             else:


### PR DESCRIPTION
Added a default value for self._sbatch_args in the SLURMGraph Plugin.
This was not present and caused nipype to abort when sbatch_args was not specified when running the plugin.
