### PR TITLE
Sometimes the filename 'arrow' is shorter (Fixes gh-1267)

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -118,8 +118,8 @@ class Dcm2nii(CommandLine):
                         base, filename, ext = split_filename(last_added_file)
                         bvecs.append(os.path.join(base, filename + ".bvec"))
                         bvals.append(os.path.join(base, filename + ".bval"))
-                elif re.search('.*-->(.*)', line):
-                    val = re.search('.*-->(.*)', line)
+                elif re.search('.*->(.*)', line):
+                    val = re.search('.*->(.*)', line)
                     val = val.groups()[0]
                     if isdefined(self.inputs.output_dir):
                         output_dir = self.inputs.output_dir

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -108,11 +108,17 @@ class Dcm2nii(CommandLine):
                     out_file = line[len("Saving "):]
                 elif line.startswith("GZip..."):
                     # for gzipped outpus files are not absolute
+                    fname = line[len("GZip..."):]
+                    if len(files) and os.path.basename(files[-1]) == fname[:-3]:
+                        # we are seeing a previously reported conversion
+                        # as being saved in gzipped form -- remove the
+                        # obsolete, uncompressed file
+                        files.pop()
                     if isdefined(self.inputs.output_dir):
                         output_dir = self.inputs.output_dir
                     else:
                         output_dir = self._gen_filename('output_dir')
-                    out_file = os.path.abspath(os.path.join(output_dir, line[len("GZip..."):]))
+                    out_file = os.path.abspath(os.path.join(output_dir, fname))
                 elif line.startswith("Number of diffusion directions "):
                     if last_added_file:
                         base, filename, ext = split_filename(last_added_file)


### PR DESCRIPTION
This is a blind push to get a PR against master. The actual manual tests were done against 0.11.