### PR TITLE
BF: Erroneous get_data call

### DIFF
--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -47,7 +47,7 @@ def tensor_fitting(data, bvals, bvecs, mask_file=None):
     -------
     TensorFit object, affine
     """
-    img = nb.load(in_file).get_data()
+    img = nb.load(in_file)
     data = img.get_data()
     affine = img.get_affine()
     if mask_file is not None:


### PR DESCRIPTION
`get_data()` returns a `numpy` array, so `img.get_data()` and `img.get_affine()` should fail.

Introduced in aa061ae