### PR TITLE
RF: Remove deprecated nibabel get_* methods

### DIFF
--- a/doc/devel/python_interface_devel.rst
+++ b/doc/devel/python_interface_devel.rst
@@ -41,7 +41,7 @@ do is to define inputs, outputs, _run_interface() (not run()), and _list_outputs
             thresholded_map = np.zeros(data.shape)
             thresholded_map[active_map] = data[active_map]
 
-            new_img = nb.Nifti1Image(thresholded_map, img.get_affine(), img.get_header())
+            new_img = nb.Nifti1Image(thresholded_map, img.affine, img.header)
             _, base, _ = split_filename(fname)
             nb.save(new_img, base + '_thresholded.nii')
 

--- a/examples/dmri_camino_dti.py
+++ b/examples/dmri_camino_dti.py
@@ -39,7 +39,7 @@ def get_vox_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     voxdims = hdr.get_zooms()
     return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]
 
@@ -49,7 +49,7 @@ def get_data_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     datadims = hdr.get_data_shape()
     return [int(datadims[0]), int(datadims[1]), int(datadims[2])]
 
@@ -57,7 +57,7 @@ def get_data_dims(volume):
 def get_affine(volume):
     import nibabel as nb
     nii = nb.load(volume)
-    return nii.get_affine()
+    return nii.affine
 
 subject_list = ['subj1']
 fsl.FSLCommand.set_default_output_type('NIFTI')

--- a/examples/dmri_connectivity.py
+++ b/examples/dmri_connectivity.py
@@ -77,7 +77,7 @@ def get_vox_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     voxdims = hdr.get_zooms()
     return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]
 
@@ -87,7 +87,7 @@ def get_data_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     datadims = hdr.get_data_shape()
     return [int(datadims[0]), int(datadims[1]), int(datadims[2])]
 
@@ -95,7 +95,7 @@ def get_data_dims(volume):
 def get_affine(volume):
     import nibabel as nb
     nii = nb.load(volume)
-    return nii.get_affine()
+    return nii.affine
 
 
 def select_aparc(list_of_files):

--- a/examples/fmri_ants_openfmri.py
+++ b/examples/fmri_ants_openfmri.py
@@ -80,8 +80,8 @@ def median(in_files):
             average = data
         else:
             average = average + data
-    median_img = nb.Nifti1Image(average / float(idx + 1),
-                                img.get_affine(), img.get_header())
+    median_img = nb.Nifti1Image(average / float(idx + 1), img.affine,
+                                img.header)
     filename = os.path.join(os.getcwd(), 'median.nii.gz')
     median_img.to_filename(filename)
     return filename

--- a/examples/fmri_fsl.py
+++ b/examples/fmri_fsl.py
@@ -108,7 +108,7 @@ def getmiddlevolume(func):
     funcfile = func
     if isinstance(func, list):
         funcfile = func[0]
-    _, _, _, timepoints = load(funcfile).get_shape()
+    _, _, _, timepoints = load(funcfile).shape
     return int(timepoints / 2) - 1
 
 preproc.connect(inputnode, ('func', getmiddlevolume), extract_ref, 't_min')

--- a/examples/fmri_spm_auditory.py
+++ b/examples/fmri_spm_auditory.py
@@ -123,7 +123,7 @@ def get_vox_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     voxdims = hdr.get_zooms()
     return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]
 

--- a/examples/fmri_spm_face.py
+++ b/examples/fmri_spm_face.py
@@ -117,7 +117,7 @@ def get_vox_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     voxdims = hdr.get_zooms()
     return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]
 

--- a/examples/rsfmri_vol_surface_preprocessing.py
+++ b/examples/rsfmri_vol_surface_preprocessing.py
@@ -125,8 +125,8 @@ def median(in_files):
             average = data
         else:
             average = average + data
-    median_img = nb.Nifti1Image(average / float(idx + 1),
-                                img.get_affine(), img.get_header())
+    median_img = nb.Nifti1Image(average / float(idx + 1), img.affine,
+                                img.header)
     filename = os.path.join(os.getcwd(), 'median.nii.gz')
     median_img.to_filename(filename)
     return filename
@@ -165,8 +165,7 @@ def bandpass_filter(files, lowpass_freq, highpass_freq, fs):
             filtered_data = data
         else:
             filtered_data = np.real(np.fft.ifftn(np.fft.fftn(data) * F))
-        img_out = nb.Nifti1Image(filtered_data, img.get_affine(),
-                                 img.get_header())
+        img_out = nb.Nifti1Image(filtered_data, img.affine, img.header)
         img_out.to_filename(out_file)
         out_files.append(out_file)
     return list_to_filename(out_files)

--- a/examples/rsfmri_vol_surface_preprocessing_nipy.py
+++ b/examples/rsfmri_vol_surface_preprocessing_nipy.py
@@ -119,8 +119,8 @@ def median(in_files):
             average = data
         else:
             average = average + data
-    median_img = nb.Nifti1Image(average / float(idx + 1),
-                                img.get_affine(), img.get_header())
+    median_img = nb.Nifti1Image(average / float(idx + 1), img.affine,
+                                img.header)
     filename = os.path.join(os.getcwd(), 'median.nii.gz')
     median_img.to_filename(filename)
     return filename
@@ -156,8 +156,7 @@ def bandpass_filter(files, lowpass_freq, highpass_freq, fs):
             filtered_data = data
         else:
             filtered_data = np.real(np.fft.ifftn(np.fft.fftn(data) * F))
-        img_out = nb.Nifti1Image(filtered_data, img.get_affine(),
-                                 img.get_header())
+        img_out = nb.Nifti1Image(filtered_data, img.affine, img.header)
         img_out.to_filename(out_file)
         out_files.append(out_file)
     return list_to_filename(out_files)

--- a/nipype/algorithms/icc.py
+++ b/nipype/algorithms/icc.py
@@ -49,19 +49,19 @@ class ICC(BaseInterface):
             icc[x], subject_var[x], session_var[x], session_F[x], _, _ = ICC_rep_anova(Y)
 
         nim = nb.load(self.inputs.subjects_sessions[0][0])
-        new_data = np.zeros(nim.get_shape())
+        new_data = np.zeros(nim.shape)
         new_data[maskdata] = icc.reshape(-1,)
-        new_img = nb.Nifti1Image(new_data, nim.get_affine(), nim.get_header())
+        new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, 'icc_map.nii')
 
-        new_data = np.zeros(nim.get_shape())
+        new_data = np.zeros(nim.shape)
         new_data[maskdata] = session_var.reshape(-1,)
-        new_img = nb.Nifti1Image(new_data, nim.get_affine(), nim.get_header())
+        new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, 'session_var_map.nii')
 
-        new_data = np.zeros(nim.get_shape())
+        new_data = np.zeros(nim.shape)
         new_data[maskdata] = subject_var.reshape(-1,)
-        new_img = nb.Nifti1Image(new_data, nim.get_affine(), nim.get_header())
+        new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, 'subject_var_map.nii')
 
         return runtime

--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -111,13 +111,12 @@ class WarpPoints(BaseInterface):
         points = np.array(mesh.points)
         warp_dims = nb.funcs.four_to_three(nb.load(self.inputs.warp))
 
-        affine = warp_dims[0].get_affine()
-        voxsize = warp_dims[0].get_header().get_zooms()
+        affine = warp_dims[0].affine
+        voxsize = warp_dims[0].header.get_zooms()
         vox2ras = affine[0:3, 0:3]
         ras2vox = np.linalg.inv(vox2ras)
         origin = affine[0:3, 3]
-        voxpoints = np.array([np.dot(ras2vox,
-                                     (p - origin)) for p in points])
+        voxpoints = np.array([np.dot(ras2vox, (p - origin)) for p in points])
 
         warps = []
         for axis in warp_dims:

--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -355,7 +355,7 @@ class SpecifyModel(BaseInterface):
             for i, out in enumerate(outliers):
                 numscans = 0
                 for f in filename_to_list(sessinfo[i]['scans']):
-                    shape = load(f).get_shape()
+                    shape = load(f).shape
                     if len(shape) == 3 or shape[3] == 1:
                         iflogger.warning(("You are using 3D instead of 4D "
                                           "files. Are you sure this was "
@@ -459,7 +459,7 @@ class SpecifySPMModel(SpecifyModel):
                 numscans = len(f)
             elif isinstance(f, string_types):
                 img = load(f)
-                numscans = img.get_shape()[3]
+                numscans = img.shape[3]
             else:
                 raise Exception('Functional input not specified correctly')
             nscans.insert(i, numscans)
@@ -779,7 +779,7 @@ class SpecifySparseModel(SpecifyModel):
             infoout[i].durations = None
             if info.conditions:
                 img = load(self.inputs.functional_runs[i])
-                nscans = img.get_shape()[3]
+                nscans = img.shape[3]
                 reg, regnames = self._cond_to_regress(info, nscans)
                 if hasattr(infoout[i], 'regressors') and infoout[i].regressors:
                     if not infoout[i].regressor_names:

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -362,10 +362,10 @@ class ArtifactDetect(BaseInterface):
                 nim = funcs.concat_images(images)
 
         # compute global intensity signal
-        (x, y, z, timepoints) = nim.get_shape()
+        (x, y, z, timepoints) = nim.shape
 
         data = nim.get_data()
-        affine = nim.get_affine()
+        affine = nim.affine
         g = np.zeros((timepoints, 1))
         masktype = self.inputs.mask_type
         if masktype == 'spm_global':  # spm_global like calculation
@@ -397,7 +397,7 @@ class ArtifactDetect(BaseInterface):
         elif masktype == 'file':  # uses a mask image to determine intensity
             maskimg = load(self.inputs.mask_file)
             mask = maskimg.get_data()
-            affine = maskimg.get_affine()
+            affine = maskimg.affine
             mask = mask > 0.5
             for t0 in range(timepoints):
                 vol = data[:, :, :, t0]

--- a/nipype/algorithms/tests/test_normalize_tpms.py
+++ b/nipype/algorithms/tests/test_normalize_tpms.py
@@ -37,8 +37,8 @@ def test_normalize_tpms():
         data = im.get_data()
         mapdata.append(data.copy())
 
-        nb.Nifti1Image(2.0 * (data * mskdata), im.get_affine(),
-                       im.get_header()).to_filename(filename)
+        nb.Nifti1Image(2.0 * (data * mskdata), im.affine,
+                       im.header).to_filename(filename)
         in_files.append(filename)
 
     normalize_tpms(in_files, in_mask, out_files=out_files)

--- a/nipype/algorithms/tests/test_splitmerge.py
+++ b/nipype/algorithms/tests/test_splitmerge.py
@@ -19,7 +19,7 @@ def test_split_and_merge():
     in_mask = example_data('tpms_msk.nii.gz')
     dwfile = op.join(tmpdir, 'dwi.nii.gz')
     mskdata = nb.load(in_mask).get_data()
-    aff = nb.load(in_mask).get_affine()
+    aff = nb.load(in_mask).affine
 
     dwshape = (mskdata.shape[0], mskdata.shape[1], mskdata.shape[2], 6)
     dwdata = np.random.normal(size=dwshape)

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -187,7 +187,7 @@ def cmat(track_file, roi_file, resolution_network_file, matrix_name, matrix_mat_
 
     roi = nb.load(roi_file)
     roiData = roi.get_data()
-    roiVoxelSize = roi.get_header().get_zooms()
+    roiVoxelSize = roi.header.get_zooms()
     (endpoints, endpointsmm) = create_endpoints_array(fib, roiVoxelSize)
 
     # Output endpoint arrays
@@ -706,7 +706,8 @@ class ROIGen(BaseInterface):
                 GMlabelDict['a'] = LUTlabelDict[label][4]
                 labelDict[label] = GMlabelDict
 
-        roi_image = nb.Nifti1Image(niiGM, niiAPARCimg.get_affine(), niiAPARCimg.get_header())
+        roi_image = nb.Nifti1Image(niiGM, niiAPARCimg.affine,
+                                   niiAPARCimg.header)
         iflogger.info('Saving ROI File to {path}'.format(path=roi_file))
         nb.save(roi_image, roi_file)
 

--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -263,12 +263,12 @@ def create_roi(subject_id, subjects_dir, fs_dir, parcellation_name, dilation):
         out_roi = op.abspath('ROI_%s.nii.gz' % parcellation_name)
 
         # update the header
-        hdr = aseg.get_header()
+        hdr = aseg.header
         hdr2 = hdr.copy()
         hdr2.set_data_dtype(np.uint16)
 
         log.info("Save output image to %s" % out_roi)
-        img = nb.Nifti1Image(rois, aseg.get_affine(), hdr2)
+        img = nb.Nifti1Image(rois, aseg.affine, hdr2)
         nb.save(img, out_roi)
 
     iflogger.info("[ DONE ]")
@@ -294,7 +294,7 @@ def create_roi(subject_id, subjects_dir, fs_dir, parcellation_name, dilation):
         # store volume eg in ROIv_scale33.nii.gz
         out_roi = op.abspath('ROIv_%s.nii.gz' % parcellation_name)
         iflogger.info("Save output image to %s" % out_roi)
-        img = nb.Nifti1Image(rois, aseg.get_affine(), hdr2)
+        img = nb.Nifti1Image(rois, aseg.affine, hdr2)
         nb.save(img, out_roi)
 
         iflogger.info("[ DONE ]")
@@ -437,7 +437,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
 
     # output white matter mask. crop and move it afterwards
     wm_out = op.join(fs_dir, 'mri', 'fsmask_1mm.nii.gz')
-    img = nb.Nifti1Image(wmmask, fsmask.get_affine(), fsmask.get_header())
+    img = nb.Nifti1Image(wmmask, fsmask.affine, fsmask.header)
     iflogger.info("Save white matter mask: %s" % wm_out)
     nb.save(img, wm_out)
 

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -181,9 +181,9 @@ def resample_proxy(in_file, order=3, new_zooms=None, out_file=None):
         out_file = op.abspath('./%s_reslice%s' % (fname, fext))
 
     img = nb.load(in_file)
-    hdr = img.get_header().copy()
+    hdr = img.header.copy()
     data = img.get_data().astype(np.float32)
-    affine = img.get_affine()
+    affine = img.affine
     im_zooms = hdr.get_zooms()[:3]
 
     if new_zooms is None:
@@ -220,9 +220,9 @@ def nlmeans_proxy(in_file, settings,
         out_file = op.abspath('./%s_denoise%s' % (fname, fext))
 
     img = nb.load(in_file)
-    hdr = img.get_header()
+    hdr = img.header
     data = img.get_data()
-    aff = img.get_affine()
+    aff = img.affine
 
     nmask = data[..., 0] > 80
     if noise_mask is not None:

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -116,9 +116,9 @@ class SimulateMultiTensor(BaseInterface):
 
         # Load the baseline b0 signal
         b0_im = nb.load(self.inputs.baseline)
-        hdr = b0_im.get_header()
-        shape = b0_im.get_shape()
-        aff = b0_im.get_affine()
+        hdr = b0_im.header
+        shape = b0_im.shape
+        aff = b0_im.affine
 
         # Check and load sticks and their volume fractions
         nsticks = len(self.inputs.in_dirs)

--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -49,7 +49,7 @@ def tensor_fitting(data, bvals, bvecs, mask_file=None):
     """
     img = nb.load(in_file)
     data = img.get_data()
-    affine = img.get_affine()
+    affine = img.affine
     if mask_file is not None:
         mask = nb.load(self.inputs.mask_file).get_data()
     else:

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -75,8 +75,8 @@ class TrackDensityMap(BaseInterface):
 
         if isdefined(self.inputs.reference):
             refnii = nb.load(self.inputs.reference)
-            affine = refnii.get_affine()
-            data_dims = refnii.get_shape()[:3]
+            affine = refnii.affine
+            data_dims = refnii.shape[:3]
             kwargs = dict(affine=affine)
         else:
             iflogger.warn(('voxel_dims and data_dims are deprecated'
@@ -103,10 +103,8 @@ class TrackDensityMap(BaseInterface):
 
         iflogger.info(
             ('Track density map saved as {i}, size={d}, '
-             'dimensions={v}').format(
-                i=out_file,
-                d=img.get_shape(),
-                v=img.get_header().get_zooms()))
+             'dimensions={v}').format(i=out_file, d=img.shape,
+                                      v=img.header.get_zooms()))
         return runtime
 
     def _list_outputs(self):

--- a/nipype/interfaces/elastix/utils.py
+++ b/nipype/interfaces/elastix/utils.py
@@ -91,20 +91,20 @@ class EditTransform(BaseInterface):
         if isdefined(self.inputs.reference_image):
             im = nb.load(self.inputs.reference_image)
 
-            if len(im.get_header().get_zooms()) == 4:
+            if len(im.header.get_zooms()) == 4:
                 im = nb.func.four_to_three(im)[0]
 
-            size = ' '.join(["%01d" % s for s in im.get_shape()])
+            size = ' '.join(["%01d" % s for s in im.shape])
             p = re.compile((self._pattern % 'Size').decode('string-escape'))
             rep = '(\g<entry>%s\g<3>' % size
             contents = p.sub(rep, contents)
 
-            index = ' '.join(["0" for s in im.get_shape()])
+            index = ' '.join(["0" for s in im.shape])
             p = re.compile((self._pattern % 'Index').decode('string-escape'))
             rep = '(\g<entry>%s\g<3>' % index
             contents = p.sub(rep, contents)
 
-            spacing = ' '.join(["%0.4f" % f for f in im.get_header().get_zooms()])
+            spacing = ' '.join(["%0.4f" % f for f in im.header.get_zooms()])
             p = re.compile((self._pattern % 'Spacing').decode('string-escape'))
             rep = '(\g<entry>%s\g<3>' % spacing
             contents = p.sub(rep, contents)
@@ -113,7 +113,7 @@ class EditTransform(BaseInterface):
             itkmat[0, 0] = -1
             itkmat[1, 1] = -1
 
-            affine = np.dot(itkmat, im.get_affine())
+            affine = np.dot(itkmat, im.affine)
             dirs = ' '.join(['%0.4f' % f for f in affine[0:3, 0:3].reshape(-1)])
             orig = ' '.join(['%0.4f' % f for f in affine[0:3, 3].reshape(-1)])
 

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -378,7 +378,7 @@ class MRIConvert(FSCommand):
         outputs = self.output_spec().get()
         outfile = self._get_outfilename()
         if isdefined(self.inputs.split) and self.inputs.split:
-            size = load(self.inputs.in_file).get_shape()
+            size = load(self.inputs.in_file).shape
             if len(size) == 3:
                 tp = 1
             else:
@@ -398,7 +398,7 @@ class MRIConvert(FSCommand):
         if isdefined(self.inputs.out_type):
             if self.inputs.out_type in ['spm', 'analyze']:
                 # generate all outputs
-                size = load(self.inputs.in_file).get_shape()
+                size = load(self.inputs.in_file).shape
                 if len(size) == 3:
                     tp = 1
                 else:

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -105,8 +105,8 @@ class PrepareFieldmap(FSLCommand):
         if runtime.returncode == 0:
             out_file = self.inputs.out_fieldmap
             im = nib.load(out_file)
-            dumb_img = nib.Nifti1Image(np.zeros(im.get_shape()),
-                                       im.get_affine(), im.get_header())
+            dumb_img = nib.Nifti1Image(np.zeros(im.shape), im.affine,
+                                       im.header)
             out_nii = nib.funcs.concat_images((im, dumb_img))
             nib.save(out_nii, out_file)
 

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -318,7 +318,7 @@ class Level1Design(BaseInterface):
                                                       self.inputs.contrasts,
                                                       no_bases, do_tempfilter)
             nim = load(func_files[i])
-            (_, _, _, timepoints) = nim.get_shape()
+            (_, _, _, timepoints) = nim.shape
             fsf_txt = fsf_header.substitute(run_num=i,
                                             interscan_interval=self.inputs.interscan_interval,
                                             num_vols=timepoints,

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -696,7 +696,7 @@ class MCFLIRT(FSLCommand):
         if isdefined(self.inputs.save_mats) and self.inputs.save_mats:
             _, filename = os.path.split(outputs['out_file'])
             matpathname = os.path.join(cwd, filename + '.mat')
-            _, _, _, timepoints = load(self.inputs.in_file).get_shape()
+            _, _, _, timepoints = load(self.inputs.in_file).shape
             outputs['mat_file'] = []
             for t in range(timepoints):
                 outputs['mat_file'].append(os.path.join(matpathname,

--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -184,7 +184,7 @@ class MRTrix2TrackVis(BaseInterface):
         dx, dy, dz = get_data_dims(self.inputs.image_file)
         vx, vy, vz = get_vox_dims(self.inputs.image_file)
         image_file = nb.load(self.inputs.image_file)
-        affine = image_file.get_affine()
+        affine = image_file.affine
         out_filename = op.abspath(self.inputs.out_filename)
 
         # Reads MRTrix tracks
@@ -202,7 +202,7 @@ class MRTrix2TrackVis(BaseInterface):
             xfm = np.genfromtxt(self.inputs.matrix_file)
             iflogger.info(xfm)
             registration_image_file = nb.load(self.inputs.registration_image_file)
-            reg_affine = registration_image_file.get_affine()
+            reg_affine = registration_image_file.affine
             r_dx, r_dy, r_dz = get_data_dims(self.inputs.registration_image_file)
             r_vx, r_vy, r_vz = get_vox_dims(self.inputs.registration_image_file)
             iflogger.info('Using affine from registration image file {r}'.format(r=self.inputs.registration_image_file))

--- a/nipype/interfaces/nipy/model.py
+++ b/nipype/interfaces/nipy/model.py
@@ -164,19 +164,19 @@ class FitGLM(BaseInterface):
         self._beta_file = os.path.abspath("beta.nii")
         beta = np.zeros(mask.shape + (glm.beta.shape[0],))
         beta[mask, :] = glm.beta.T
-        nb.save(nb.Nifti1Image(beta, nii.get_affine()), self._beta_file)
+        nb.save(nb.Nifti1Image(beta, nii.affine), self._beta_file)
 
         self._s2_file = os.path.abspath("s2.nii")
         s2 = np.zeros(mask.shape)
         s2[mask] = glm.s2
-        nb.save(nb.Nifti1Image(s2, nii.get_affine()), self._s2_file)
+        nb.save(nb.Nifti1Image(s2, nii.affine), self._s2_file)
 
         if self.inputs.save_residuals:
             explained = np.dot(design_matrix, glm.beta)
             residuals = np.zeros(mask.shape + (nscans,))
             residuals[mask, :] = timeseries - explained.T
             self._residuals_file = os.path.abspath("residuals.nii")
-            nb.save(nb.Nifti1Image(residuals, nii.get_affine()), self._residuals_file)
+            nb.save(nb.Nifti1Image(residuals, nii.affine), self._residuals_file)
 
         self._nvbeta = glm.nvbeta
         self._dof = glm.dof
@@ -186,7 +186,7 @@ class FitGLM(BaseInterface):
             self._a_file = os.path.abspath("a.nii")
             a = np.zeros(mask.shape)
             a[mask] = glm.a.squeeze()
-            nb.save(nb.Nifti1Image(a, nii.get_affine()), self._a_file)
+            nb.save(nb.Nifti1Image(a, nii.affine), self._a_file)
         self._model = glm.model
         self._method = glm.method
 
@@ -295,19 +295,19 @@ class EstimateContrast(BaseInterface):
             stat_map = np.zeros(mask.shape)
             stat_map[mask] = est_contrast.stat().T
             stat_map_file = os.path.abspath(name + "_stat_map.nii")
-            nb.save(nb.Nifti1Image(stat_map, nii.get_affine()), stat_map_file)
+            nb.save(nb.Nifti1Image(stat_map, nii.affine), stat_map_file)
             self._stat_maps.append(stat_map_file)
 
             p_map = np.zeros(mask.shape)
             p_map[mask] = est_contrast.pvalue().T
             p_map_file = os.path.abspath(name + "_p_map.nii")
-            nb.save(nb.Nifti1Image(p_map, nii.get_affine()), p_map_file)
+            nb.save(nb.Nifti1Image(p_map, nii.affine), p_map_file)
             self._p_maps.append(p_map_file)
 
             z_map = np.zeros(mask.shape)
             z_map[mask] = est_contrast.zscore().T
             z_map_file = os.path.abspath(name + "_z_map.nii")
-            nb.save(nb.Nifti1Image(z_map, nii.get_affine()), z_map_file)
+            nb.save(nb.Nifti1Image(z_map, nii.affine), z_map_file)
             self._z_maps.append(z_map_file)
 
         return runtime

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -65,8 +65,8 @@ class ComputeMask(BaseInterface):
         brain_mask = compute_mask(**args)
         _, name, ext = split_filename(self.inputs.mean_volume)
         self._brain_mask_path = os.path.abspath("%s_mask.%s" % (name, ext))
-        nb.save(nb.Nifti1Image(brain_mask.astype(np.uint8),
-                               nii.get_affine()), self._brain_mask_path)
+        nb.save(nb.Nifti1Image(brain_mask.astype(np.uint8), nii.affine),
+                self._brain_mask_path)
 
         return runtime
 
@@ -371,10 +371,7 @@ class Trim(BaseInterface):
             s = slice(self.inputs.begin_index, nii.shape[3])
         else:
             s = slice(self.inputs.begin_index, self.inputs.end_index)
-        nii2 = nb.Nifti1Image(
-            nii.get_data()[..., s],
-            nii.get_affine(),
-            nii.get_header())
+        nii2 = nb.Nifti1Image(nii.get_data()[..., s], nii.affine, nii.header)
         nb.save(nii2, out_file)
         return runtime
 

--- a/nipype/interfaces/spm/base.py
+++ b/nipype/interfaces/spm/base.py
@@ -46,7 +46,7 @@ def func_is_3d(in_file):
         return func_is_3d(in_file[0])
     else:
         img = load(in_file)
-        shape = img.get_shape()
+        shape = img.shape
         if len(shape) == 3 or (len(shape) == 4 and shape[3] == 1):
             return True
         else:
@@ -74,10 +74,10 @@ def scans_for_fname(fname):
             scans[sno] = '%s,1' % f
         return scans
     img = load(fname)
-    if len(img.get_shape()) == 3:
+    if len(img.shape) == 3:
         return np.array(('%s,1' % fname,), dtype=object)
     else:
-        n_scans = img.get_shape()[3]
+        n_scans = img.shape[3]
         scans = np.zeros((n_scans,), dtype=object)
         for sno in range(n_scans):
             scans[sno] = '%s,%d' % (fname, sno + 1)

--- a/nipype/workflows/dmri/dipy/denoise.py
+++ b/nipype/workflows/dmri/dipy/denoise.py
@@ -64,7 +64,7 @@ def csf_mask(in_file, in_mask, out_file=None):
         out_file = op.abspath("%s_csfmask%s" % (fname, ext))
 
     im = nb.load(in_file)
-    hdr = im.get_header().copy()
+    hdr = im.header.copy()
     hdr.set_data_dtype(np.uint8)
     hdr.set_xyzt_units('mm')
     imdata = im.get_data()
@@ -84,8 +84,8 @@ def csf_mask(in_file, in_mask, out_file=None):
     remove_pixel = mask_size[label_im]
     label_im[remove_pixel] = 0
     label_im[label_im > 0] = 1
-    nb.Nifti1Image(label_im.astype(np.uint8),
-                   im.get_affine(), hdr).to_filename(out_file)
+    nb.Nifti1Image(label_im.astype(np.uint8), im.affine,
+                   hdr).to_filename(out_file)
     return out_file
 
 
@@ -107,13 +107,11 @@ def bg_mask(in_file, in_mask, out_file=None):
         out_file = op.abspath("%s_bgmask%s" % (fname, ext))
 
     im = nb.load(in_file)
-    hdr = im.get_header().copy()
+    hdr = im.header.copy()
     hdr.set_data_dtype(np.uint8)
     hdr.set_xyzt_units('mm')
     imdata = im.get_data()
     msk = nb.load(in_mask).get_data()
-    msk = 1 - binary_dilation(msk,
-                              structure=np.ones((20, 20, 20)))
-    nb.Nifti1Image(msk.astype(np.uint8),
-                   im.get_affine(), hdr).to_filename(out_file)
+    msk = 1 - binary_dilation(msk, structure=np.ones((20, 20, 20)))
+    nb.Nifti1Image(msk.astype(np.uint8), im.affine, hdr).to_filename(out_file)
     return out_file

--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -899,7 +899,7 @@ def _xfm_jacobian(in_xfm):
 def _get_zoom(in_file, enc_dir):
     import nibabel as nb
 
-    zooms = nb.load(in_file).get_header().get_zooms()
+    zooms = nb.load(in_file).header.get_zooms()
 
     if 'y' in enc_dir:
         return zooms[1]

--- a/nipype/workflows/dmri/fsl/epi.py
+++ b/nipype/workflows/dmri/fsl/epi.py
@@ -731,8 +731,7 @@ def _prepare_phasediff(in_file):
     if fext == '.gz':
         name, _ = os.path.splitext(name)
     out_file = os.path.abspath('./%s_2pi.nii.gz' % name)
-    nib.save(nib.Nifti1Image(
-        diff_norm, img.get_affine(), img.get_header()), out_file)
+    nib.save(nib.Nifti1Image(diff_norm, img.affine, img.header), out_file)
     return out_file
 
 
@@ -756,8 +755,7 @@ def _fill_phase(in_file):
     import os
     import numpy as np
     img = nib.load(in_file)
-    dumb_img = nib.Nifti1Image(np.zeros(
-        img.get_shape()), img.get_affine(), img.get_header())
+    dumb_img = nib.Nifti1Image(np.zeros(img.shape), img.affine, img.header)
     out_nii = nib.funcs.concat_images((img, dumb_img))
     name, fext = os.path.splitext(os.path.basename(in_file))
     if fext == '.gz':
@@ -778,7 +776,7 @@ def _vsm_remove_mean(in_file, mask_file, in_unwarped):
     img_data[msk == 0] = 0
     vsmmag_masked = ma.masked_values(img_data.reshape(-1), 0.0)
     vsmmag_masked = vsmmag_masked - vsmmag_masked.mean()
-    img._data = vsmmag_masked.reshape(img.get_shape())
+    img._data = vsmmag_masked.reshape(img.shape)
     name, fext = os.path.splitext(os.path.basename(in_file))
     if fext == '.gz':
         name, _ = os.path.splitext(name)

--- a/nipype/workflows/dmri/fsl/tbss.py
+++ b/nipype/workflows/dmri/fsl/tbss.py
@@ -14,7 +14,7 @@ def tbss1_op_string(in_files):
     op_strings = []
     for infile in in_files:
         img = nib.load(infile)
-        dimtup = tuple([d - 2 for d in img.get_shape()])
+        dimtup = tuple(d - 2 for d in img.shape)
         dimtup = dimtup[0:3]
         op_str = '-min 1 -ero -roi 1 %d 1 %d 1 %d 0 1' % dimtup
         op_strings.append(op_str)

--- a/nipype/workflows/fmri/fsl/estimate.py
+++ b/nipype/workflows/fmri/fsl/estimate.py
@@ -251,15 +251,15 @@ def create_fixed_effects_flow(name='fixedfx'):
         import nibabel as nb
         import numpy as np
         img = nb.load(cope_files[0])
-        if len(img.get_shape()) > 3:
-            out_data = np.zeros(img.get_shape())
+        if len(img.shape) > 3:
+            out_data = np.zeros(img.shape)
         else:
-            out_data = np.zeros(list(img.get_shape()) + [1])
+            out_data = np.zeros(list(img.shape) + [1])
         for i in range(out_data.shape[-1]):
             dof = np.loadtxt(dof_files[i])
             out_data[:, :, :, i] = dof
         filename = os.path.join(os.getcwd(), 'dof_file.nii.gz')
-        newimg = nb.Nifti1Image(out_data, None, img.get_header())
+        newimg = nb.Nifti1Image(out_data, None, img.header)
         newimg.to_filename(filename)
         return filename
 

--- a/nipype/workflows/fmri/fsl/preprocess.py
+++ b/nipype/workflows/fmri/fsl/preprocess.py
@@ -29,7 +29,7 @@ def pickmiddle(files):
     import numpy as np
     middlevol = []
     for f in files:
-        middlevol.append(int(np.ceil(load(f).get_shape()[3] / 2)))
+        middlevol.append(int(np.ceil(load(f).shape[3] / 2)))
     return middlevol
 
 
@@ -39,9 +39,9 @@ def pickvol(filenames, fileidx, which):
     if which.lower() == 'first':
         idx = 0
     elif which.lower() == 'middle':
-        idx = int(np.ceil(load(filenames[fileidx]).get_shape()[3] / 2))
+        idx = int(np.ceil(load(filenames[fileidx]).shape[3] / 2))
     elif which.lower() == 'last':
-        idx = load(filenames[fileidx]).get_shape()[3] - 1
+        idx = load(filenames[fileidx]).shape[3] - 1
     else:
         raise Exception('unknown value for volume selection : %s' % which)
     return idx

--- a/nipype/workflows/fmri/spm/preprocess.py
+++ b/nipype/workflows/fmri/spm/preprocess.py
@@ -191,7 +191,7 @@ def create_vbm_preproc(name='vbmpreproc'):
         from numpy import prod
         icv = []
         for session in class_images:
-            voxel_volume = prod(load(session[0][0]).get_header().get_zooms())
+            voxel_volume = prod(load(session[0][0]).header.get_zooms())
             img = load(session[0][0]).get_data() + \
                 load(session[1][0]).get_data() + \
                 load(session[2][0]).get_data()

--- a/nipype/workflows/misc/utils.py
+++ b/nipype/workflows/misc/utils.py
@@ -10,7 +10,7 @@ def get_vox_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     voxdims = hdr.get_zooms()
     return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]
 
@@ -20,7 +20,7 @@ def get_data_dims(volume):
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume)
-    hdr = nii.get_header()
+    hdr = nii.header
     datadims = hdr.get_data_shape()
     return [int(datadims[0]), int(datadims[1]), int(datadims[2])]
 
@@ -28,7 +28,7 @@ def get_data_dims(volume):
 def get_affine(volume):
     import nibabel as nb
     nii = nb.load(volume)
-    return nii.get_affine()
+    return nii.affine
 
 
 def select_aparc(list_of_files):

--- a/nipype/workflows/rsfmri/fsl/resting.py
+++ b/nipype/workflows/rsfmri/fsl/resting.py
@@ -46,7 +46,7 @@ def select_volume(filename, which):
     if which.lower() == 'first':
         idx = 0
     elif which.lower() == 'middle':
-        idx = int(np.ceil(load(filename).get_shape()[3] / 2))
+        idx = int(np.ceil(load(filename).shape[3] / 2))
     else:
         raise Exception('unknown value for volume selection : %s' % which)
     return idx


### PR DESCRIPTION
Nibabel deprecated the use of `img.get_header()` and `img.get_affine()` functions in favor of `img.header` and `img.affine` in 2.0.0, and `img.get_shape()` was deprecated in nibabel 1.2.0.

Nipype has a [nibabel >= 2.0.1](https://github.com/nipy/nipype/blob/master/requirements.txt#L6) requirement, so these changes are safe.