### PR TITLE
FIX: Freesurfer surf2vol - Added XOR to mkmask and source_file

### DIFF
--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -390,7 +390,7 @@ class SurfaceTransform(FSCommand):
 
 class Surface2VolTransformInputSpec(FSTraitedSpec):
     source_file = File(exists=True, argstr='--surfval %s',
-                       copyfile=False, mandatory=True,
+                       copyfile=False, mandatory=True, xor=['mkmask'],
                        desc='This is the source of the surface values')
     hemi = traits.Str(argstr='--hemi %s', mandatory=True,
                       desc='hemisphere of data')
@@ -404,7 +404,7 @@ class Surface2VolTransformInputSpec(FSTraitedSpec):
     template_file = File(exists=True, argstr='--template %s',
                          desc='Output template volume')
     mkmask = traits.Bool(desc='make a mask instead of loading surface values',
-                         argstr='--mkmask')
+                         argstr='--mkmask', xor=['source_file'])
     vertexvol_file = File(name_template="%s_asVol_vertex.nii",
                           desc=('Path name of the vertex output volume, which '
                                 'is the same as output volume except that the '

--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -37,6 +37,8 @@ class OARPlugin(SGELikeBatchManagerBase):
         self._max_tries = 2
         self._max_jobname_length = 15
         if 'plugin_args' in kwargs and kwargs['plugin_args']:
+            if 'oarsub_args' in kwargs['plugin_args']:
+                self._oarsub_args = kwargs['plugin_args']['oarsub_args']
             if 'retry_timeout' in kwargs['plugin_args']:
                 self._retry_timeout = kwargs['plugin_args']['retry_timeout']
             if 'max_tries' in kwargs['plugin_args']:

--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -37,8 +37,6 @@ class OARPlugin(SGELikeBatchManagerBase):
         self._max_tries = 2
         self._max_jobname_length = 15
         if 'plugin_args' in kwargs and kwargs['plugin_args']:
-            if 'oarsub_args' in kwargs['plugin_args']:
-                self._oarsub_args = kwargs['plugin_args']['oarsub_args']
             if 'retry_timeout' in kwargs['plugin_args']:
                 self._retry_timeout = kwargs['plugin_args']['retry_timeout']
             if 'max_tries' in kwargs['plugin_args']:


### PR DESCRIPTION
mri_surf2vol can either be run using a source file OR without a
source_file if the user wants to create a binary mask. Added XOR
parameter to take this behavior into account