### PR TITLE
BUG: Sets usedefault=True for invert_initial_moving_transform

### DIFF
--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -235,7 +235,7 @@ class RegistrationInputSpec(ANTSCommandInputSpec):
     initial_moving_transform = File(argstr='%s', exists=True, desc='',
                                     xor=['initial_moving_transform_com'])
     invert_initial_moving_transform = traits.Bool(
-        default=False, requires=["initial_moving_transform"],
+        default=False, requires=["initial_moving_transform"], usedefault=True,
         desc='', xor=['initial_moving_transform_com'])
 
     initial_moving_transform_com = traits.Enum(0, 1, 2, argstr='%s',


### PR DESCRIPTION
The invert_initial_moving_transform variable in RegistrationInputSpec
needs usedefault=True to fix "TypeError: int() argument must be a
string or a number, not '_Undefined'". This occurred in line 817
"do_invert_transform = int(self.inputs.invert_initial_moving_transform)".