### PR TITLE
SGEGraph fix

### DIFF
--- a/nipype/pipeline/plugins/sgegraph.py
+++ b/nipype/pipeline/plugins/sgegraph.py
@@ -122,7 +122,7 @@ class SGEGraphPlugin(GraphPluginBase):
                         for jobid in dependencies[idx]:
                             # Avoid dependancies of done jobs
                             if not self._dont_resubmit_completed_jobs or cache_doneness_per_node[jobid] == False:
-                                values += "${{{0}}},".format(make_job_name(jobid, nodes))
+                                values += "{0},".format(make_job_name(jobid, nodes))
                         if values != ' ':  # i.e. if some jobs were added to dependency list
                             values = values.rstrip(',')
                             deps = '-hold_jid%s' % values


### PR DESCRIPTION
SGEGraph was incorrectly formatting job names for `-hold_jid` in the
qsub calls in the submit_jobs.sh script. qsub wants `-hold_jid
j0_jobname,j1_jobname`, while SGEGraph was wrapping the names with `${}`
so they were `-hold_jid ${j0_jobname},${j1_jobname}`. This was causing
the submission of all jobs with `-hold_jid` to fail.