### PR TITLE
explicitly set f-test contrasts to 0

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -252,13 +252,16 @@ class Level1Design(BaseInterface):
                                                               element=count,
                                                               ctype=ctype, val=val)
                         ev_txt += "\n"
-                    if con[0] in list(con_map.keys()):
-                        for fconidx in con_map[con[0]]:
-                            ev_txt += contrast_ftest_element.substitute(
-                                cnum=ftest_idx.index(fconidx) + 1,
-                                element=tidx,
-                                ctype=ctype,
-                                val=1)
+                        
+                    for fconidx in ftest_idx:
+                        fval=0
+                        if con[0] in con_map.keys() and fconidx in con_map[con[0]]:
+                            fval=1
+                        ev_txt += contrast_ftest_element.substitute(
+                            cnum=ftest_idx.index(fconidx) + 1,
+                            element=tidx,
+                            ctype=ctype,
+                            val=fval)
                         ev_txt += "\n"
 
             # add contrast mask info


### PR DESCRIPTION
For the f-test vector need to explicitly set elements for contrasts that should not be included in the test to 0.