### PR TITLE
FIX proposed for S3io

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -664,6 +664,9 @@ class S3DataGrabber(IOBase):
                     outputs[key][i] = self.s3tolocal(path, bkt)
             elif type(outputs[key]) == str:
                 outputs[key] = self.s3tolocal(outputs[key], bkt)
+            else:
+                outputs[key] = self.s3tolocal(outputs[key], bkt)
+
 
         return outputs
 


### PR DESCRIPTION
When I tried running this code, type(outputs[key]) was never == list or == str, so the method, self.s3tolocal, never got called. When I tried debugging, type(outputs[key]) turned out to be of type 'unicode'