### PR TITLE
py3 and ipython fixes

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -20,7 +20,7 @@ from .fixes.numpy.testing import nosetester
 try:
     import faulthandler
     faulthandler.enable()
-except:
+except (ImportError,IOError) as e:
     pass
 
 

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1271,9 +1271,16 @@ def run_command(runtime, output=None, timeout=0.01, redirect_x=False):
     if output == 'allatonce':
         stdout, stderr = proc.communicate()
         if stdout and isinstance(stdout, bytes):
-            stdout = stdout.decode()
+            try:
+                stdout = stdout.decode()
+            except:
+                stdout = stdout.decode("ISO-8859-1")
         if stderr and isinstance(stderr, bytes):
-            stderr = stderr.decode()
+            try:
+                stderr = stderr.decode()
+            except:
+                stderr = stderr.decode("ISO-8859-1")
+
         result['stdout'] = str(stdout).split('\n')
         result['stderr'] = str(stderr).split('\n')
         result['merged'] = ''

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1273,12 +1273,12 @@ def run_command(runtime, output=None, timeout=0.01, redirect_x=False):
         if stdout and isinstance(stdout, bytes):
             try:
                 stdout = stdout.decode()
-            except:
+            except UnicodeDecodeError:
                 stdout = stdout.decode("ISO-8859-1")
         if stderr and isinstance(stderr, bytes):
             try:
                 stderr = stderr.decode()
-            except:
+            except UnicodeDecodeError:
                 stderr = stderr.decode("ISO-8859-1")
 
         result['stdout'] = str(stdout).split('\n')


### PR DESCRIPTION
this PR has two fixes:
- I discovered a bug in the ipython kernel (https://github.com/ipython/ipykernel/issues/91) that caused faulthandler.enable() to fail with an IOError.  I added explicit catching of IOError to catch this
- decoding of stderr/stdout using the standard .decode() failed in py3.  I added decoding using ISO-8859-1