### PR TITLE
Pass on the oarsub args

### DIFF
--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -37,6 +37,8 @@ class OARPlugin(SGELikeBatchManagerBase):
         self._max_tries = 2
         self._max_jobname_length = 15
         if 'plugin_args' in kwargs and kwargs['plugin_args']:
+             if 'oarsub_args' in kwargs['plugin_args']:
+                self._oarsub_args = kwargs['plugin_args']['oarsub_args']
             if 'retry_timeout' in kwargs['plugin_args']:
                 self._retry_timeout = kwargs['plugin_args']['retry_timeout']
             if 'max_tries' in kwargs['plugin_args']:

--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -37,7 +37,7 @@ class OARPlugin(SGELikeBatchManagerBase):
         self._max_tries = 2
         self._max_jobname_length = 15
         if 'plugin_args' in kwargs and kwargs['plugin_args']:
-             if 'oarsub_args' in kwargs['plugin_args']:
+            if 'oarsub_args' in kwargs['plugin_args']:
                 self._oarsub_args = kwargs['plugin_args']['oarsub_args']
             if 'retry_timeout' in kwargs['plugin_args']:
                 self._retry_timeout = kwargs['plugin_args']['retry_timeout']


### PR DESCRIPTION
Previously, the arguments supposed to be passed onto the oarsub command just were discarded. Now they are correctly passed to the command such that one can for example set higher wall times or restrict job submission to a certain subset of nodes etc

Tested and working on our OAR cluster