### PR TITLE
Pin to specific Miniconda version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ $script = <<SCRIPT
 # qconf -aattr queue slots "2, [neuro=3]" main.q
 
 # install anaconda
-wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh
 chmod +x miniconda.sh
 ./miniconda.sh -b
 echo "export PATH=$HOME/miniconda/bin:\\$PATH" >> .bashrc


### PR DESCRIPTION
Bug: 
Miniconda's conda and pip are not at the path location assumed by the Vagrant shell provisioner, so the VM configuration fails partway.

Cause:
<whatever_url for miniconda.sh>
-> appears to be a moving target because they changed the path component from "miniconda" as (assumed by and hard-coded within the current version of the script) to "miniconda2".

Proposed solution:
Pin the (versioned!) Vagrantfile to a specific version of the Miniconda script at http://repo.continuum.io/miniconda/ like a versioned vendor drop (instead of simply using "Miniconda-latest-Linux-x86_64.sh"). The version used by the Vagrantfile after it's verified in testing can be updated after somebody tests it. To wit:

Checking the hashes & timestamps at repo.continuum.io/miniconda/, I see that "Miniconda-<ver>-<platform>" AND "Miniconda2-<ver>-<platformFoo>" are linked to "Miniconda2-3.19.0-<platform>" as of 2015-12-17. Maybe that's follow-up on deprecation or EOL. Anyway, investigating now:
```
git tag -n # -> It didn't work against master, but I see 0.11.0 which is the latest release:
git checkout 0.11.0 # Lightweight tag **, so check its commit's dates:
git log -n 1 --pretty=format:"%an, %ad, %cd"
```

-> Looks like Satra had it working ca. 2015-09-16. I see the latest version of "Miniconda-<etc>" dated before this is from 2015-08-24, so in Vagrantfile I replace "Miniconda-latest-Linux-x86_64.sh" with "Miniconda-3.16.0-Linux-x86_64.sh". The script appears to operate correctly after that, revealing an separate issue installing lxml.

** Aside:
Lightweight-ness of tag 0.11.0 is probably an oversight, and might have something to do with why download links are stuck at 0.10.0 (the latest annotated tag on master, and linked to at e.g. http://nipy.org/nipype/users/install.html). Also, git-describe's (sensible) default behavior is to skip past lightweight tags unless the "--tags" flag is present. Also, "(from nipype==0.12.0.dev0)" shows up in requirements resolution...

Edit: title/message should perhaps include "in Vangrant config".