### PR TITLE
Ensure presence of lxml's binary deps

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,13 @@ chmod +x miniconda.sh
 ./miniconda.sh -b
 echo "export PATH=$HOME/miniconda/bin:\\$PATH" >> .bashrc
 
+# install nipype dependencies' dependencies:
+sudo apt-get -y update
+# lxml requires binary libs libxml2 and libxslt, which entails building the wheel on Ubuntu
+# (unfortunately none of this is explicit in this script or the Vagrant file containing it); therefore:
+sudo apt-get -y install libxml2-dev
+sudo apt-get -y install libxslt1-dev
+
 # install nipype dependencies
 $HOME/miniconda/bin/conda update --yes conda
 $HOME/miniconda/bin/conda install --yes pip numpy scipy nose traits networkx


### PR DESCRIPTION
Bug:
The Vagrant shell provisioner fails out when the lxml wheel fails to build.

Cause:
lxml's binary dependencies libxml2 and libxslt are missing from the image's default installation.

Proposed solution:
Use the Vagrant shell provisioner to ensure the presence of Ubuntu header packages "libxml2-dev" and "libxslt1-dev", which grab their respective libs as dependencies (see diff).
Edit: title/message should perhaps include "in Vangrant config".
