### PR TITLE
[ENH] Check AFNI version in SkullStrip to avoid xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 - if $INSTALL_DEB_DEPENDECIES; then travis_retry sudo apt-get install -qq fsl-atlases;
   fi
 - if $INSTALL_DEB_DEPENDECIES; then source /etc/fsl/fsl.sh; fi
+- if $INSTALL_DEB_DEPENDECIES; then source /etc/afni/afni.sh; fi
 install:
 - conda update --yes conda
 - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -41,23 +41,22 @@ class Info(object):
         try:
             clout = CommandLine(command='afni_vcheck',
                                 terminal_output='allatonce').run()
-            out = clout.runtime.stdout.split('\n')[1]
         except IOError:
             # If afni_vcheck is not present, return None
             warn('afni_vcheck executable not found.')
             return None
-        except RuntimeError:
+        except RuntimeError as e:
             # If AFNI is outdated, afni_vcheck throws error
             warn('AFNI is outdated')
-            out = clout.runtime.stderr.split('\n')[1]
+            return str(e).split('\n')[4].split('=', 1)[1].strip()
 
         # Try to parse the version number
-        m = re.search(r'[\.\d]*$', out)
-        # is the format kept through versions before 16.x?
-        if m is None or not m.group(0):
-            return out
+        out = clout.runtime.stdout.split('\n')[1].split('=', 1)[1].strip()
 
-        v = m.group(0).split('.')
+        if out.startswith('AFNI_'):
+            out = out[5:]
+
+        v = out.split('.')
         try:
             v = [int(n) for n in v]
         except ValueError:

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -38,8 +38,13 @@ class Info(object):
 
         """
         import re
-        clout = CommandLine(command='afni_vcheck',
-                            terminal_output='allatonce').run()
+        try:
+            clout = CommandLine(command='afni_vcheck',
+                                terminal_output='allatonce').run()
+        except IOError:
+            # If afni_vcheck is not present, return None
+            return None
+
         out = clout.runtime.stdout.split('\n')[1]
 
         # Try to parse the version number
@@ -173,3 +178,10 @@ class AFNICommand(CommandLine):
                     if ext == "":
                         outputs[name] = outputs[name] + "+orig.BRIK"
         return outputs
+
+
+def no_afni():
+    """ Checks if AFNI is available """
+    if Info.version() is None:
+        return True
+    return False

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -43,6 +43,7 @@ class Info(object):
                                 terminal_output='allatonce').run()
         except IOError:
             # If afni_vcheck is not present, return None
+            warn('afni_vcheck executable not found.')
             return None
 
         out = clout.runtime.stdout.split('\n')[1]

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -37,10 +37,23 @@ class Info(object):
            Version number as string or None if AFNI not found
 
         """
+        import re
         clout = CommandLine(command='afni_vcheck',
                             terminal_output='allatonce').run()
-        out = clout.runtime.stdout
-        return out.split('\n')[1]
+        out = clout.runtime.stdout.split('\n')[1]
+
+        # Try to parse the version number
+        m = re.search(r'[\.\d]*$', out)
+        # is the format kept through versions before 16.x?
+        if m is None or not m.group(0):
+            return out
+
+        v = m.group(0).split('.')
+        try:
+            v = [int(n) for n in v]
+        except ValueError:
+            return out
+        return tuple(v)
 
     @classmethod
     def outputtype_to_ext(cls, outputtype):

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -37,7 +37,6 @@ class Info(object):
            Version number as string or None if AFNI not found
 
         """
-        import re
         try:
             clout = CommandLine(command='afni_vcheck',
                                 terminal_output='allatonce').run()

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -41,12 +41,15 @@ class Info(object):
         try:
             clout = CommandLine(command='afni_vcheck',
                                 terminal_output='allatonce').run()
+            out = clout.runtime.stdout.split('\n')[1]
         except IOError:
             # If afni_vcheck is not present, return None
             warn('afni_vcheck executable not found.')
             return None
-
-        out = clout.runtime.stdout.split('\n')[1]
+        except RuntimeError:
+            # If AFNI is outdated, afni_vcheck throws error
+            warn('AFNI is outdated')
+            out = clout.runtime.stderr.split('\n')[1]
 
         # Try to parse the version number
         m = re.search(r'[\.\d]*$', out)

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -1245,8 +1245,6 @@ class SkullStrip(AFNICommand):
             # As of AFNI 16.0.00, redirect_x is not needed
             if isinstance(v[0], int) and v[0] > 15:
                 self._redirect_x = False
-        else:
-            raise RuntimeWarning('afni_vcheck executable not found.')
 
 
 class TCatInputSpec(AFNICommandInputSpec):

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -1235,6 +1235,15 @@ class SkullStrip(AFNICommand):
     input_spec = SkullStripInputSpec
     output_spec = AFNICommandOutputSpec
 
+    def __init__(self, **inputs):
+        from .base import Info
+        super(SkullStrip, self).__init__(**inputs)
+        v = Info.version()
+
+        # As of AFNI 16.0.00, redirect_x is not needed
+        if isinstance(v[0], int) and v[0] > 15:
+            self._redirect_x = False
+
 
 class TCatInputSpec(AFNICommandInputSpec):
     in_files = InputMultiPath(

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -1236,13 +1236,17 @@ class SkullStrip(AFNICommand):
     output_spec = AFNICommandOutputSpec
 
     def __init__(self, **inputs):
-        from .base import Info
+        from .base import Info, no_afni
         super(SkullStrip, self).__init__(**inputs)
-        v = Info.version()
 
-        # As of AFNI 16.0.00, redirect_x is not needed
-        if isinstance(v[0], int) and v[0] > 15:
-            self._redirect_x = False
+        if not no_afni():
+            v = Info.version()
+
+            # As of AFNI 16.0.00, redirect_x is not needed
+            if isinstance(v[0], int) and v[0] > 15:
+                self._redirect_x = False
+        else:
+            raise RuntimeWarning('afni_vcheck executable not found.')
 
 
 class TCatInputSpec(AFNICommandInputSpec):


### PR DESCRIPTION
Added version checking in afni.SkullStrip to avoid use of virtual display with AFNI >= 16

(comes from https://github.com/poldracklab/mriqc/issues/25#issuecomment-173917499)