### PR TITLE
Improve sbatch stdout parsing for JobID.

### DIFF
--- a/nipype/pipeline/plugins/slurmgraph.py
+++ b/nipype/pipeline/plugins/slurmgraph.py
@@ -135,7 +135,7 @@ class SLURMGraphPlugin(GraphPluginBase):
                     if self._sbatch_args.count('-o ') == 0:
                         stdoutFile = '-o {outFile}'.format(
                             outFile=batchscriptoutfile)
-                    full_line = '{jobNm}=$(sbatch {outFileOption} {errFileOption} {extraSBatchArgs} {dependantIndex} -J {jobNm} {batchscript} | awk \'{{print $4}}\')\n'.format(
+                    full_line = '{jobNm}=$(sbatch {outFileOption} {errFileOption} {extraSBatchArgs} {dependantIndex} -J {jobNm} {batchscript} | awk \'/^Submitted/ {{print $4}}\')\n'.format(
                         jobNm=jobname,
                         outFileOption=stdoutFile,
                         errFileOption=stderrFile,


### PR DESCRIPTION
Our system prints out a lot of additional information about the submission process that cannot be disabled using the --quiet option to sbatch. This PR is one potential fix. Below is the example output:


    -----------------------------------------------------------------
              Welcome to the Lonestar 5 Supercomputer          
    -----------------------------------------------------------------

    No reservation for this job
    --> Verifying valid submit host (login1)...OK
    --> Verifying valid jobname...OK
    --> Enforcing max jobs per user...OK
    --> Verifying availability of your home dir (/home1/03872/wtriplet)...OK
    --> Verifying availability of your work dir (/work/03872/wtriplet/lonestar)...OK
    --> Verifying availability of your scratch dir (/scratch/03872/wtriplet)...OK
    --> Verifying valid ssh keys...OK
    --> Verifying access to desired queue (normal)...OK
    --> Verifying job request is within current queue limits...OK
    --> Checking available allocation (Analysis_Lonestar)...OK
    Submitted batch job 55473
