### PR TITLE
epi_param.txt: missing acc_factor added. epi_acc renamed to acc_factor?

### DIFF
--- a/nipype/testing/data/epi_param.txt
+++ b/nipype/testing/data/epi_param.txt
@@ -4,7 +4,7 @@
     "delta_te": 2.46e-3,
     "epi_factor": 128,
     "epi_lines": 57,
-    "epi_acc": 2,
+    "acc_factor": 2,
     "field_strength": 3.0,
     "field_axis": "z"
 }


### PR DESCRIPTION
For the workflows/dmri/fsl/artifacts the acc_factor was missing. I guess epi_acc was renamed to acc_factor?
FYI: On Philips scanners this factor is always 1, even with Sense acceleration. The Sense factor is taken into account during the echo spacing calculation.
wfs(Hz) = gamma * B0 * 3.4 ppm => 434.215 Hz at 3T
Echo spacing = WFS(pixel) / (wfs *(ETL +1))
Changing Sense will affect both WFS and ETL.

see Philips doc: EPI unwarping using B0 maps.pdf