### PR TITLE
[FIX] Missing link to fsl-feeds from apt (rel. #1333)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ dependencies:
     - "~/.apt-cache"
     - "~/examples/data"
     - "~/examples/fsdata"
-    - "~/examples/feeds"
     - "~/mcr"
     - "~/spm12"
     - "~/examples/fsl_course_data"
@@ -18,6 +17,7 @@ dependencies:
     - sudo apt-get install -y fsl-core fsl-atlases fsl-mni152-templates fsl-feeds afni
     - echo "source /etc/fsl/fsl.sh" >> $HOME/.profile
     - echo "source /etc/afni/afni.sh" >> $HOME/.profile
+    - ln -sf /usr/share/fsl-feeds/ ~/examples/feeds
     # Set up python environment
     - pip install --upgrade pip
     - pip install -e .


### PR DESCRIPTION
Since ```~/examples/fsl-feeds``` was cached, this problem passed unnoticed. Amends #1333.