### PR TITLE
[ENH] Improved AFNI version parsing after recent publication of 16.0.01

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -8,10 +8,10 @@
     >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
     >>> os.chdir(datadir)
 """
-import warnings
 
 import os
 import re
+from warnings import warn
 
 from .base import AFNICommand, AFNICommandInputSpec, AFNICommandOutputSpec
 from ..base import CommandLineInputSpec, CommandLine, OutputMultiPath
@@ -19,8 +19,6 @@ from ..base import (Directory, TraitedSpec,
                     traits, isdefined, File, InputMultiPath, Undefined)
 from ...utils.filemanip import (load_json, save_json, split_filename)
 from ...utils.filemanip import fname_presuffix
-
-warn = warnings.warn
 
 
 class To3DInputSpec(AFNICommandInputSpec):


### PR DESCRIPTION
#1328 only implemented the use case when AFNI was outdated and <16.0.00. This means, ```afni_vcheck``` returned a version ID derived from the date of compilation. Since 16.0.00 it returns an ID containing the version number.

However, with the release of 16.0.01 tonight, I've found that the case of outdated installations with the new format was not correctly processed. This PR fixes that (until they change the version ID format again...)