### PR TITLE
Fixed write_dot error for networkx>=1.11 in nipype/pipeline/utils.py

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1021,7 +1021,10 @@ def export_graph(graph_in, base_dir=None, show=False, use_execgraph=False,
                                suffix='.dot',
                                use_ext=False,
                                newpath=base_dir)
-    nx.write_dot(pklgraph, outfname)
+    if float(nx.__version__)<1.11:                           
+        nx.write_dot(pklgraph, outfname)
+    else:
+        nx.drawing.nx_pydot.write_dot(pklgraph, outfname)
     logger.info('Creating dot file: %s' % outfname)
     cmd = 'dot -T%s -O %s' % (format, outfname)
     res = CommandLine(cmd, terminal_output='allatonce').run()

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -27,7 +27,6 @@ import re
 import numpy as np
 from nipype.utils.misc import package_check
 from functools import reduce
-from distutils.version import LooseVersion
 
 package_check('networkx', '1.3')
 
@@ -1022,10 +1021,7 @@ def export_graph(graph_in, base_dir=None, show=False, use_execgraph=False,
                                suffix='.dot',
                                use_ext=False,
                                newpath=base_dir)
-    if LooseVersion(nx.__version__) < LooseVersion('1.11'):                           
-        nx.write_dot(pklgraph, outfname)
-    else:
-        nx.drawing.nx_pydot.write_dot(pklgraph, outfname)
+    nx.drawing.nx_pydot.write_dot(pklgraph, outfname)
     logger.info('Creating dot file: %s' % outfname)
     cmd = 'dot -T%s -O %s' % (format, outfname)
     res = CommandLine(cmd, terminal_output='allatonce').run()

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -27,6 +27,7 @@ import re
 import numpy as np
 from nipype.utils.misc import package_check
 from functools import reduce
+from distutils.version import LooseVersion
 
 package_check('networkx', '1.3')
 
@@ -1021,7 +1022,7 @@ def export_graph(graph_in, base_dir=None, show=False, use_execgraph=False,
                                suffix='.dot',
                                use_ext=False,
                                newpath=base_dir)
-    if float(nx.__version__)<1.11:                           
+    if LooseVersion(nx.__version__) < LooseVersion('1.11'):                           
         nx.write_dot(pklgraph, outfname)
     else:
         nx.drawing.nx_pydot.write_dot(pklgraph, outfname)


### PR DESCRIPTION
This fixes an incompatibility with networkx>=1.11 reported here:
https://github.com/nipy/nipype/issues/1350#issuecomment-181495121
