### PR TITLE
WIP/ENH: Allow client args as IPython plugin_args

### DIFF
--- a/nipype/pipeline/plugins/ipython.py
+++ b/nipype/pipeline/plugins/ipython.py
@@ -49,6 +49,11 @@ class IPythonPlugin(DistributedPluginBase):
         if IPython_not_loaded:
             raise ImportError('ipyparallel could not be imported')
         super(IPythonPlugin, self).__init__(plugin_args=plugin_args)
+        valid_args = ('url_file', 'profile', 'cluster_id', 'context', 'debug',
+                      'timeout', 'config', 'username', 'sshserver', 'sshkey',
+                      'password', 'paramiko')
+        self.client_args = {arg: plugin_args[arg]
+                            for arg in valid_args if arg in plugin_args}
         self.iparallel = None
         self.taskclient = None
         self.taskmap = {}
@@ -67,7 +72,7 @@ class IPythonPlugin(DistributedPluginBase):
             raise ImportError("Ipython kernel not found. Parallel execution "
                               "will be unavailable")
         try:
-            self.taskclient = self.iparallel.Client()
+            self.taskclient = self.iparallel.Client(**self.client_args)
         except Exception as e:
             if isinstance(e, TimeoutError):
                 raise Exception("No IPython clients found.")


### PR DESCRIPTION
I want to manage cluster processing outside of the default IPython profile, and this change allows nipype to accommodate that. While I'm only using the `profile` argument, this change accepts all of the valid parameters for `IPython.parallel.Client`. I think `url_file`, `profile` and `cluster_id` are probably a minimal set.

No tests yet, but throwing this up before I get too far, in case people have opinions on the approach, whether this is a good idea, etc.