### PR TITLE
fix: Complete the documentation for ConMat

### DIFF
--- a/nipype/interfaces/camino/connectivity.py
+++ b/nipype/interfaces/camino/connectivity.py
@@ -126,6 +126,7 @@ class Conmat(CommandLine):
     >>> conmat.inputs.in_file = 'tracts.Bdouble'
     >>> conmat.inputs.target_file = 'atlas.nii.gz'
     >>> conmat.inputs.scalar_file = 'fa.nii.gz'
+    >>> conmat.tract_stat         = 'mean'
     >>> conmat.run()        # doctest: +SKIP
     """
     _cmd = 'conmat'


### PR DESCRIPTION
The `tract_stat` input option is mandatory when you use `scalar_file` using Camino's ConMat.

I fixed the example so people don't forget to set it.