### PR TITLE
FIX: Use realpath to determine hard link source

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Next release
 * API: Default model level for the bedpostx workflow has been set to "2" following FSL 5.0.9 lead
 * ENH: New interfaces for interacting with AWS S3: S3DataSink and S3DataGrabber (https://github.com/nipy/nipype/pull/1201)
 * ENH: Interfaces for MINC tools (https://github.com/nipy/nipype/pull/1304)
+* FIX: Use realpath to determine hard link source (https://github.com/nipy/nipype/pull/1388)
 
 Release 0.11.0 (September 15, 2015)
 ============

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -285,12 +285,15 @@ def copyfile(originalfile, newfile, copy=False, create_new=False,
         matofile = originalfile[:-4] + ".mat"
         if os.path.exists(matofile):
             matnfile = newfile[:-4] + ".mat"
-            copyfile(matofile, matnfile, copy)
-        copyfile(hdrofile, hdrnfile, copy)
+            copyfile(matofile, matnfile, copy, create_new, hashmethod,
+                     use_hardlink)
+        copyfile(hdrofile, hdrnfile, copy, create_new, hashmethod,
+                 use_hardlink)
     elif originalfile.endswith(".BRIK"):
         hdrofile = originalfile[:-5] + ".HEAD"
         hdrnfile = newfile[:-5] + ".HEAD"
-        copyfile(hdrofile, hdrnfile, copy)
+        copyfile(hdrofile, hdrnfile, copy, create_new, hashmethod,
+                 use_hardlink)
 
     return newfile
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -42,7 +42,9 @@ def nipype_hardlink_wrapper(raw_src, raw_dst):
     If the hardlink fails, then fall back to using
     a standard copy.
     """
-    src = os.path.normpath(raw_src)
+    # Use realpath to avoid hardlinking symlinks
+    src = os.path.realpath(raw_src)
+    # Use normpath, in case destination is a symlink
     dst = os.path.normpath(raw_dst)
     del raw_src
     del raw_dst

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -132,6 +132,41 @@ def test_copyfiles():
     os.unlink(new_hdr2)
 
 
+def test_linkchain():
+    if os.name is not 'posix':
+        return
+    orig_img, orig_hdr = _temp_analyze_files()
+    pth, fname = os.path.split(orig_img)
+    new_img1 = os.path.join(pth, 'newfile1.img')
+    new_hdr1 = os.path.join(pth, 'newfile1.hdr')
+    new_img2 = os.path.join(pth, 'newfile2.img')
+    new_hdr2 = os.path.join(pth, 'newfile2.hdr')
+    new_img3 = os.path.join(pth, 'newfile3.img')
+    new_hdr3 = os.path.join(pth, 'newfile3.hdr')
+    copyfile(orig_img, new_img1)
+    yield assert_true, os.path.islink(new_img1)
+    yield assert_true, os.path.islink(new_hdr1)
+    copyfile(new_img1, new_img2, copy=True)
+    yield assert_false, os.path.islink(new_img2)
+    yield assert_false, os.path.islink(new_hdr2)
+    yield assert_false, os.path.samefile(orig_img, new_img2)
+    yield assert_false, os.path.samefile(orig_hdr, new_hdr2)
+    copyfile(new_img1, new_img3, copy=True, use_hardlink=True)
+    yield assert_false, os.path.islink(new_img3)
+    yield assert_false, os.path.islink(new_hdr3)
+    yield assert_true, os.path.samefile(orig_img, new_img3)
+    yield assert_true, os.path.samefile(orig_hdr, new_hdr3)
+    os.unlink(new_img1)
+    os.unlink(new_hdr1)
+    os.unlink(new_img2)
+    os.unlink(new_hdr2)
+    os.unlink(new_img3)
+    os.unlink(new_hdr3)
+    # final cleanup
+    os.unlink(orig_img)
+    os.unlink(orig_hdr)
+
+
 def test_filename_to_list():
     x = filename_to_list('foo.nii')
     yield assert_equal, x, ['foo.nii']


### PR DESCRIPTION
Fixes bug introduced in #1161.

Attempting to link to a symlink results in `DataSink` pushing symlinks to the nipype working directory out onto the filesystem at large. Can reproduce by connecting a `Rename` node to a `DataSink` node.

Test verifies the behavior of copying and linking from a symlink, fails prior to fix. Final patch passes optional `copyfiles` arguments to secondary calls. That seems like the least surprising behavior.