### PR TITLE
ENH: Make interfaces.utility.Merge(1) merge a list of lists

### DIFF
--- a/nipype/interfaces/utility/base.py
+++ b/nipype/interfaces/utility/base.py
@@ -156,10 +156,8 @@ class Merge(IOBase):
                 else:
                     out.append(value)
         else:
-            for i in range(len(filename_to_list(values[0]))):
-                out.insert(i, [])
-                for value in values:
-                    out[i].append(filename_to_list(value)[i])
+            lists = [filename_to_list(val) for val in values]
+            out = [[val[i] for val in lists] for i in range(len(lists[0]))]
         if out:
             outputs['out'] = out
         return outputs

--- a/nipype/interfaces/utility/base.py
+++ b/nipype/interfaces/utility/base.py
@@ -109,6 +109,8 @@ class MergeOutputSpec(TraitedSpec):
 class Merge(IOBase):
     """Basic interface class to merge inputs into a single list
 
+    ``Merge(1)`` will merge a list of lists
+
     Examples
     --------
 
@@ -121,16 +123,22 @@ class Merge(IOBase):
     >>> out.outputs.out
     [1, 2, 5, 3]
 
+    >>> merge = Merge()   # Or Merge(1)
+    >>> merge.inputs.in_lists = [1, [2, 5], 3]
+    >>> out = merge.run()
+    >>> out.outputs.out
+    [1, 2, 5, 3]
+
     """
     input_spec = MergeInputSpec
     output_spec = MergeOutputSpec
 
-    def __init__(self, numinputs=0, **inputs):
+    def __init__(self, numinputs=1, **inputs):
         super(Merge, self).__init__(**inputs)
         self._numinputs = numinputs
-        if numinputs > 0:
+        if numinputs > 1:
             input_names = ['in%d' % (i + 1) for i in range(numinputs)]
-        elif numinputs == 0:
+        elif numinputs == 1:
             input_names = ['in_lists']
         else:
             input_names = []
@@ -140,10 +148,10 @@ class Merge(IOBase):
         outputs = self._outputs().get()
         out = []
 
-        if self._numinputs == 0:
-            values = getattr(self.inputs, 'in_lists')
-            if not isdefined(values):
-                return outputs
+        if self._numinputs < 1:
+            return outputs
+        elif self._numinputs == 1:
+            values = self.inputs.in_lists
         else:
             getval = lambda idx: getattr(self.inputs, 'in%d' % (idx + 1))
             values = [getval(idx) for idx in range(self._numinputs)
@@ -158,8 +166,7 @@ class Merge(IOBase):
         else:
             lists = [filename_to_list(val) for val in values]
             out = [[val[i] for val in lists] for i in range(len(lists[0]))]
-        if out:
-            outputs['out'] = out
+        outputs['out'] = out
         return outputs
 
 

--- a/nipype/interfaces/utility/tests/test_base.py
+++ b/nipype/interfaces/utility/tests/test_base.py
@@ -54,17 +54,16 @@ def test_split(tmpdir, args, expected):
 
 @pytest.mark.parametrize("args, kwargs, in_lists, expected", [
         ([3], {}, [0, [1, 2], [3, 4, 5]], [0, 1, 2, 3, 4, 5]),
-        ([], {}, None, None),
+        ([0], {}, None, None),
+        ([], {}, [], []),
         ([], {}, [0, [1, 2], [3, 4, 5]], [0, 1, 2, 3, 4, 5]),
         ([3], {'axis': 'hstack'}, [[0], [1, 2], [3, 4, 5]], [[0, 1, 3]]),
         ([3], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
          [[0, 2, 4], [1, 3, 5]]),
         ([3], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
          [[0, 2, 4], [1, 3, 5]]),
-        # Note: Merge(0, axis='hstack') would error on run, prior to
-        # in_lists implementation
-        ([0], {'axis': 'hstack'}, [[0], [1, 2], [3, 4, 5]], [[0, 1, 3]]),
-        ([0], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
+        ([1], {'axis': 'hstack'}, [[0], [1, 2], [3, 4, 5]], [[0, 1, 3]]),
+        ([1], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
          [[0, 2, 4], [1, 3, 5]]),
         ])
 def test_merge(tmpdir, args, kwargs, in_lists, expected):
@@ -72,15 +71,15 @@ def test_merge(tmpdir, args, kwargs, in_lists, expected):
 
     node = pe.Node(utility.Merge(*args, **kwargs), name='merge')
 
-    numinputs = args[0] if args else 0
-    if numinputs == 0 and in_lists:
+    numinputs = args[0] if args else 1
+    if numinputs == 1:
         node.inputs.in_lists = in_lists
-    else:
+    elif numinputs > 1:
         for i in range(1, numinputs + 1):
             setattr(node.inputs, 'in{:d}'.format(i), in_lists[i - 1])
 
     res = node.run()
-    if numinputs == 0 and in_lists is None:
+    if numinputs < 1:
         assert not isdefined(res.outputs.out)
     else:
         assert res.outputs.out == expected

--- a/nipype/interfaces/utility/tests/test_base.py
+++ b/nipype/interfaces/utility/tests/test_base.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from nipype.interfaces import utility
+from nipype.interfaces.base import isdefined
 import nipype.pipeline.engine as pe
 
 
@@ -49,3 +50,28 @@ def test_split(tmpdir, args, expected):
     res = node.run()
     assert res.outputs.out1 == expected[0]
     assert res.outputs.out2 == expected[1]
+
+
+@pytest.mark.parametrize("args, kwargs, in_lists, expected", [
+        ([3], {}, [0, [1, 2], [3, 4, 5]], [0, 1, 2, 3, 4, 5]),
+        ([], {}, None, None),
+        ([3], {'axis': 'hstack'}, [[0], [1, 2], [3, 4, 5]], [[0, 1, 3]]),
+        ([3], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
+         [[0, 2, 4], [1, 3, 5]]),
+        ([3], {'axis': 'hstack'}, [[0, 1], [2, 3], [4, 5]],
+         [[0, 2, 4], [1, 3, 5]]),
+        ])
+def test_merge(tmpdir, args, kwargs, in_lists, expected):
+    os.chdir(str(tmpdir))
+
+    node = pe.Node(utility.Merge(*args, **kwargs), name='merge')
+
+    numinputs = args[0] if args else 0
+    for i in range(1, numinputs + 1):
+        setattr(node.inputs, 'in{:d}'.format(i), in_lists[i - 1])
+
+    res = node.run()
+    if numinputs == 0:
+        assert not isdefined(res.outputs.out)
+    else:
+        assert res.outputs.out == expected


### PR DESCRIPTION
At present, `Merge()` does nothing, providing an undefined `outputs.out`. This change allows it to merge a list of lists (`inputs.in_lists`) into a single list, rather than enumerating them with `inputs.in1 .. inputs.inN`.

If no `inputs.in_lists` is set, `Merge()` still provides an undefined `outputs.out`, so we shouldn't break existing code.

`Merge(n)` for `n < 0` is unchanged.
