### PR TITLE
WIP: antsRegistrationSyNQuick.sh wrapper

### DIFF
--- a/nipype/interfaces/ants/syn_test.py
+++ b/nipype/interfaces/ants/syn_test.py
@@ -1,0 +1,1 @@
+__author__ = 'franzliem'

--- a/nipype/interfaces/ants/syn_test.py
+++ b/nipype/interfaces/ants/syn_test.py
@@ -1,1 +1,0 @@
-__author__ = 'franzliem'


### PR DESCRIPTION
Hi guys,

I created a wrapper for antsRegistrationSyNQuick.sh. It's my first interface, so it would be great if you had suggestions for improvements (I marked a couple of issues in the code with # todo).

Additionally, I'd like to create a wrapper for antsRegistrationSyN.sh.
antsRegistrationSyNQuick.sh and antsRegistrationSyN.sh  do not have completely identical input arguments:
-t (transform type) has different valid values in SyN and SyNQuick.
-r is setting a different variable
SyNQuick: -r: histogram bins for mutual information in SyN stage (default = 32);
Syn: -r:  radius for cross correlation metric used during SyN stage (default = 4)
What would be the most elegant way to have interfaces for both? Two separat interfaces?
