### PR TITLE
FIX: Updates link to the example tutorials site and data.

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -1,4 +1,4 @@
 A dataset for use with these scripts can be downloaded from the nipype
 website. At the time of writing, it's at:
 
-http://nipy.sourceforge.net/nipype/users/pipeline_tutorial.html
+http://nipy.org/nipype/users/pipeline_tutorial.html


### PR DESCRIPTION
The link to the example dataset wasn't working. This PR updates the link to one that currently works.