### PR TITLE
FIX: Permit relative path for concatenated_file input to Concatenate()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Next release
 ============
+
 * ENH: Created interface for BrainSuite Cortical Surface Extraction command line tools (https://github.com/nipy/nipype/pull/1305)
 * FIX: job execution on systems/approaches where locale is undefined (https://github.com/nipy/nipype/pull/1401)
 * FIX: Clean up byte/unicode issues using subprocess (https://github.com/nipy/nipype/pull/1394)
@@ -26,6 +27,7 @@ Next release
 * FIX: Use realpath to determine hard link source (https://github.com/nipy/nipype/pull/1388)
 * FIX: Correct linking/copying fallback behavior (https://github.com/nipy/nipype/pull/1391)
 * ENH: Nipype workflow and interfaces for FreeSurfer's recon-all (https://github.com/nipy/nipype/pull/1326)
+* FIX: Permit relative path for concatenated_file input to Concatenate() (https://github.com/nipy/nipype/pull/1411)
 
 Release 0.11.0 (September 15, 2015)
 ============

--- a/nipype/interfaces/freesurfer/__init__.py
+++ b/nipype/interfaces/freesurfer/__init__.py
@@ -2,7 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Top-level namespace for freesurfer."""
 
-from .base import Info, FSCommand
+from .base import Info, FSCommand, no_freesurfer
 from .preprocess import (ParseDICOMDir, UnpackSDICOMDir, MRIConvert, Resample,
                          ReconAll, BBRegister, ApplyVolTransform, Smooth,
                          DICOMConvert, RobustRegister, FitMSParams,

--- a/nipype/interfaces/freesurfer/base.py
+++ b/nipype/interfaces/freesurfer/base.py
@@ -117,10 +117,6 @@ class FSCommand(CommandLine):
     def set_default_subjects_dir(cls, subjects_dir):
         cls._subjects_dir = subjects_dir
 
-    @property
-    def version(self):
-        return Info.version()
-
     def run(self, **inputs):
         if 'subjects_dir' in inputs:
             self.inputs.subjects_dir = inputs['subjects_dir']
@@ -220,3 +216,14 @@ class FSCommandOpenMP(FSCommand):
             self.inputs.num_threads = inputs['num_threads']
         self._num_threads_update()
         return super(FSCommandOpenMP, self).run(**inputs)
+
+
+def no_freesurfer():
+    """Checks if FreeSurfer is NOT installed
+    used with skipif to skip tests that will
+    fail if FreeSurfer is not installed"""
+
+    if Info.version() is None:
+        return True
+    else:
+        return False

--- a/nipype/interfaces/freesurfer/model.py
+++ b/nipype/interfaces/freesurfer/model.py
@@ -603,11 +603,11 @@ class Concatenate(FSCommand):
 
     def _list_outputs(self):
         outputs = self.output_spec().get()
-        if not isdefined(self.inputs.concatenated_file):
-            outputs['concatenated_file'] = os.path.join(os.getcwd(),
-                                                        'concat_output.nii.gz')
-        else:
-            outputs['concatenated_file'] = self.inputs.concatenated_file
+
+        fname = self.inputs.concatenated_file
+        if not isdefined(fname):
+            fname = 'concat_output.nii.gz'
+        outputs['concatenated_file'] = os.path.join(os.getcwd(), fname)
         return outputs
 
     def _gen_filename(self, name):

--- a/nipype/interfaces/freesurfer/tests/test_model.py
+++ b/nipype/interfaces/freesurfer/tests/test_model.py
@@ -7,10 +7,11 @@ import shutil
 import numpy as np
 import nibabel as nib
 
-from nipype.testing import assert_equal
-from nipype.interfaces.freesurfer import model
+from nipype.testing import assert_equal, skipif
+from nipype.interfaces.freesurfer import model, no_freesurfer
 
 
+@skipif(no_freesurfer)
 def test_concatenate():
     tmp_dir = tempfile.mkdtemp()
     cwd = os.getcwd()

--- a/nipype/interfaces/freesurfer/tests/test_model.py
+++ b/nipype/interfaces/freesurfer/tests/test_model.py
@@ -1,0 +1,48 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+
+import os
+import tempfile
+import shutil
+import numpy as np
+import nibabel as nib
+
+from nipype.testing import assert_equal
+from nipype.interfaces.freesurfer import model
+
+
+def test_concatenate():
+    tmp_dir = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    os.chdir(tmp_dir)
+    in1 = 'cont1.nii'
+    in2 = 'cont2.nii'
+    out = 'bar.nii'
+
+    data1 = np.zeros((3, 3, 3, 1), dtype=np.float32)
+    data2 = np.ones((3, 3, 3, 5), dtype=np.float32)
+    out_data = np.concatenate((data1, data2), axis=3)
+    mean_data = np.mean(out_data, axis=3)
+
+    nib.Nifti1Image(data1, affine=np.eye(4)).to_filename(in1)
+    nib.Nifti1Image(data2, affine=np.eye(4)).to_filename(in2)
+
+    # Test default behavior
+    res = model.Concatenate(in_files=[in1, in2]).run()
+    yield (assert_equal, res.outputs.concatenated_file,
+           os.path.join(tmp_dir, 'concat_output.nii.gz'))
+    yield (assert_equal, nib.load('concat_output.nii.gz').get_data(), out_data)
+
+    # Test specified concatenated_file
+    res = model.Concatenate(in_files=[in1, in2], concatenated_file=out).run()
+    yield (assert_equal, res.outputs.concatenated_file,
+           os.path.join(tmp_dir, out))
+    yield (assert_equal, nib.load(out).get_data(), out_data)
+
+    # Test a simple statistic
+    res = model.Concatenate(in_files=[in1, in2], concatenated_file=out,
+                            stats='mean').run()
+    yield (assert_equal, nib.load(out).get_data(), mean_data)
+
+    os.chdir(cwd)
+    shutil.rmtree(tmp_dir)

--- a/nipype/interfaces/freesurfer/tests/test_preprocess.py
+++ b/nipype/interfaces/freesurfer/tests/test_preprocess.py
@@ -5,16 +5,8 @@ from shutil import rmtree
 import nibabel as nif
 import numpy as np
 from tempfile import mkdtemp
-from nipype.testing import (assert_equal, assert_false, assert_true,
-                            assert_raises, skipif)
+from nipype.testing import assert_equal, assert_raises, skipif
 import nipype.interfaces.freesurfer as freesurfer
-
-
-def no_freesurfer():
-    if freesurfer.Info().version is None:
-        return True
-    else:
-        return False
 
 
 def create_files_in_directory():
@@ -38,7 +30,7 @@ def clean_directory(outdir, old_wd):
     os.chdir(old_wd)
 
 
-@skipif(no_freesurfer)
+@skipif(freesurfer.no_freesurfer)
 def test_robustregister():
     filelist, outdir, cwd = create_files_in_directory()
 
@@ -66,7 +58,7 @@ def test_robustregister():
     clean_directory(outdir, cwd)
 
 
-@skipif(no_freesurfer)
+@skipif(freesurfer.no_freesurfer)
 def test_fitmsparams():
     filelist, outdir, cwd = create_files_in_directory()
 
@@ -91,7 +83,7 @@ def test_fitmsparams():
     clean_directory(outdir, cwd)
 
 
-@skipif(no_freesurfer)
+@skipif(freesurfer.no_freesurfer)
 def test_synthesizeflash():
     filelist, outdir, cwd = create_files_in_directory()
 

--- a/nipype/interfaces/freesurfer/tests/test_utils.py
+++ b/nipype/interfaces/freesurfer/tests/test_utils.py
@@ -15,13 +15,6 @@ from nipype.interfaces.base import TraitError
 import nipype.interfaces.freesurfer as fs
 
 
-def no_freesurfer():
-    if fs.Info().version is None:
-        return True
-    else:
-        return False
-
-
 def create_files_in_directory():
     outdir = os.path.realpath(mkdtemp())
     cwd = os.getcwd()
@@ -60,7 +53,7 @@ def clean_directory(outdir, old_wd):
     os.chdir(old_wd)
 
 
-@skipif(no_freesurfer)
+@skipif(fs.no_freesurfer)
 def test_sample2surf():
 
     s2s = fs.SampleToSurface()
@@ -104,7 +97,7 @@ def test_sample2surf():
     clean_directory(cwd, oldwd)
 
 
-@skipif(no_freesurfer)
+@skipif(fs.no_freesurfer)
 def test_surfsmooth():
 
     smooth = fs.SurfaceSmooth()
@@ -139,7 +132,7 @@ def test_surfsmooth():
     clean_directory(cwd, oldwd)
 
 
-@skipif(no_freesurfer)
+@skipif(fs.no_freesurfer)
 def test_surfxfm():
 
     xfm = fs.SurfaceTransform()
@@ -173,7 +166,7 @@ def test_surfxfm():
     clean_directory(cwd, oldwd)
 
 
-@skipif(no_freesurfer)
+@skipif(fs.no_freesurfer)
 def test_surfshots():
 
     fotos = fs.SurfaceSnapshots()


### PR DESCRIPTION
The example as given in the [docs](http://nipy.org/nipype/interfaces/generated/nipype.interfaces.freesurfer.model.html#id1) will fail to run, raising:

    TraitError: The 'concatenated_file' trait of a ConcatenateOutputSpec instance must be an existing file name, but a value of 'bar.nii' <type 'str'> was specified.

While the `ConcatenateInputSpec` seems happy with a relative path, it seems `ConcatenateOutputSpec` needs an absolute path, so simply passing it through is insufficient. This change prepends the working directory. I've tested this on my own pipeline, and it resolves an error like the one above.