### PR TITLE
fsl.MotionOutliers output spec no longer requires out_file to exist

### DIFF
--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -2045,7 +2045,7 @@ class MotionOutliersInputSpec(FSLCommandInputSpec):
 
 
 class MotionOutliersOutputSpec(TraitedSpec):
-    out_file = File(exists=True)
+    out_file = File()
     out_metric_values = File(exists=True)
     out_metric_plot = File(exists=True)
 


### PR DESCRIPTION
fsl.MotionOutliers output spec no longer requires out_file to exist. fsl_motion_outliers does not create an output file when no timepoints are above the threshold, and in this situation fsl.MotionOutliers would throw a FileNotFoundError. This pull request fixes that immediate problem.
