### PR TITLE
add a finally statement in _node_runner

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -1151,7 +1151,8 @@ class MapNode(Node):
                 if str2bool(self.config['execution']['stop_on_first_crash']):
                     self._result = node.result
                     raise
-            yield i, node, err
+            finally:
+                yield i, node, err
 
     def _collate_results(self, nodes):
         self._result = InterfaceResult(interface=[], runtime=[],


### PR DESCRIPTION
The fact that Python 3.x deletes the exception variable after the `except` block makes this `finally` necessary.