### PR TITLE
fix: to have recon-all work with 5.3 on OSX

### DIFF
--- a/nipype/interfaces/freesurfer/tests/test_auto_Sphere.py
+++ b/nipype/interfaces/freesurfer/tests/test_auto_Sphere.py
@@ -20,7 +20,6 @@ def test_Sphere_inputs():
     in_smoothwm=dict(copyfile=True,
     ),
     magic=dict(argstr='-q',
-    requires=['in_smoothwm'],
     ),
     num_threads=dict(),
     out_file=dict(argstr='%s',

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -1668,7 +1668,6 @@ class SphereInputSpec(FSTraitedSpecOpenMP):
     seed = traits.Int(argstr="-seed %d",
                       desc="Seed for setting random number generator")
     magic = traits.Bool(argstr="-q",
-                        requires=['in_smoothwm'],
                         desc="No documentation. Direct questions to analysis-bugs@nmr.mgh.harvard.edu")
     in_smoothwm = File( exists=True, copyfile=True,
                        desc="Input surface required when -q flag is not selected")

--- a/nipype/workflows/smri/freesurfer/autorecon3.py
+++ b/nipype/workflows/smri/freesurfer/autorecon3.py
@@ -1,4 +1,4 @@
-from nipype.interfaces.utility import IdentityInterface, Merge
+from nipype.interfaces.utility import IdentityInterface, Merge, Function
 import nipype.pipeline.engine as pe  # pypeline engine
 from nipype.interfaces.freesurfer import *
 from .ba_maps import create_ba_maps_wf

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -151,16 +151,17 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
     else:
         # 5.3 is default
         fsvernum = 5.3
-        if 'v5.3' in fs_version_full:
-            fs_version = 'v5.3'
-        else:
-            if fs_version_full:
-                fs_version = fs_version_full.split('-')[-1]
+        if fs_version_full:
+            if 'v5.3' in fs_version_full:
+                fs_version = 'v5.3'
             else:
-                fs_version = 5.3 # assume version 5.3
-            print("Warning: Workflow may not work properly if FREESURFER_HOME " +
-                  "environmental variable is not set or if you are using an older " +
-                  "version of FreeSurfer")
+                fs_version = fs_version_full.split('-')[-1]
+                logger.info(("Warning: Workflow may not work properly if "
+                             "FREESURFER_HOME environmental variable is not "
+                             "set or if you are using an older version of "
+                             "FreeSurfer"))
+        else:
+            fs_version = 5.3 # assume version 5.3
         th3 = False
         shrink = None
         distance = 50

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -84,9 +84,8 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
 
     Example
     -------
-    >>> from nipype.workflows.smri.freesurfer import create_skullstripped_recon_flow
-    >>> import nipype.interfaces.freesurfer as fs
-    >>> recon_all = create_skullstripped_recon_flow()
+    >>> from nipype.workflows.smri.freesurfer import create_reconall_workflow
+    >>> recon_all = create_reconall_flow()
     >>> recon_all.inputs.inputspec.subject_id = 'subj1'
     >>> recon_all.inputs.inputspec.subjects_dir = '.'
     >>> recon_all.inputs.inputspec.T1_files = 'T1.nii.gz'

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -7,6 +7,7 @@ from .autorecon3 import create_AutoRecon3
 from ....interfaces.freesurfer import AddXFormToHeader, Info
 from ....interfaces.io import DataSink
 from .utils import getdefaultconfig
+from ....pipeline.engine.base import logger
 
 def create_skullstripped_recon_flow(name="skullstripped_recon_all"):
     """Performs recon-all on voulmes that are already skull stripped.
@@ -164,7 +165,7 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
         entorhinal = False
         rb_date = "2008-03-26"
 
-    print("FreeSurfer Version: {0}".format(fs_version))
+    logger.info("FreeSurfer Version: {0}".format(fs_version))
 
     def setconfig(reg_template=None,
                   reg_template_withskull=None,

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -136,7 +136,7 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
 
     # check freesurfer version and set parameters
     fs_version_full = Info.version()
-    if 'v6.0' in fs_version_full or 'dev' in fs_version_full:
+    if fs_version_full and 'v6.0' in fs_version_full or 'dev' in fs_version_full:
         # assuming that dev is 6.0
         fsvernum = 6.0
         fs_version = 'v6.0'
@@ -153,7 +153,10 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
         if 'v5.3' in fs_version_full:
             fs_version = 'v5.3'
         else:
-            fs_vesion = fs_version_full.split('-')[-1]
+            if fs_version_full:
+                fs_version = fs_version_full.split('-')[-1]
+            else:
+                fs_version = 5.3 # assume version 5.3
             print("Warning: Workflow may not work properly if FREESURFER_HOME " +
                   "environmental variable is not set or if you are using an older " +
                   "version of FreeSurfer")

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -85,7 +85,7 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
     Example
     -------
     >>> from nipype.workflows.smri.freesurfer import create_reconall_workflow
-    >>> recon_all = create_reconall_flow()
+    >>> recon_all = create_reconall_workflow()
     >>> recon_all.inputs.inputspec.subject_id = 'subj1'
     >>> recon_all.inputs.inputspec.subjects_dir = '.'
     >>> recon_all.inputs.inputspec.T1_files = 'T1.nii.gz'

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -136,7 +136,8 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
 
     # check freesurfer version and set parameters
     fs_version_full = Info.version()
-    if fs_version_full and 'v6.0' in fs_version_full or 'dev' in fs_version_full:
+    if fs_version_full and ('v6.0' in fs_version_full or
+                                    'dev' in fs_version_full):
         # assuming that dev is 6.0
         fsvernum = 6.0
         fs_version = 'v6.0'


### PR DESCRIPTION
@dgellis90  and @hjmjohnson - could you please take a look at these changes? this did allow running from start to finish. 

```
from nipype import config
config.enable_provenance()
import os
from nipype.workflows.smri.freesurfer import create_reconall_workflow
recon_all = create_reconall_workflow()
recon_all.inputs.inputspec.subject_id = 'time'
recon_all.inputs.inputspec.subjects_dir = os.getcwd()
recon_all.inputs.inputspec.T1_files = os.path.abspath('mprage003.nii.gz')
recon_all.base_dir = os.getcwd()
recon_all.run(plugin='MultiProc', plugin_args={'n_procs': 4})
```

also subject_id did not seem to get carried along into the sub commands. so i saw commands like this where the --subject is called with subejct_id instead of 'time' as i used in calling the workflow.

```
Running: mri_segstats --brainmask brainmask.mgz --ctab /Applications/freesurfer/WMParcStatsLUT.txt
 --etiv --excludeid 0 --in /software/temp/share_blake/ReconAll/AutoRecon2/CA_Normalize/norm.mgz
 --in-intensity-name norm --in-intensity-units MR --pv /software/temp/share_blake/ReconAll/AutoRecon2/CA_Normalize/norm.mgz --seg 
/software/temp/share_blake/ReconAll/AutoRecon3/WM_Parcellation/wmparc.mgz --subject subject_id
 --surf-wm-vol --sum ./wmparc.stats```