### PR TITLE
FIX SGEGraph fixed to allow for varied file permissions

### DIFF
--- a/nipype/pipeline/plugins/sgegraph.py
+++ b/nipype/pipeline/plugins/sgegraph.py
@@ -136,7 +136,7 @@ class SGEGraphPlugin(GraphPluginBase):
                     if self._qsub_args.count('-o ') == 0:
                         stdoutFile = '-o {outFile}'.format(
                             outFile=batchscriptoutfile)
-                    full_line = '{jobNm}=$(qsub {outFileOption} {errFileOption} {extraQSubArgs} {dependantIndex} -N {jobNm} {batchscript} | awk \'{{print $3}}\')\n'.format(
+                    full_line = '{jobNm}=$(qsub {outFileOption} {errFileOption} {extraQSubArgs} {dependantIndex} -N {jobNm} bash {batchscript} | awk \'{{print $3}}\')\n'.format(
                         jobNm=jobname,
                         outFileOption=stdoutFile,
                         errFileOption=stderrFile,


### PR DESCRIPTION
By not specifying bash in qsub commands you require the generated files to have executable permissions. Most linux systems create 644 files without these permissions. I corrected this by adding bash to the qsub command before the batchscript variable. If there is another proper way to do this please let me know.

Thank you,

Olivia
