### PR TITLE
output for DTI vectors changed (dcm2nii -> dcm2niix)

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -292,7 +292,7 @@ class Dcm2niix(CommandLine):
                         bvals.append(out_file + ".bval")
                         find_b = False
                 # next scan will have bvals/bvecs
-                elif 'DTI gradient directions' in line:
+                elif 'DTI gradients' in line:
                     find_b = True
                 else:
                     pass


### PR DESCRIPTION
New: Saving 65 DTI gradients. Please validate if you are conducting DTI
analyses.

see https://github.com/nipy/nipype/issues/1389
