### PR TITLE
spm coreg fix

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -322,18 +322,17 @@ class Coregister(SPMCommand):
     def _format_arg(self, opt, spec, val):
         """Convert input to appropriate format for spm
         """
-        if opt == 'target' or (opt == 'source' and self.inputs.jobtype != "write"):
-            return scans_for_fnames(filename_to_list(val),
-                                    keep4d=True)
+        if opt == 'target' or (opt == 'source' and  "write" not in self.inputs.jobtype):
+            return scans_for_fnames(filename_to_list(val))
         if opt == 'apply_to_files':
-            return np.array(filename_to_list(val), dtype=object)
-        if opt == 'source' and self.inputs.jobtype == "write":
+            return scans_for_fnames(filename_to_list(val))
+        if opt == 'source' and "write" in self.inputs.jobtype:
             if isdefined(self.inputs.apply_to_files):
                 return scans_for_fnames(val + self.inputs.apply_to_files)
             else:
                 return scans_for_fnames(val)
         return super(Coregister, self)._format_arg(opt, spec, val)
-
+        
     def _parse_inputs(self):
         """validate spm coregister options if set to None ignore
         """


### PR DESCRIPTION
spm.interface.preprocess.Coregister’s _format_arg  function was
creating incorrect input parameters resulting in an infinite loop.

"estwrite" was not taken into account and Input parameter "target"
should be called with default keep4d=False in order to appropriately
create the "ref" parameter for MATLAB.
