### PR TITLE
fslmaths -Tstd option added

### DIFF
--- a/nipype/interfaces/fsl/maths.py
+++ b/nipype/interfaces/fsl/maths.py
@@ -103,6 +103,17 @@ class Threshold(MathsCommand):
             return arg
         return super(Threshold, self)._format_arg(name, spec, value)
 
+class StdImageInput(MathsInput):
+
+    dimension = traits.Enum("T", "X", "Y", "Z", usedefault=True, argstr="-%sTstd", position=4,
+                            desc="dimension to standard deviate across")
+
+
+class StdImage(MathsCommand):
+    """Use fslmaths to generate a standard deviation in an image across a given dimension.
+    """
+    input_spec = StdImageInput
+_suffix = "_std"
 
 class MeanImageInput(MathsInput):
 

--- a/nipype/interfaces/fsl/maths.py
+++ b/nipype/interfaces/fsl/maths.py
@@ -113,7 +113,7 @@ class StdImage(MathsCommand):
     """Use fslmaths to generate a standard deviation in an image across a given dimension.
     """
     input_spec = StdImageInput
-_suffix = "_std"
+    _suffix = "_std"
 
 class MeanImageInput(MathsInput):
 

--- a/nipype/interfaces/fsl/maths.py
+++ b/nipype/interfaces/fsl/maths.py
@@ -105,7 +105,7 @@ class Threshold(MathsCommand):
 
 class StdImageInput(MathsInput):
 
-    dimension = traits.Enum("T", "X", "Y", "Z", usedefault=True, argstr="-%sTstd", position=4,
+    dimension = traits.Enum("T", "X", "Y", "Z", usedefault=True, argstr="-%sstd", position=4,
                             desc="dimension to standard deviate across")
 
 

--- a/nipype/interfaces/fsl/tests/test_maths.py
+++ b/nipype/interfaces/fsl/tests/test_maths.py
@@ -168,6 +168,32 @@ def test_meanimage():
 
     # Clean up our mess
     clean_directory(testdir, origdir, ftype)
+    
+    @skipif(no_fsl)
+def test_stdimage():
+    files, testdir, origdir, ftype = create_files_in_directory()
+
+    # Get the command
+    stder = fsl.StdImage(in_file="a.nii",out_file="b.nii")
+
+    # Test the underlying command
+    yield assert_equal, stder.cmd, "fslmaths"
+
+    # Test the defualt opstring
+    yield assert_equal, stder.cmdline, "fslmaths a.nii -Tstd b.nii"
+
+    # Test the other dimensions
+    cmdline = "fslmaths a.nii -%sstd b.nii"
+    for dim in ["X","Y","Z","T"]:
+        stder.inputs.dimension=dim
+        yield assert_equal, stder.cmdline, cmdline%dim
+
+    # Test the auto naming
+    stder = fsl.StdImage(in_file="a.nii")
+    yield assert_equal, stder.cmdline, "fslmaths a.nii -Tstd %s"%os.path.join(testdir, "a_std.nii")
+
+    # Clean up our mess
+    clean_directory(testdir, origdir, ftype)
 
 @skipif(no_fsl)
 def test_maximage():


### PR DESCRIPTION
Hi, I added a class to fslmaths to calculate the standard deviation in a voxel. 

Here is the neurostars-thread about it:
https://neurostars.org/p/4004/

I already tried it out in my local nipype version in a workflow like this.
stdev = pe.Node(fsl.maths.StdImage(), name= 'Std_deviation_calculation')
The result looks good.

It is the first time I do something like this. Is this right? Also, I don't know, where I would have to add documentation. Feedback appreciated. Thanks, Leonie