### PR TITLE
added logic to prevent directory creation collisions

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1056,9 +1056,15 @@ def make_output_dir(outdir):
     outdir : output directory to create
 
     """
-    if not os.path.exists(os.path.abspath(outdir)):
-        logger.debug("Creating %s" % outdir)
-        os.makedirs(outdir)
+    # this odd approach deals with concurrent directory cureation
+    try:
+        if not os.path.exists(os.path.abspath(outdir)):
+            logger.debug("Creating %s" % outdir)
+            os.makedirs(outdir)
+    except OSError:
+            logger.debug("Problem creating %s" % outdir)
+            if not os.path.exists(outdir):
+               raise OSError('Could not create %s'%outdir)
     return outdir
 
 


### PR DESCRIPTION
the previous version was experiencing errors when run on an HPC system, wherein multiple processes were trying to create the same directory at exactly the same time. this adds code to prevent this error, but still throw an error if the directory can't be made and doesn't exist.