### PR TITLE
removed "experimental" warning of Randomise

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -1769,9 +1769,7 @@ class RandomiseOutputSpec(TraitedSpec):
 
 
 class Randomise(FSLCommand):
-    """XXX UNSTABLE DO NOT USE
-
-    FSL Randomise: feeds the 4D projected FA data into GLM
+    """FSL Randomise: feeds the 4D projected FA data into GLM
     modelling and thresholding
     in order to find voxels which correlate with your model
 


### PR DESCRIPTION
Removed the "experimental" disclaimer for the Randomise interface. This has been causing a lot of confusion over the years, but as far as I know there is nothing wrong with this interface.