### PR TITLE
Fix broken format_node due to missing inspect import.

### DIFF
--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -15,6 +15,8 @@ The `EngineBase` class implements the more general view of a task.
 
 """
 
+from __future__ import absolute_import
+
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -15,6 +15,8 @@ The `Node` class provides core functionality for batch processing.
 
 """
 
+from __future__ import absolute_import
+
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -5,6 +5,8 @@
 """Utility routines for workflow graphs
 """
 
+from __future__ import absolute_import
+
 from future import standard_library
 standard_library.install_aliases()
 
@@ -22,6 +24,10 @@ from collections import OrderedDict
 from copy import deepcopy
 from glob import glob
 from collections import defaultdict
+try:
+    from inspect import signature
+except ImportError:
+    from funcsigs import signature
 import os
 import re
 import numpy as np
@@ -115,6 +121,7 @@ def _write_inputs(node):
 
 def format_node(node, format='python', include_config=False):
     """Format a node in a given output syntax."""
+    from .nodes import MapNode
     lines = []
     name = node.fullname.replace('.', '_')
     if format == 'python':
@@ -122,8 +129,9 @@ def format_node(node, format='python', include_config=False):
         importline = 'from %s import %s' % (klass.__module__,
                                             klass.__class__.__name__)
         comment = '# Node: %s' % node.fullname
-        spec = inspect.signature(node._interface.__init__)
-        args = spec.args[1:]
+        spec = signature(node._interface.__init__)
+        args = [p.name for p in spec.parameters.values()]
+        args = args[1:]
         if args:
             filled_args = []
             for arg in args:

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -15,6 +15,8 @@ The `Workflow` class provides core functionality for batch processing.
 
 """
 
+from __future__ import absolute_import
+
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range


### PR DESCRIPTION
I tried to use the export feature of the workflow object, but it kept failing because of the import of the inspect module. The latter was indeed missing. Since inspect is not available for the early Python 3 and Python 2 releases, I also use the funcsigs module which backports the signature function.

I have tested it on my private fork, running Python 2.7 and the export now works. However I could not figure out how to specify the conditional install_requires on funcsigs inside the setup.py. You guys might want to merge this PR as it is and fix the setup.py later, or give me some pointers on how to do it.

cheers.

