### PR TITLE
FIX: import error in workflow export

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -30,6 +30,7 @@ except ImportError:
     from funcsigs import signature
 import os
 import re
+import pickle
 import numpy as np
 from nipype.utils.misc import package_check
 from functools import reduce


### PR DESCRIPTION
Import the pickle module, which is required for workflow export
function.