### PR TITLE
Changed default for CommandLine._run_interface to not be mutable

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1660,7 +1660,7 @@ class CommandLine(BaseInterface):
         runtime = self._run_interface(runtime)
         return runtime
 
-    def _run_interface(self, runtime, correct_return_codes=[0]):
+    def _run_interface(self, runtime, correct_return_codes=(0,)):
         """Execute command via subprocess
 
         Parameters


### PR DESCRIPTION
The correct_runtime_codes default is a list, which is mutable. This allows for the default to be changed in subsequent calls. Changed to a tuple