### PR TITLE
[FIX] CircleCI fails when examples are not cached

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,20 +9,19 @@ dependencies:
     - "~/.apt-cache"
 
   pre:
-    - mkdir -p "~/scratch/nose"
-    - mkdir -p "~/examples"
     # Let CircleCI cache the apt archive
-    - sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
+    - mkdir -p ~/.apt-cache/partial && sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives
     - sudo apt-get -y update && sudo apt-get install -y wget bzip2
 
   override:
+    - mkdir -p ~/scratch/nose ~/examples
+    - if [[ ! -d ~/examples/nipype-tutorial ]]; then wget -q -O nipype-tutorial.tar.bz2 https://dl.dropbox.com/s/jzgq2nupxyz36bp/nipype-tutorial.tar.bz2 && tar xjf nipype-tutorial.tar.bz2 -C ~/examples/; fi
+    - if [[ ! -d ~/examples/feeds ]]; then wget -q -O fsl-feeds.tar.gz https://googledrive.com/host/0BxI12kyv2olZNXBONlJKV0Y1Tm8 && tar xzf fsl-feeds.tar.gz -C ~/examples/; fi
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - docker build -f docker/nipype_test_py27/Dockerfile -t nipype/nipype_test:py27 . :
         timeout: 1600
     - mkdir -p ~/docker; docker save nipype/nipype_test:py27 > ~/docker/image.tar :
         timeout: 1600
-    - if [[ ! -d ~/examples/nipype-tutorial ]]; then wget -q -O nipype-tutorial.tar.bz2 https://dl.dropbox.com/s/jzgq2nupxyz36bp/nipype-tutorial.tar.bz2 && tar xjf nipype-tutorial.tar.bz2 -C ~/examples/; fi
-    - if [[ ! -d ~/examples/feeds ]]; then wget -q -O fsl-feeds.tar.gz https://googledrive.com/host/0BxI12kyv2olZNXBONlJKV0Y1Tm8 && tar xzf fsl-feeds.tar.gz -C ~/examples/; fi
 
 test:
   override:


### PR DESCRIPTION
This is causing #1570 and other PRs to fail.