### PR TITLE
Fix for https://github.com/nipy/nipype/issues/1575

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -145,7 +145,7 @@ try:
     cwd = os.getcwd()
     info = loadpkl(pklfile)
     result = info['node'].run(updatehash=info['updatehash'])
-except Exception, e:
+except Exception as e:
     etype, eval, etr = sys.exc_info()
     traceback = format_exception(etype,eval,etr)
     if info is None or not os.path.exists(info['node'].output_dir()):


### PR DESCRIPTION
Fixed exception syntax to be compatible with Python 3.

@oesteban It looks like the "e" reference is used in L172 if the clause on L164 executes.