### PR TITLE
TEST: Do not test copy idempotence for unlinked files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ Upcoming release 0.13
 
 * TST: reduce the size of docker images & use tags for images (https://github.com/nipy/nipype/pull/1564)
 * ENH: Implement missing inputs/outputs in FSL AvScale (https://github.com/nipy/nipype/pull/1563)
-* FIX: Fix symlink test in copyfile (https://github.com/nipy/nipype/pull/1570)
+* FIX: Fix symlink test in copyfile (https://github.com/nipy/nipype/pull/1570, https://github.com/nipy/nipype/pull/1586)
 
 
 Release 0.12.1 (August 3, 2016)

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -158,20 +158,6 @@ def test_linkchain():
     yield assert_true, os.path.samefile(orig_img, new_img3)
     yield assert_true, os.path.samefile(orig_hdr, new_hdr3)
 
-    # Test that re-copying leaves files
-    stat1 = os.stat(new_img1)
-    stat2 = os.stat(new_img2)
-    stat3 = os.stat(new_img3)
-    # Same symlink
-    copyfile(orig_img, new_img1)
-    # Hash matches
-    copyfile(new_img1, new_img2, copy=True)
-    # Hardlinks
-    copyfile(new_img1, new_img3, copy=True, use_hardlink=True)
-    yield assert_equal, stat1, os.stat(new_img1)
-    yield assert_equal, stat2, os.stat(new_img2)
-    yield assert_equal, stat3, os.stat(new_img3)
-
     os.unlink(new_img1)
     os.unlink(new_hdr1)
     os.unlink(new_img2)
@@ -179,6 +165,47 @@ def test_linkchain():
     os.unlink(new_img3)
     os.unlink(new_hdr3)
     # final cleanup
+    os.unlink(orig_img)
+    os.unlink(orig_hdr)
+
+
+def test_recopy():
+    # Re-copying with the same parameters on an unchanged file should be
+    # idempotent
+    #
+    # Test for copying from regular files and symlinks
+    orig_img, orig_hdr = _temp_analyze_files()
+    pth, fname = os.path.split(orig_img)
+    img_link = os.path.join(pth, 'imglink.img')
+    hdr_link = os.path.join(pth, 'imglink.hdr')
+    new_img = os.path.join(pth, 'newfile.img')
+    new_hdr = os.path.join(pth, 'newfile.hdr')
+    copyfile(orig_img, img_link)
+    for copy in (True, False):
+        for use_hardlink in (True, False):
+            copyfile(orig_img, new_img, copy=copy, use_hardlink=use_hardlink)
+            img_stat = os.stat(new_img)
+            hdr_stat = os.stat(new_hdr)
+            copyfile(orig_img, new_img, copy=copy, use_hardlink=use_hardlink)
+            err_msg = "Regular - OS: {}; Copy: {}; Hardlink: {}".format(
+                os.name, copy, use_hardlink)
+            yield assert_equal, img_stat, os.stat(new_img), err_msg
+            yield assert_equal, hdr_stat, os.stat(new_hdr), err_msg
+            os.unlink(new_img)
+            os.unlink(new_hdr)
+
+            copyfile(img_link, new_img, copy=copy, use_hardlink=use_hardlink)
+            img_stat = os.stat(new_img)
+            hdr_stat = os.stat(new_hdr)
+            copyfile(img_link, new_img, copy=copy, use_hardlink=use_hardlink)
+            err_msg = "Symlink - OS: {}; Copy: {}; Hardlink: {}".format(
+                os.name, copy, use_hardlink)
+            yield assert_equal, img_stat, os.stat(new_img), err_msg
+            yield assert_equal, hdr_stat, os.stat(new_hdr), err_msg
+            os.unlink(new_img)
+            os.unlink(new_hdr)
+    os.unlink(img_link)
+    os.unlink(hdr_link)
     os.unlink(orig_img)
     os.unlink(orig_hdr)
 


### PR DESCRIPTION
Not actually a bug, since there's no harm in what we were doing, but the test from #1570 caught unexpected behavior. Seen in [test failure](https://circleci.com/gh/effigies/nipype/79) for #1379.

The general rule when creating symlinks in `copyfile` is: if the new symlink will point to the same place as the old, do not replace. When creating a symlink from a symlink, though, it does not dereference the source symlink to check whether the end reference would be the same, and so always removes and recreates the destination symlink.

This brings the behavior with a symlink source file in line with behavior for a regular source file.

Separated the test to be more thorough and added error messages for debugging.