### PR TITLE
Add out_prefix input to interfaces.spm.Normalize12

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -570,6 +570,8 @@ class Normalize12InputSpec(SPMCommandInputSpec):
                                           'normalised images'))
     write_interp = traits.Range(low=0, high=7, field='woptions.interp',
                                 desc='degree of b-spline used for interpolation')
+    out_prefix = traits.String('w', field='woptions.prefix', usedefault=True,
+                               desc='Normalized output prefix')
 
 
 class Normalize12OutputSpec(TraitedSpec):


### PR DESCRIPTION
This change allows the user to set the woptions.prefix field of an SPM12 normalization routine.