### PR TITLE
[Issue #1272] Input a list of warping regularization parameters to interfaces.spm.NewSegment

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -849,7 +849,7 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                                            field='warp.reg',
                                            desc=('Warping regularization '
                                                  'parameter(s). Accepts float '
-                                                 'or list of floats (the
+                                                 'or list of floats (the '
                                                  'latter is required by '
                                                  'SPM12)')
     sampling_distance = traits.Float(field='warp.samp',

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -843,10 +843,14 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                           field='tissue')
     affine_regularization = traits.Enum('mni', 'eastern', 'subj', 'none', field='warp.affreg',
                                         desc='mni, eastern, subj, none ')
-    warping_regularization = traits.Float(field='warp.reg',
-                                          desc='Aproximate distance between sampling points.')
-    warping_regularization_12 = traits.List(traits.Float(), minlen=5, maxlen=5, field='warp.reg',
-                                            desc='Warping regularization parameter list (SPM12)')
+    warping_regularization = traits.Either(traits.Float,
+                                           traits.List(traits.Float(),
+                                                       minlen=5, maxlen=5),
+                                           field='warp.reg'
+                                           desc='Warping regularization \
+                                           parameter(s). Accepts float or \
+                                           list of floats (the latter being \
+                                           required by SPM12)')
     sampling_distance = traits.Float(field='warp.samp',
                                      desc='Sampling distance on data for parameter estimation')
     write_deformation_fields = traits.List(traits.Bool(), minlen=2, maxlen=2, field='warp.write',

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -845,6 +845,8 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                                         desc='mni, eastern, subj, none ')
     warping_regularization = traits.Float(field='warp.reg',
                                           desc='Aproximate distance between sampling points.')
+    warping_regularization_12 = traits.List(traits.Float(), minlen=5, maxlen=5, field='warp.reg',
+                                            desc='Warping regularization parameters')
     sampling_distance = traits.Float(field='warp.samp',
                                      desc='Sampling distance on data for parameter estimation')
     write_deformation_fields = traits.List(traits.Bool(), minlen=2, maxlen=2, field='warp.write',

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -843,7 +843,7 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                           field='tissue')
     affine_regularization = traits.Enum('mni', 'eastern', 'subj', 'none', field='warp.affreg',
                                         desc='mni, eastern, subj, none ')
-    warping_regularization = traits.Either(traits.Float,
+    warping_regularization = traits.Either(traits.Float(),
                                            traits.List(traits.Float(),
                                                        minlen=5, maxlen=5),
                                            field='warp.reg'

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -846,11 +846,12 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
     warping_regularization = traits.Either(traits.Float(),
                                            traits.List(traits.Float(),
                                                        minlen=5, maxlen=5),
-                                           field='warp.reg'
-                                           desc='Warping regularization \
-                                           parameter(s). Accepts float or \
-                                           list of floats (the latter being \
-                                           required by SPM12)')
+                                           field='warp.reg',
+                                           desc=('Warping regularization '
+                                                 'parameter(s). Accepts float '
+                                                 'or list of floats (the
+                                                 'latter is required by '
+                                                 'SPM12)')
     sampling_distance = traits.Float(field='warp.samp',
                                      desc='Sampling distance on data for parameter estimation')
     write_deformation_fields = traits.List(traits.Bool(), minlen=2, maxlen=2, field='warp.write',

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -846,7 +846,7 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
     warping_regularization = traits.Float(field='warp.reg',
                                           desc='Aproximate distance between sampling points.')
     warping_regularization_12 = traits.List(traits.Float(), minlen=5, maxlen=5, field='warp.reg',
-                                            desc='Warping regularization parameters')
+                                            desc='Warping regularization parameter list (SPM12)')
     sampling_distance = traits.Float(field='warp.samp',
                                      desc='Sampling distance on data for parameter estimation')
     write_deformation_fields = traits.List(traits.Bool(), minlen=2, maxlen=2, field='warp.write',

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -843,9 +843,9 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                           field='tissue')
     affine_regularization = traits.Enum('mni', 'eastern', 'subj', 'none', field='warp.affreg',
                                         desc='mni, eastern, subj, none ')
-    warping_regularization = traits.Either(traits.Float(),
-                                           traits.List(traits.Float(),
+    warping_regularization = traits.Either(traits.List(traits.Float(),
                                                        minlen=5, maxlen=5),
+                                           traits.Float(),
                                            field='warp.reg',
                                            desc=('Warping regularization '
                                                  'parameter(s). Accepts float '

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -851,7 +851,7 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
                                                  'parameter(s). Accepts float '
                                                  'or list of floats (the '
                                                  'latter is required by '
-                                                 'SPM12)')
+                                                 'SPM12)'))
     sampling_distance = traits.Float(field='warp.samp',
                                      desc='Sampling distance on data for parameter estimation')
     write_deformation_fields = traits.List(traits.Bool(), minlen=2, maxlen=2, field='warp.write',


### PR DESCRIPTION
Allows the user to submit a list of warping regularization parameters to an spm.NewSegment routine, which appears to be required for some SPM12 workflows. This is a fix for Issue #1272.