### PR TITLE
REF: define related filetypes once.

### DIFF
--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -8,13 +8,14 @@ import os
 from tempfile import mkstemp, mkdtemp
 import warnings
 
-from ...testing import assert_equal, assert_true, assert_false, TempFATFS
+from ...testing import (assert_equal, assert_true, assert_false,
+                        assert_in, assert_not_in, TempFATFS)
 from ...utils.filemanip import (save_json, load_json,
-                                    fname_presuffix, fnames_presuffix,
-                                    hash_rename, check_forhash,
-                                    copyfile, copyfiles,
-                                    filename_to_list, list_to_filename,
-                                    split_filename, get_related_files)
+                                fname_presuffix, fnames_presuffix,
+                                hash_rename, check_forhash,
+                                copyfile, copyfiles,
+                                filename_to_list, list_to_filename,
+                                split_filename, get_related_files)
 
 import numpy as np
 
@@ -247,6 +248,30 @@ def test_copyfallback():
     finally:
         os.unlink(orig_img)
         os.unlink(orig_hdr)
+
+
+def test_get_related_files():
+    orig_img, orig_hdr = _temp_analyze_files()
+
+    related_files = get_related_files(orig_img)
+    yield assert_in, orig_img, related_files
+    yield assert_in, orig_hdr, related_files
+
+    related_files = get_related_files(orig_hdr)
+    yield assert_in, orig_img, related_files
+    yield assert_in, orig_hdr, related_files
+
+
+def test_get_related_files_noninclusive():
+    orig_img, orig_hdr = _temp_analyze_files()
+
+    related_files = get_related_files(orig_img, include_this_file=False)
+    yield assert_not_in, orig_img, related_files
+    yield assert_in, orig_hdr, related_files
+
+    related_files = get_related_files(orig_hdr, include_this_file=False)
+    yield assert_in, orig_img, related_files
+    yield assert_not_in, orig_hdr, related_files
 
 
 def test_filename_to_list():


### PR DESCRIPTION
In response to #1612

Refactors using DRY principal, define related files once.

Additionally, can be patched to extend the related filtypes with:

    import nipype
    nipype.utils.filemanip.related_filetype_sets.extend([
        ('.avh', '.hv', '.v'),
        ('.avs', '.hs', '.s'),
    ])

Local tests run, and I have checked the above patching with some of my code using Interfiles.

Potential caveats:
 - copyfile is recursive, my base condition is not to recurse if the destination file exists (i.e., has been copied). This could lead to infinite recursion if the copy fails. Suggestions are welcome (check for infinite recursion and throw instructive error? Add a new function argument defining whether to check related files so is only checked at top level?)

- behaviour is not identical to before. i.e., before `copyfile` on checked for related files for `.img` or `.BRIK`, and not if the other file part was used. I think this way is better, but some issues may come from using `.mat` files?