### PR TITLE
Fix dictstrstr

### DIFF
--- a/nipype/interfaces/traits_extension.py
+++ b/nipype/interfaces/traits_extension.py
@@ -33,7 +33,7 @@ from traits.trait_base import _Undefined, class_of
 from traits.api import BaseUnicode
 from traits.api import Unicode
 
-DictStrStr = traits.Dict((bytes,str), (bytes, str))
+DictStrStr = traits.Dict((bytes,str,unicode), (bytes,str,unicode))
 Str = Unicode
 
 class BaseFile(BaseUnicode):

--- a/nipype/interfaces/traits_extension.py
+++ b/nipype/interfaces/traits_extension.py
@@ -33,7 +33,7 @@ from traits.trait_base import _Undefined, class_of
 from traits.api import BaseUnicode
 from traits.api import Unicode
 
-DictStrStr = traits.Dict(str, (bytes, str))
+DictStrStr = traits.Dict((bytes,str), (bytes, str))
 Str = Unicode
 
 class BaseFile(BaseUnicode):

--- a/nipype/interfaces/traits_extension.py
+++ b/nipype/interfaces/traits_extension.py
@@ -33,7 +33,7 @@ from traits.trait_base import _Undefined, class_of
 from traits.api import BaseUnicode
 from traits.api import Unicode
 
-DictStrStr = traits.Dict((bytes,str,unicode), (bytes,str,unicode))
+DictStrStr = traits.Dict((bytes, str), (bytes, str))
 Str = Unicode
 
 class BaseFile(BaseUnicode):


### PR DESCRIPTION
The future strings in traits definition causes crashes for most interfaces using os.environ as an input.