### PR TITLE
TEST: Ignore atime in test_filemanip.test_recopy

### DIFF
--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 from builtins import open
 
 import os
-import time
 from tempfile import mkstemp, mkdtemp
 import warnings
 
@@ -18,13 +17,6 @@ from ...utils.filemanip import (save_json, load_json,
                                 split_filename, get_related_files)
 
 import numpy as np
-
-
-def _wait_for_tick(tic=None):
-    tic = time.time() if tic is None else tic
-    toc = time.time()
-    while int(tic) == int(toc):
-        toc = time.time()
 
 
 def _ignore_atime(stat):
@@ -205,11 +197,9 @@ def test_recopy():
                 if copy and not use_hardlink and hashmethod == 'timestamp':
                     continue
 
-                tic = time.time()
                 copyfile(orig_img, new_img, **kwargs)
                 img_stat = _ignore_atime(os.stat(new_img))
                 hdr_stat = _ignore_atime(os.stat(new_hdr))
-                _wait_for_tick(tic)
                 copyfile(orig_img, new_img, **kwargs)
                 err_msg = "Regular - OS: {}; Copy: {}; Hardlink: {}".format(
                     os.name, copy, use_hardlink)
@@ -220,11 +210,9 @@ def test_recopy():
                 os.unlink(new_img)
                 os.unlink(new_hdr)
 
-                tic = time.time()
                 copyfile(img_link, new_img, **kwargs)
                 img_stat = _ignore_atime(os.stat(new_img))
                 hdr_stat = _ignore_atime(os.stat(new_hdr))
-                _wait_for_tick(tic)
                 copyfile(img_link, new_img, **kwargs)
                 err_msg = "Symlink - OS: {}; Copy: {}; Hardlink: {}".format(
                     os.name, copy, use_hardlink)


### PR DESCRIPTION
From #1617, comparing `stat` on an unchanged file can falsely indicate a change if the filesystem sets `atime`s.

The first commit uses a helper function to cause tests to always span a clock tick, to demonstrate that all test-timing-related bugs (e.g. #1586) are handled, so we don't have to keep coming back to this.

The second commit removes the delays so that the tests run in <1s instead of ~13s.

Given that this follows on #1391, #1570 and #1586, no changelog entry.