### PR TITLE
[FIX] setup.py: remove future and configparse deps

### DIFF
--- a/setup_egg.py
+++ b/setup_egg.py
@@ -3,7 +3,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Wrapper to run setup.py using setuptools."""
 from __future__ import print_function, division, unicode_literals, absolute_import
-from builtins import open
+from io import open
 import os.path
 
 ################################################################################


### PR DESCRIPTION
When installing with pip install -e ., these needed to be already installed.