### PR TITLE
[FIX] Remove remaining import from six

### DIFF
--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -431,7 +431,7 @@ wf1.write_graph(graph2use='exec')
 import nipype.pipeline.engine as pe
 import nipype.interfaces.spm as spm
 import os
-from six import StringIO
+from io import StringIO
 from nipype.utils.config import config
 
 config.readfp(StringIO("""


### PR DESCRIPTION
A tiny leftover. I have checked that we don't import six nor from six anymore.