### PR TITLE
[FIX] Minor errors in the travis file and in one doctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   fsl afni elastix fsl-atlases; fi &&
   if $INSTALL_DEB_DEPENDECIES; then
     source /etc/fsl/fsl.sh;
-    source /etc/afni/afni.sh; fi &&
-  export FSLOUTPUTTYPE=NIFTI_GZ; }
+    source /etc/afni/afni.sh; 
+    export FSLOUTPUTTYPE=NIFTI_GZ; fi }
 - travis_retry bef_inst
 install:
 #  Add install of vtk and mayavi to test mesh (disabled): conda install -y vtk mayavi &&

--- a/nipype/interfaces/fsl/possum.py
+++ b/nipype/interfaces/fsl/possum.py
@@ -79,6 +79,7 @@ class B0Calc(FSLCommand):
     >>> b0calc = B0Calc()
     >>> b0calc.inputs.in_file = 'tissue+air_map.nii'
     >>> b0calc.inputs.z_b0 = 3.0
+    >>> b0calc.inputs.output_type = "NIFTI_GZ"
     >>> b0calc.cmdline  # doctest: +IGNORE_UNICODE
     'b0calc -i tissue+air_map.nii -o tissue+air_map_b0field.nii.gz --b0=3.00'
 


### PR DESCRIPTION
The `inputs.output_type` was not specified in the B0calc example, and a tests run by travis didn't fail since an export statement was outside an if block. 