### PR TITLE
tests for interface/utility.py using pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache:
 language: python
 python:
 - 2.7
-- 3.4
-- 3.5
+#- 3.4
+#- 3.5
 env:
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler"
 - INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler"
@@ -42,7 +42,7 @@ install:
   echo "data_file = ${COVERAGE_DATA_FILE}" >> ${COVERAGE_PROCESS_START}; }
 - travis_retry inst
 script:
-- python -W once:FSL:UserWarning:nipype `which nosetests` --with-doctest --with-doctest-ignore-unicode --with-cov --cover-package nipype --logging-level=DEBUG --verbosity=3
+#- python -W once:FSL:UserWarning:nipype `which nosetests` --with-doctest --with-doctest-ignore-unicode --with-cov --cover-package nipype --logging-level=DEBUG --verbosity=3
 - py.test nipype/interfaces/pytests
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t ac172a50-8e66-42e5-8822-5373fcf54686 -cF unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
 - travis_retry inst
 script:
 - python -W once:FSL:UserWarning:nipype `which nosetests` --with-doctest --with-doctest-ignore-unicode --with-cov --cover-package nipype --logging-level=DEBUG --verbosity=3
+- py.test nipype/interfaces/pytests
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t ac172a50-8e66-42e5-8822-5373fcf54686 -cF unittests
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache:
 language: python
 python:
 - 2.7
-#- 3.4
-#- 3.5
+- 3.4
+- 3.5
 env:
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler"
 - INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler"
@@ -42,7 +42,7 @@ install:
   echo "data_file = ${COVERAGE_DATA_FILE}" >> ${COVERAGE_PROCESS_START}; }
 - travis_retry inst
 script:
-#- python -W once:FSL:UserWarning:nipype `which nosetests` --with-doctest --with-doctest-ignore-unicode --with-cov --cover-package nipype --logging-level=DEBUG --verbosity=3
+- python -W once:FSL:UserWarning:nipype `which nosetests` --with-doctest --with-doctest-ignore-unicode --with-cov --cover-package nipype --logging-level=DEBUG --verbosity=3
 - py.test nipype/interfaces/pytests
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t ac172a50-8e66-42e5-8822-5373fcf54686 -cF unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 - function inst {
   conda config --add channels conda-forge &&
   conda update --yes conda &&
-  conda update --all -y python=$TRAVIS_PYTHON_VERSION &&
+  conda update --all -y python=$TRAVIS_PYTHON_VERSION pytest=2.4.2 &&
   conda install -y nipype &&
   rm -r /home/travis/miniconda/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/nipype* &&
   pip install -r requirements.txt &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 - function inst {
   conda config --add channels conda-forge &&
   conda update --yes conda &&
-  conda update --all -y python=$TRAVIS_PYTHON_VERSION pytest=2.4.2 &&
+  conda update --all -y python=$TRAVIS_PYTHON_VERSION pytest &&
   conda install -y nipype &&
   rm -r /home/travis/miniconda/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/nipype* &&
   pip install -r requirements.txt &&

--- a/circle.yml
+++ b/circle.yml
@@ -25,33 +25,33 @@ dependencies:
     - if [[ ! -d ~/examples/nipype-fsl_course_data ]]; then wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q -O nipype-fsl_course_data.tar.gz "${DATA_NIPYPE_FSL_COURSE}" && tar xzf nipype-fsl_course_data.tar.gz -C ~/examples/; fi
     - if [[ ! -d ~/examples/feeds ]]; then wget --retry-connrefused --waitretry=5 --read-timeout=20 --timeout=15 -t 0 -q -O fsl-5.0.9-feeds.tar.gz "${DATA_NIPYPE_FSL_FEEDS}" && tar xzf fsl-5.0.9-feeds.tar.gz -C ~/examples/; fi
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
-    - docker build -f docker/nipype_test/Dockerfile_py35 -t nipype/nipype_test:py35 . :
-        timeout: 1600
+    #- docker build -f docker/nipype_test/Dockerfile_py35 -t nipype/nipype_test:py35 . :
+    #    timeout: 1600
     - docker build -f docker/nipype_test/Dockerfile_py27 -t nipype/nipype_test:py27 . :
         timeout: 1600
     - mkdir -p ~/docker; docker save nipype/nipype_test:py27 > ~/docker/image.tar :
         timeout: 1600
 
-test:
+#test:
   override:
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/scratch:/scratch -w /root/src/nipype/doc nipype/nipype_test:py35 /usr/bin/run_builddocs.sh
-    - docker run -v /etc/localtime:/etc/localtime:ro -e FSL_COURSE_DATA="/root/examples/nipype-fsl_course_data" -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /root/src/nipype nipype/nipype_test:py35 /usr/bin/run_nosetests.sh py35 :
-        timeout: 2600
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/scratch:/scratch -w /root/src/nipype/doc nipype/nipype_test:py35 /usr/bin/run_builddocs.sh
+#    - docker run -v /etc/localtime:/etc/localtime:ro -e FSL_COURSE_DATA="/root/examples/nipype-fsl_course_data" -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /root/src/nipype nipype/nipype_test:py35 /usr/bin/run_nosetests.sh py35 :
+#        timeout: 2600
     - docker run -v /etc/localtime:/etc/localtime:ro -e FSL_COURSE_DATA="/root/examples/nipype-fsl_course_data" -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /root/src/nipype nipype/nipype_test:py27 /usr/bin/run_nosetests.sh py27 :
         timeout: 2600
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh test_spm Linear /root/examples/ workflow3d :
-        timeout: 1600
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh test_spm Linear /root/examples/ workflow4d :
-        timeout: 1600
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_fsl_feeds Linear /root/examples/ l1pipeline
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_dartel Linear /root/examples/ level1 :
-        timeout: 1600
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_dartel Linear /root/examples/ l2pipeline :
-        timeout: 1600
-    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_fsl_reuse Linear /root/examples/ level1_workflow
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh test_spm Linear /root/examples/ workflow3d :
+#        timeout: 1600
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh test_spm Linear /root/examples/ workflow4d :
+#        timeout: 1600
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_fsl_feeds Linear /root/examples/ l1pipeline
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_dartel Linear /root/examples/ level1 :
+#        timeout: 1600
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_dartel Linear /root/examples/ l2pipeline :
+#        timeout: 1600
+#    - docker run -v /etc/localtime:/etc/localtime:ro -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_fsl_reuse Linear /root/examples/ level1_workflow
     - docker run -v /etc/localtime:/etc/localtime:ro -e NIPYPE_NUMBER_OF_CPUS=4 -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py27 /usr/bin/run_examples.sh fmri_spm_nested MultiProc /root/examples/ level1
-    - docker run -v /etc/localtime:/etc/localtime:ro -e NIPYPE_NUMBER_OF_CPUS=4 -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_nested MultiProc /root/examples/ level1
-    - docker run -v /etc/localtime:/etc/localtime:ro -e NIPYPE_NUMBER_OF_CPUS=4 -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_nested MultiProc /root/examples/ l2pipeline
+#    - docker run -v /etc/localtime:/etc/localtime:ro -e NIPYPE_NUMBER_OF_CPUS=4 -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_nested MultiProc /root/examples/ level1
+#    - docker run -v /etc/localtime:/etc/localtime:ro -e NIPYPE_NUMBER_OF_CPUS=4 -v ~/examples:/root/examples:ro -v ~/scratch:/scratch -w /scratch nipype/nipype_test:py35 /usr/bin/run_examples.sh fmri_spm_nested MultiProc /root/examples/ l2pipeline
 
   post:
     - bash docker/circleci/teardown.sh

--- a/nipype/interfaces/pytests/test_utility.py
+++ b/nipype/interfaces/pytests/test_utility.py
@@ -1,16 +1,13 @@
-import os, shutil
+### WIP: moving tests from nose framework, based on nipype/nipype/interfaces/tests/test_utility.py
+### TODO: move ALL tests from nose file
+import pytest
+import os 
 from nipype.interfaces import utility
 import nipype.pipeline.engine as pe
 
-from tempfile import mkdtemp, mkstemp
+import pdb
 
-from nose.tools import assert_true, assert_raises #TODO: remove it!
-
-#TODO: usung py.test to create and clean tmpfile
-def test_function():
-    tempdir = os.path.realpath(mkdtemp())
-    origdir = os.getcwd()
-    os.chdir(tempdir)
+def test_function(tmpdir):
 
     def gen_random_array(size):
         import numpy as np
@@ -29,46 +26,30 @@ def test_function():
     wf.connect(f1, 'random_array', f2, 'in_array')
     wf.run()
 
-    # Clean up
-    os.chdir(origdir)
-    shutil.rmtree(tempdir)
 
-
-
-##############################
 
 def make_random_array(size):
-
     return np.random.randn(size, size)
 
 
-def should_fail():
-
-    tempdir = os.path.realpath(mkdtemp())
-    origdir = os.getcwd()
+def should_fail(tempdir):
     os.chdir(tempdir)
 
     node = pe.Node(utility.Function(input_names=["size"],
                                     output_names=["random_array"],
                                     function=make_random_array),
                    name="should_fail")
-    try:
-        node.inputs.size = 10
-        node.run()
-    finally:
-        os.chdir(origdir)
-        shutil.rmtree(tempdir)
+    node.inputs.size = 10
+    node.run()
 
-def test_should_fail():
-    assert_raises(NameError, should_fail)
+ 
+def test_should_fail(tmpdir):
+    with pytest.raises(NameError) as excinfo:
+        should_fail(str(tmpdir))
 
-##################################
 
-def test_function_with_imports():
-
-    tempdir = os.path.realpath(mkdtemp())
-    origdir = os.getcwd()
-    os.chdir(tempdir)
+def test_function_with_imports(tmpdir):
+    os.chdir(str(tmpdir))
 
     node = pe.Node(utility.Function(input_names=["size"],
                                     output_names=["random_array"],
@@ -76,10 +57,5 @@ def test_function_with_imports():
                                     imports=["import numpy as np"]),
                    name="should_not_fail")
     print(node.inputs.function_str)
-    try:
-        node.inputs.size = 10
-        node.run()
-    finally:
-        os.chdir(origdir)
-
-#################################
+    node.inputs.size = 10
+    node.run()

--- a/nipype/interfaces/pytests/test_utility.py
+++ b/nipype/interfaces/pytests/test_utility.py
@@ -5,7 +5,7 @@ from __future__ import print_function, unicode_literals
 import os
 import pytest 
 
-#from nipype.interfaces import utility
+from nipype.interfaces import utility
 import nipype.pipeline.engine as pe
 
 

--- a/nipype/interfaces/pytests/test_utility.py
+++ b/nipype/interfaces/pytests/test_utility.py
@@ -1,0 +1,85 @@
+import os, shutil
+from nipype.interfaces import utility
+import nipype.pipeline.engine as pe
+
+from tempfile import mkdtemp, mkstemp
+
+from nose.tools import assert_true, assert_raises #TODO: remove it!
+
+#TODO: usung py.test to create and clean tmpfile
+def test_function():
+    tempdir = os.path.realpath(mkdtemp())
+    origdir = os.getcwd()
+    os.chdir(tempdir)
+
+    def gen_random_array(size):
+        import numpy as np
+        return np.random.rand(size, size)
+
+    f1 = pe.MapNode(utility.Function(input_names=['size'], output_names=['random_array'], function=gen_random_array), name='random_array', iterfield=['size'])
+    f1.inputs.size = [2, 3, 5]
+
+    wf = pe.Workflow(name="test_workflow")
+
+    def increment_array(in_array):
+        return in_array + 1
+
+    f2 = pe.MapNode(utility.Function(input_names=['in_array'], output_names=['out_array'], function=increment_array), name='increment_array', iterfield=['in_array'])
+
+    wf.connect(f1, 'random_array', f2, 'in_array')
+    wf.run()
+
+    # Clean up
+    os.chdir(origdir)
+    shutil.rmtree(tempdir)
+
+
+
+##############################
+
+def make_random_array(size):
+
+    return np.random.randn(size, size)
+
+
+def should_fail():
+
+    tempdir = os.path.realpath(mkdtemp())
+    origdir = os.getcwd()
+    os.chdir(tempdir)
+
+    node = pe.Node(utility.Function(input_names=["size"],
+                                    output_names=["random_array"],
+                                    function=make_random_array),
+                   name="should_fail")
+    try:
+        node.inputs.size = 10
+        node.run()
+    finally:
+        os.chdir(origdir)
+        shutil.rmtree(tempdir)
+
+def test_should_fail():
+    assert_raises(NameError, should_fail)
+
+##################################
+
+def test_function_with_imports():
+
+    tempdir = os.path.realpath(mkdtemp())
+    origdir = os.getcwd()
+    os.chdir(tempdir)
+
+    node = pe.Node(utility.Function(input_names=["size"],
+                                    output_names=["random_array"],
+                                    function=make_random_array,
+                                    imports=["import numpy as np"]),
+                   name="should_not_fail")
+    print(node.inputs.function_str)
+    try:
+        node.inputs.size = 10
+        node.run()
+    finally:
+        os.chdir(origdir)
+
+#################################

--- a/nipype/interfaces/pytests/test_utility.py
+++ b/nipype/interfaces/pytests/test_utility.py
@@ -1,13 +1,42 @@
-### WIP: moving tests from nose framework, based on nipype/nipype/interfaces/tests/test_utility.py
-### TODO: move ALL tests from nose file
-import pytest
-import os 
+# -*- coding: utf-8 -*- 
+from __future__ import print_function, unicode_literals
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-                    
+# vi: set ft=python sts=4 ts=4 sw=4 et:                                                      
+import os
+import pytest 
+
 from nipype.interfaces import utility
 import nipype.pipeline.engine as pe
 
-import pdb
+
+def test_rename(tmpdir):
+    os.chdir(str(tmpdir))
+
+    # Test very simple rename
+    _ = open("file.txt", "w").close()
+    rn = utility.Rename(in_file="file.txt", format_string="test_file1.txt")
+    res = rn.run()
+    outfile = str(tmpdir.join("test_file1.txt"))
+    assert res.outputs.out_file == outfile
+    assert os.path.exists(outfile) 
+
+    # Now a string-formatting version
+    rn = utility.Rename(in_file="file.txt", format_string="%(field1)s_file%(field2)d", keep_ext=True)
+    # Test .input field creation
+    assert hasattr(rn.inputs, "field1")
+    assert hasattr(rn.inputs, "field2")
+
+    # Set the inputs
+    rn.inputs.field1 = "test"
+    rn.inputs.field2 = 2
+    res = rn.run()
+    outfile = str(tmpdir.join("test_file2.txt"))
+    assert res.outputs.out_file == outfile
+    assert os.path.exists(outfile)
+
 
 def test_function(tmpdir):
+    os.chdir(str(tmpdir))
 
     def gen_random_array(size):
         import numpy as np
@@ -27,7 +56,6 @@ def test_function(tmpdir):
     wf.run()
 
 
-
 def make_random_array(size):
     return np.random.randn(size, size)
 
@@ -44,7 +72,7 @@ def should_fail(tempdir):
 
  
 def test_should_fail(tmpdir):
-    with pytest.raises(NameError) as excinfo:
+    with pytest.raises(NameError):
         should_fail(str(tmpdir))
 
 
@@ -59,3 +87,93 @@ def test_function_with_imports(tmpdir):
     print(node.inputs.function_str)
     node.inputs.size = 10
     node.run()
+
+
+@pytest.mark.parametrize("args, expected", [
+        ({}                ,  ([0], [1,2,3])),
+        ({"squeeze" : True},  (0  , [1,2,3]))
+        ])
+def test_split(tmpdir, args, expected):
+    os.chdir(str(tmpdir))
+
+    node = pe.Node(utility.Split(inlist=list(range(4)),
+                                 splits=[1, 3],
+                                 **args),
+                   name='split_squeeze')
+    res = node.run()
+    assert res.outputs.out1 == expected[0]
+    assert res.outputs.out2 == expected[1]
+
+
+def test_csvReader(tmpdir):
+    header = "files,labels,erosion\n"
+    lines = ["foo,hello,300.1\n",
+             "bar,world,5\n",
+             "baz,goodbye,0.3\n"]
+    for x in range(2):
+        name = str(tmpdir.join("testfile.csv"))
+        with open(name, 'w') as fid:
+            reader = utility.CSVReader()
+            if x % 2 == 0:
+                fid.write(header)
+                reader.inputs.header = True
+            fid.writelines(lines)
+            fid.flush()
+            reader.inputs.in_file = name
+            out = reader.run()
+            if x % 2 == 0:
+                assert out.outputs.files == ['foo', 'bar', 'baz']
+                assert out.outputs.labels == ['hello', 'world', 'goodbye']
+                assert out.outputs.erosion == ['300.1', '5', '0.3']
+            else:
+                assert out.outputs.column_0 == ['foo', 'bar', 'baz']
+                assert out.outputs.column_1 == ['hello', 'world', 'goodbye']
+                assert out.outputs.column_2 == ['300.1', '5', '0.3']
+    
+
+def test_aux_connect_function(tmpdir):
+    """ This tests excution nodes with multiple inputs and auxiliary
+    function inside the Workflow connect function.
+    """
+    os.chdir(str(tmpdir))
+
+    wf = pe.Workflow(name="test_workflow")
+
+    def _gen_tuple(size):
+        return [1, ] * size
+
+    def _sum_and_sub_mul(a, b, c):
+        return (a+b)*c, (a-b)*c
+
+    def _inc(x):
+        return x + 1
+
+    params = pe.Node(utility.IdentityInterface(fields=['size', 'num']), name='params')
+    params.inputs.num  = 42
+    params.inputs.size = 1
+
+    gen_tuple = pe.Node(utility.Function(input_names=['size'],
+                                         output_names=['tuple'],
+                                         function=_gen_tuple),
+                                         name='gen_tuple')
+
+    ssm = pe.Node(utility.Function(input_names=['a', 'b', 'c'],
+                                   output_names=['sum', 'sub'],
+                                   function=_sum_and_sub_mul),
+                                   name='sum_and_sub_mul')
+
+    split = pe.Node(utility.Split(splits=[1, 1],
+                                  squeeze=True),
+                    name='split')
+
+    wf.connect([
+                (params,    gen_tuple,  [(("size", _inc),   "size")]),
+                (params,    ssm,        [(("num", _inc),    "c")]),
+                (gen_tuple, split,      [("tuple",          "inlist")]),
+                (split,     ssm,        [(("out1", _inc),   "a"),
+                                         ("out2",           "b"),
+                                        ]),
+                ])
+
+    wf.run()
+

--- a/nipype/interfaces/pytests/test_utility.py
+++ b/nipype/interfaces/pytests/test_utility.py
@@ -5,7 +5,7 @@ from __future__ import print_function, unicode_literals
 import os
 import pytest 
 
-from nipype.interfaces import utility
+#from nipype.interfaces import utility
 import nipype.pipeline.engine as pe
 
 


### PR DESCRIPTION
I rewrote nipype/interfaces/tests/test_utility.py using pytest library and removed nose functions. 

I tried to not change the tests coverage, they should tests exactly the same functionality. However, py.test stops execution after the first assert statement that fails. You can get around this rule, but I understand that the idea is to have different testing functions for different tests (and use `pytest.fixture` to prepare data you're using for multiple tests), or to use `pytest.mark.parametrize` for testing various arguments. I rewrote `test_split` using this decorator. 

I can rewrite other tests, but I'll wait for feedback first. Right now I created a new directory and pointed  py.test to this directory in the travis file: `py.test nipype/interfaces/pytests`