### PR TITLE
fix semaphore acquire bug

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -160,7 +160,6 @@ class MultiProcPlugin(DistributedPluginBase):
     def _wait(self):
         if len(self.pending_tasks) > 0:
             semaphore_singleton.semaphore.acquire()
-        semaphore_singleton.semaphore.release()
 
     def _get_result(self, taskid):
         if taskid not in self._taskresult:

--- a/nipype/pipeline/plugins/semaphore_singleton.py
+++ b/nipype/pipeline/plugins/semaphore_singleton.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, unicode_literals, absolute_import
 import threading
-semaphore = threading.Semaphore(1)
+semaphore = threading.Semaphore(0)


### PR DESCRIPTION
There was a bug on how the semaphore of the multiproc plugin was initialized and released.
The semaphore counter was initialized with 1, being acquired over and over again and never released.
That is because semaphore.acquire() was called more times than semaphore.release(), so the semaphore internal counter would always be > 0, leading to the master process to be active all the time.

We noticed that bug because the master process of the run was utilizing 100% cpu, even on the times it was supposed to be sleeping.

This fix makes the multiproc plugin have the expected behavior: the main process sleeps when it is waiting for jobs to finish.
Besides that, the multiproc plugin still works exactly the same as before.