### PR TITLE
Fixed type referencing non-existent attribute in QJobInfo

### DIFF
--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -47,7 +47,7 @@ class QJobInfo(object):
         self._job_info_creation_time = time.time(
         )  # When this job was created (for comparing against initalization)
         self._job_queue_name = job_queue_name  # Where the job is running
-        self._job_slots = job_slots  # How many slots are being used
+        self._job_slots = int(job_slots)  # How many slots are being used
         self._qsub_command_line = qsub_command_line
 
     def __repr__(self):
@@ -91,7 +91,7 @@ class QJobInfo(object):
         self._job_queue_state = job_queue_state
         self._job_time = job_time
         self._job_queue_name = job_queue_name
-        self._job_slots = job_slots
+        self._job_slots = int(job_slots)
 
     def set_state(self, new_state):
         self._job_queue_state = new_state

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -52,7 +52,7 @@ class QJobInfo(object):
 
     def __repr__(self):
         return '{:<8d}{:12}{:<3d}{:20}{:8}{}'.format(
-            self._job_num, self._queue_state, self._job_slots,
+            self._job_num, self._job_queue_state, self._job_slots,
             time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(self._job_time)),
             self._job_queue_name, self._qsub_command_line)
 


### PR DESCRIPTION
This is an artifact from #1656. Causes an AttributeError when zombie processes are found.