### PR TITLE
BF: install requires configparser

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -144,7 +144,8 @@ REQUIRES = [
     'prov>=%s' % PROV_MIN_VERSION,
     'click>=%s' % CLICK_MIN_VERSION,
     'xvfbwrapper',
-    'funcsigs'
+    'funcsigs',
+    'configparser',
 ]
 
 TESTS_REQUIRES = [


### PR DESCRIPTION
otherwise - kaboom:
```shell
$> virtualenv venv-tests
Running virtualenv with interpreter /usr/bin/python2
New python executable in /tmp/venv-tests/bin/python2
Also creating executable in /tmp/venv-tests/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
2 16589.....................................:Mon 31 Oct 2016 12:36:49 PM EDT:.
hopa:/tmp
$> source venv-tests/bin/activate
(venv-tests) 2 16590.....................................:Mon 31 Oct 2016 12:36:51 PM EDT:.
hopa:/tmp
$> pip install nipype
Collecting nipype
  Using cached nipype-0.12.1-py2.py3-none-any.whl
Collecting nibabel>=2.0.1 (from nipype)
Collecting traits>=4.3 (from nipype)
Collecting future>=0.15.2 (from nipype)
Collecting scipy>=0.11 (from nipype)
  Using cached scipy-0.18.1-cp27-cp27mu-manylinux1_x86_64.whl
Collecting xvfbwrapper (from nipype)
Collecting numpy>=1.6.2 (from nipype)
  Using cached numpy-1.11.2-cp27-cp27mu-manylinux1_x86_64.whl
Collecting python-dateutil>=1.5 (from nipype)
  Using cached python_dateutil-2.5.3-py2.py3-none-any.whl
Collecting prov>=1.4.0 (from nipype)
  Using cached prov-1.5.0-py2.py3-none-any.whl
Collecting simplejson>=3.8.0 (from nipype)
Collecting mock (from nipype)
  Using cached mock-2.0.0-py2.py3-none-any.whl
Collecting networkx>=1.7 (from nipype)
  Using cached networkx-1.11-py2.py3-none-any.whl
Collecting nose>=1.2 (from nipype)
  Using cached nose-1.3.7-py2-none-any.whl
Collecting six>=1.5 (from python-dateutil>=1.5->nipype)
  Using cached six-1.10.0-py2.py3-none-any.whl
Collecting lxml (from prov>=1.4.0->nipype)
  Using cached lxml-3.6.4-cp27-cp27mu-manylinux1_x86_64.whl
Collecting rdflib>=4.2.1 (from prov>=1.4.0->nipype)
Collecting funcsigs>=1; python_version < "3.3" (from mock->nipype)
  Using cached funcsigs-1.0.2-py2.py3-none-any.whl
Collecting pbr>=0.11 (from mock->nipype)
  Using cached pbr-1.10.0-py2.py3-none-any.whl
Collecting decorator>=3.4.0 (from networkx>=1.7->nipype)
  Using cached decorator-4.0.10-py2.py3-none-any.whl
Collecting pyparsing (from rdflib>=4.2.1->prov>=1.4.0->nipype)
  Using cached pyparsing-2.1.10-py2.py3-none-any.whl
Collecting isodate (from rdflib>=4.2.1->prov>=1.4.0->nipype)
Collecting SPARQLWrapper (from rdflib>=4.2.1->prov>=1.4.0->nipype)
Collecting html5lib (from rdflib>=4.2.1->prov>=1.4.0->nipype)
  Using cached html5lib-0.999999999-py2.py3-none-any.whl
Collecting keepalive>=0.5 (from SPARQLWrapper->rdflib>=4.2.1->prov>=1.4.0->nipype)
Requirement already satisfied (use --upgrade to upgrade): setuptools>=18.5 in ./venv-tests/lib/python2.7/site-packages (from html5lib->rdflib>=4.2.1->prov>=1.4.0->nipype)
Collecting webencodings (from html5lib->rdflib>=4.2.1->prov>=1.4.0->nipype)
Installing collected packages: numpy, nibabel, traits, future, scipy, xvfbwrapper, six, python-dateutil, lxml, decorator, networkx, pyparsing, isodate, keepalive, SPARQLWrapper, webencodings, html5lib, rdflib, prov, simplejson, funcsigs, pbr, mock, nose, nipype
Successfully installed SPARQLWrapper-1.7.6 decorator-4.0.10 funcsigs-1.0.2 future-0.16.0 html5lib-0.999999999 isodate-0.5.4 keepalive-0.5 lxml-3.6.4 mock-2.0.0 networkx-1.11 nibabel-2.1.0 nipype-0.12.1 nose-1.3.7 numpy-1.11.2 pbr-1.10.0 prov-1.5.0 pyparsing-2.1.10 python-dateutil-2.5.3 rdflib-4.2.1 scipy-0.18.1 simplejson-3.10.0 six-1.10.0 traits-4.5.0 webencodings-0.5 xvfbwrapper-0.2.8
pip install nipype  8.94s user 1.22s system 95% cpu 10.595 total
(venv-tests) 2 16591.....................................:Mon 31 Oct 2016 12:37:06 PM EDT:.
hopa:/tmp
$> python -c 'from nipype import Function, Node'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/venv-tests/local/lib/python2.7/site-packages/nipype/__init__.py", line 11, in <module>
    from .utils.config import NipypeConfig
  File "/tmp/venv-tests/local/lib/python2.7/site-packages/nipype/utils/config.py", line 15, in <module>
    import configparser
ImportError: No module named configparser
```