### PR TITLE
Add support for uncode filenames to filename_to_list()  in filemanip.py

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -428,8 +428,8 @@ def copyfiles(filelist, dest, copy=False, create_new=False):
 def filename_to_list(filename):
     """Returns a list given either a string or a list
     """
-    if isinstance(filename, (str, bytes)):
-        return [filename]
+    if isinstance(filename, (str, bytes,unicode)):
+        return [str(filename)]
     elif isinstance(filename, list):
         return filename
     elif is_container(filename):

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -429,7 +429,7 @@ def filename_to_list(filename):
     """Returns a list given either a string or a list
     """
     if isinstance(filename, (str, bytes,unicode)):
-        return [str(filename)]
+        return [filename]
     elif isinstance(filename, list):
         return filename
     elif is_container(filename):


### PR DESCRIPTION
Filemanip.py's filename_to_list() used to return None when passed a filename that is a unicode string. This commit allows it to behave correctly (return a list containing a unicode string) when passed a unicode string as a filename.