### PR TITLE
ENH: Allows ReconAll.inputs.flags to take in a list of flags

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -638,7 +638,7 @@ class ReconAllInputSpec(CommandLineInputSpec):
                   desc="Set parameters using expert file")
     subjects_dir = Directory(exists=True, argstr='-sd %s', hash_files=False,
                              desc='path to subjects directory', genfile=True)
-    flags = traits.Str(argstr='%s', desc='additional parameters')
+    flags = traits.Either(traits.Str, traits.List, argstr='%s', desc='additional parameters')
 
     # Expert options
     talairach = traits.Str(desc="Flags to pass to talairach commands", xor=['expert'])
@@ -689,7 +689,12 @@ class ReconAll(CommandLine):
     >>> reconall.inputs.T1_files = 'structural.nii'
     >>> reconall.cmdline # doctest: +ALLOW_UNICODE
     'recon-all -all -i structural.nii -subjid foo -sd .'
-
+    >>> reconall.inputs.flags = "-qcache"
+    >>> reconall.cmdline # doctest: +IGNORE_UNICODE
+    'recon-all -all -i structural.nii -qcache -subjid foo -sd .'
+    >>> reconall.inputs.flags = ["-cw256", "-qcache"]
+    >>> reconall.cmdline # doctest: +IGNORE_UNICODE
+    'recon-all -all -i structural.nii -cw256 -qcache -subjid foo -sd .'
     """
 
     _cmd = 'recon-all'

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -638,7 +638,7 @@ class ReconAllInputSpec(CommandLineInputSpec):
                   desc="Set parameters using expert file")
     subjects_dir = Directory(exists=True, argstr='-sd %s', hash_files=False,
                              desc='path to subjects directory', genfile=True)
-    flags = traits.Either(traits.Str, traits.List, argstr='%s', desc='additional parameters')
+    flags = InputMultiPath(traits.Str, argstr='%s', desc='additional parameters')
 
     # Expert options
     talairach = traits.Str(desc="Flags to pass to talairach commands", xor=['expert'])
@@ -690,10 +690,10 @@ class ReconAll(CommandLine):
     >>> reconall.cmdline # doctest: +ALLOW_UNICODE
     'recon-all -all -i structural.nii -subjid foo -sd .'
     >>> reconall.inputs.flags = "-qcache"
-    >>> reconall.cmdline # doctest: +IGNORE_UNICODE
+    >>> reconall.cmdline # doctest: +ALLOW_UNICODE
     'recon-all -all -i structural.nii -qcache -subjid foo -sd .'
     >>> reconall.inputs.flags = ["-cw256", "-qcache"]
-    >>> reconall.cmdline # doctest: +IGNORE_UNICODE
+    >>> reconall.cmdline # doctest: +ALLOW_UNICODE
     'recon-all -all -i structural.nii -cw256 -qcache -subjid foo -sd .'
     """
 


### PR DESCRIPTION
Allows for the flags input to ReconAll interface to be either a string or a list of strings. This makes it possible to set multiple flags on ReconAll without having to first convert them to a string as is the case here: https://neurostars.org/p/4314/#4320