### PR TITLE
fix: correctly join iterable expansion

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,7 +796,7 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if (node._id == src_id and
+                    if (node._id.startswith(src_id + '.') and
                        jnode._hierarchy in node._hierarchy):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -711,7 +711,7 @@ def generate_expanded_graph(graph_in):
             in_edges = jedge_dict[jnode] = {}
             edges2remove = []
             for src, dest, data in graph_in.in_edges_iter(jnode, True):
-                in_edges[src.fullname] = data
+                in_edges[src._id] = data
                 edges2remove.append((src, dest))
 
             for src, dest in edges2remove:
@@ -796,7 +796,8 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if node._id.startswith(src_id + '.'):
+                    if node._id.startswith(src_id) and
+                       jnode._hierarchy in node._hierarchy:
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,8 +796,7 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if (node._id.startswith(src_id + '.') and
-                       jnode._hierarchy in node._hierarchy):
+                    if (node._id.startswith(src_id + '.aI'):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,8 +796,8 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if node._id.startswith(src_id) and
-                       jnode._hierarchy in node._hierarchy:
+                    if (node._id.startswith(src_id) and
+                       jnode._hierarchy in node._hierarchy):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -711,7 +711,7 @@ def generate_expanded_graph(graph_in):
             in_edges = jedge_dict[jnode] = {}
             edges2remove = []
             for src, dest, data in graph_in.in_edges_iter(jnode, True):
-                in_edges[src._id] = data
+                in_edges[src.fullname] = data
                 edges2remove.append((src, dest))
 
             for src, dest in edges2remove:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,7 +796,7 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if (node._id.startswith(src_id) and
+                    if (node._id == src_id and
                        jnode._hierarchy in node._hierarchy):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,7 +796,7 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if (node._id.startswith(src_id + '.aI'):
+                    if (node._id.startswith(src_id + '.')):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -796,7 +796,7 @@ def generate_expanded_graph(graph_in):
             expansions = defaultdict(list)
             for node in graph_in.nodes_iter():
                 for src_id, edge_data in list(old_edge_dict.items()):
-                    if node._id.startswith(src_id):
+                    if node._id.startswith(src_id + '.'):
                         expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"


### PR DESCRIPTION
This change ensures JoinNode connects only nodes with iterables (.a1, .a2, etc.).