### PR TITLE
[FIX] FAST output files

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -323,17 +323,20 @@ class FAST(FSLCommand):
             nclasses = self.inputs.number_classes
         # when using multichannel, results basename is based on last
         # input filename
+        _gen_fname_opts = {}
         if isdefined(self.inputs.out_basename):
-            basefile = self.inputs.out_basename
+            _gen_fname_opts['basename'] = self.inputs.out_basename
+            _gen_fname_opts['cwd'] = os.getcwd()
         else:
-            basefile = self.inputs.in_files[-1]
+            _gen_fname_opts['basename'] = self.inputs.in_files[-1]
+            _gen_fname_opts['cwd'], _, _ = split_filename(_gen_fname_opts['basename'])
 
-        outputs['tissue_class_map'] = self._gen_fname(basefile, suffix='_seg')
+        outputs['tissue_class_map'] = self._gen_fname(suffix='_seg', **_gen_fname_opts)
         if self.inputs.segments:
             outputs['tissue_class_files'] = []
             for i in range(nclasses):
                 outputs['tissue_class_files'].append(
-                    self._gen_fname(basefile, suffix='_seg_%d' % i))
+                    self._gen_fname(suffix='_seg_%d' % i, **_gen_fname_opts))
         if isdefined(self.inputs.output_biascorrected):
             outputs['restored_image'] = []
             if len(self.inputs.in_files) > 1:
@@ -342,22 +345,21 @@ class FAST(FSLCommand):
                 for val, f in enumerate(self.inputs.in_files):
                     # image numbering is 1-based
                     outputs['restored_image'].append(
-                        self._gen_fname(basefile,
-                                        suffix='_restore_%d' % (val + 1)))
+                        self._gen_fname(suffix='_restore_%d' % (val + 1), **_gen_fname_opts))
             else:
                 # single image segmentation has unnumbered output image
                 outputs['restored_image'].append(
-                    self._gen_fname(basefile, suffix='_restore'))
+                    self._gen_fname(suffix='_restore', **_gen_fname_opts))
 
-        outputs['mixeltype'] = self._gen_fname(basefile, suffix='_mixeltype')
+        outputs['mixeltype'] = self._gen_fname(suffix='_mixeltype', **_gen_fname_opts)
         if not self.inputs.no_pve:
             outputs['partial_volume_map'] = self._gen_fname(
-                basefile, suffix='_pveseg')
+                suffix='_pveseg', **_gen_fname_opts)
             outputs['partial_volume_files'] = []
             for i in range(nclasses):
                 outputs[
                     'partial_volume_files'].append(
-                        self._gen_fname(basefile, suffix='_pve_%d' % i))
+                        self._gen_fname(suffix='_pve_%d' % i, **_gen_fname_opts))
         if self.inputs.output_biasfield:
             outputs['bias_field'] = []
             if len(self.inputs.in_files) > 1:
@@ -366,18 +368,17 @@ class FAST(FSLCommand):
                 for val, f in enumerate(self.inputs.in_files):
                     # image numbering is 1-based
                     outputs['bias_field'].append(
-                        self._gen_fname(basefile,
-                                        suffix='_bias_%d' % (val + 1)))
+                        self._gen_fname(suffix='_bias_%d' % (val + 1), **_gen_fname_opts))
             else:
                 # single image segmentation has unnumbered output image
                 outputs['bias_field'].append(
-                    self._gen_fname(basefile, suffix='_bias'))
+                    self._gen_fname(suffix='_bias', **_gen_fname_opts))
 
         if self.inputs.probability_maps:
             outputs['probability_maps'] = []
             for i in range(nclasses):
                 outputs['probability_maps'].append(
-                    self._gen_fname(basefile, suffix='_prob_%d' % i))
+                    self._gen_fname(suffix='_prob_%d' % i, **_gen_fname_opts))
         return outputs
 
 

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -315,6 +315,15 @@ class FAST(FSLCommand):
             formated = "-S %d %s" % (len(value), formated)
         return formated
 
+    def _parse_inputs(self, skip=None):
+        ''' ensures out_basename (argstring -o) always exists, otherwise fast
+        puts the outputs in the same folder as the inputs '''
+        arg_list = super(FAST, self)._parse_inputs(skip)
+        if not ('-o ' in [arg[:3] for arg in arg_list]
+                or '--out ' in [arg[:6] for arg in arg_list]):
+            arg_list.insert(0, '-o {}'.format(self._gen_fname(self.inputs.in_files[-1])))
+        return arg_list
+
     def _list_outputs(self):
         outputs = self.output_spec().get()
         if not isdefined(self.inputs.number_classes):

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -315,15 +315,6 @@ class FAST(FSLCommand):
             formated = "-S %d %s" % (len(value), formated)
         return formated
 
-    def _parse_inputs(self, skip=None):
-        ''' ensures out_basename (argstring -o) always exists, otherwise fast
-        puts the outputs in the same folder as the inputs '''
-        arg_list = super(FAST, self)._parse_inputs(skip)
-        if not ('-o ' in [arg[:3] for arg in arg_list]
-                or '--out ' in [arg[:6] for arg in arg_list]):
-            arg_list.insert(0, '-o {}'.format(self._gen_fname(self.inputs.in_files[-1])))
-        return arg_list
-
     def _list_outputs(self):
         outputs = self.output_spec().get()
         if not isdefined(self.inputs.number_classes):

--- a/nipype/interfaces/fsl/tests/test_preprocess.py
+++ b/nipype/interfaces/fsl/tests/test_preprocess.py
@@ -167,6 +167,30 @@ def test_fast():
                                                       "-S 1 %s" % tmp_infile])
     teardown_infile(tmp_dir)
 
+@skipif(no_fsl)
+def test_fast_list_outputs():
+    ''' By default (no -o), FSL's fast command outputs files into the same
+    directory as the input files. If the flag -o is set, it outputs files into
+    the cwd '''
+    def _run_and_test(opts, output_base):
+        outputs = fsl.FAST(**opts)._list_outputs()
+        assert_equal(output_base, outputs['tissue_class_map'][:len(output_base)])
+        assert_true(False)
+
+    # set up
+    infile, indir = setup_infile()
+    cwd = tempfile.mkdtemp()
+    os.chdir(cwd)
+    yield assert_not_equal, indir, cwd
+    out_basename = 'a_basename.nii.gz'
+
+    # run and test
+    opts = {'in_files': tmp_infile}
+    input_path, input_filename, input_ext = split_filename(tmp_infile)
+    _run_and_test(opts, os.path.join(input_path, input_filename))
+
+    opts['out_basename'] = out_basename
+    _run_and_test(opts, os.path.join(cwd, out_basename))
 
 @skipif(no_fsl)
 def setup_flirt():

--- a/nipype/interfaces/fsl/tests/test_preprocess.py
+++ b/nipype/interfaces/fsl/tests/test_preprocess.py
@@ -12,7 +12,7 @@ import shutil
 from nipype.testing import (assert_equal, assert_not_equal, assert_raises,
                             skipif)
 
-from nipype.utils.filemanip import split_filename
+from nipype.utils.filemanip import split_filename, filename_to_list
 from .. import preprocess as fsl
 from nipype.interfaces.fsl import Info
 from nipype.interfaces.base import File, TraitError, Undefined, isdefined
@@ -174,15 +174,18 @@ def test_fast_list_outputs():
     the cwd '''
     def _run_and_test(opts, output_base):
         outputs = fsl.FAST(**opts)._list_outputs()
-        assert_equal(output_base, outputs['tissue_class_map'][:len(output_base)])
-        assert_true(False)
+        for output in outputs.values():
+            filenames = filename_to_list(output)
+            if filenames is not None:
+                for filename in filenames:
+                    assert_equal(filename[:len(output_base)], output_base)
 
     # set up
     infile, indir = setup_infile()
     cwd = tempfile.mkdtemp()
     os.chdir(cwd)
     yield assert_not_equal, indir, cwd
-    out_basename = 'a_basename.nii.gz'
+    out_basename = 'a_basename'
 
     # run and test
     opts = {'in_files': tmp_infile}


### PR DESCRIPTION
NEW: `FAST._list_outputs()` was incorrectly listing output files in `cwd` when `out_basename` is not set. This PR fixes it.

OLD:The FAST interface is not outputting files into the correct directory when `out_basename` is not set. This solution feels hacky. I'm also concerned that this seemingly obvious bug hasn't been caught and fixed before now.

I'll fix up the tests once I have confidence this is the "right" solution.