### PR TITLE
changes slice_order type from Int to Float

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -47,11 +47,13 @@ class SliceTimingInputSpec(SPMCommandInputSpec):
                                           'calculated as TR-(TR/num_slices)'),
                                     mandatory=True)
     slice_order = traits.List(traits.Float(), field='so',
-                              desc=('1-based order or onset in which slices are '
-                                    'acquired'),
+                              desc=('1-based order or onset (in ms) in which '
+                                    'slices are acquired'),
                               mandatory=True)
     ref_slice = traits.Int(field='refslice',
-                           desc='1-based Number of the reference slice',
+                           desc='1-based Number of the reference slice or '
+                                'reference time point if slice_order is in '
+                                'onsets (ms)',
                            mandatory=True)
     out_prefix = traits.String('a', field='prefix', usedefault=True,
                                desc='slicetimed output prefix')

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -46,8 +46,8 @@ class SliceTimingInputSpec(SPMCommandInputSpec):
                                     desc=('time of volume acquisition. usually'
                                           'calculated as TR-(TR/num_slices)'),
                                     mandatory=True)
-    slice_order = traits.List(traits.Int(), field='so',
-                              desc=('1-based order in which slices are '
+    slice_order = traits.List(traits.Float(), field='so',
+                              desc=('1-based order or onset in which slices are '
                                     'acquired'),
                               mandatory=True)
     ref_slice = traits.Int(field='refslice',


### PR DESCRIPTION
With the newer SPM12, it is now possible to use "slice onsets" in milliseconds, instead of the good old simple slice order.

I've tested if there is any difference between slice_order [0 1 2 3,...] or [0.0 1.0 2.0 3.0,...] and with my test data there was none.

SPM12 and SPM8, both accept the float point approach, but SPM8 crashes if one tries to use actual onsets, i.e. [0.0 66.66 133.33, 200.0...].