### PR TITLE
potential fixes

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -218,7 +218,6 @@ class DistributedPluginBase(PluginBase):
         self.proc_done = None
         self.proc_pending = None
         self.max_jobs = np.inf
-        self.last_pending_task = []
         if plugin_args and 'max_jobs' in plugin_args:
             self.max_jobs = plugin_args['max_jobs']
 
@@ -236,14 +235,11 @@ class DistributedPluginBase(PluginBase):
         # setup polling - TODO: change to threaded model
         notrun = []
 
-        if self._config['execution']['poll_sleep_duration']:
-            self._timeout=float(self._config['execution']['poll_sleep_duration'])
-        
+
         while np.any(self.proc_done == False) | \
                 np.any(self.proc_pending == True):
             toappend = []
             # trigger callbacks for any pending results
-            num_jobs_to_begin_with=len(self.pending_tasks)
             while self.pending_tasks:
                 taskid, jobid = self.pending_tasks.pop()
                 try:

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -139,7 +139,7 @@ class MultiProcPlugin(DistributedPluginBase):
         self.processors = cpu_count()
         self.memory_gb = get_system_total_memory_gb()*0.9 # 90% of system memory
 
-        self._timout=2.0
+        self._timeout=2.0
         self._event = threading.Event()
 
 

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -11,6 +11,7 @@ from builtins import open
 
 # Import packages
 from multiprocessing import Process, Pool, cpu_count, pool
+import threading
 from traceback import format_exception
 import sys
 
@@ -20,14 +21,13 @@ import numpy as np
 from ... import logging, config
 from ...utils.misc import str2bool
 from ..engine import MapNode
-from ..plugins import semaphore_singleton
 from .base import (DistributedPluginBase, report_crash)
 
 # Init logger
 logger = logging.getLogger('workflow')
 
 # Run node
-def run_node(node, updatehash):
+def run_node(node, updatehash, taskid):
     """Function to execute node.run(), catch and log any errors and
     return the result dictionary
 
@@ -45,7 +45,7 @@ def run_node(node, updatehash):
     """
 
     # Init variables
-    result = dict(result=None, traceback=None)
+    result = dict(result=None, traceback=None, taskid=taskid)
 
     # Try and execute the node via node.run()
     try:
@@ -75,10 +75,6 @@ class NonDaemonPool(pool.Pool):
     """A process pool with non-daemon processes.
     """
     Process = NonDaemonProcess
-
-
-def release_lock(args):
-    semaphore_singleton.semaphore.release()
 
 
 # Get total system RAM
@@ -136,11 +132,17 @@ class MultiProcPlugin(DistributedPluginBase):
         # Init variables and instance attributes
         super(MultiProcPlugin, self).__init__(plugin_args=plugin_args)
         self._taskresult = {}
+        self._task_obj = {}
         self._taskid = 0
         non_daemon = True
         self.plugin_args = plugin_args
         self.processors = cpu_count()
         self.memory_gb = get_system_total_memory_gb()*0.9 # 90% of system memory
+
+        self._timout=2.0
+        self._event = threading.Event()
+
+
 
         # Check plugin args
         if self.plugin_args:
@@ -150,6 +152,9 @@ class MultiProcPlugin(DistributedPluginBase):
                 self.processors = self.plugin_args['n_procs']
             if 'memory_gb' in self.plugin_args:
                 self.memory_gb = self.plugin_args['memory_gb']
+
+        logger.debug("MultiProcPlugin starting %d threads in pool"%(self.processors))
+
         # Instantiate different thread pools for non-daemon processes
         if non_daemon:
             # run the execution using the non-daemon pool subclass
@@ -158,15 +163,26 @@ class MultiProcPlugin(DistributedPluginBase):
             self.pool = Pool(processes=self.processors)
 
     def _wait(self):
+        self._event.clear()
         if len(self.pending_tasks) > 0:
-            semaphore_singleton.semaphore.acquire()
+
+            if self._config['execution']['poll_sleep_duration']:
+                self._timeout = float(self._config['execution']['poll_sleep_duration'])
+
+            sig_received=self._event.wait(self._timeout)
+            if not sig_received:
+                logger.debug('MultiProcPlugin timeout before signal received. Deadlock averted??')
+
+    def _async_callback(self, args):
+        self._taskresult[args['taskid']]=args
+        self._event.set()
 
     def _get_result(self, taskid):
         if taskid not in self._taskresult:
-            raise RuntimeError('Multiproc task %d not found' % taskid)
-        if not self._taskresult[taskid].ready():
-            return None
-        return self._taskresult[taskid].get()
+            result=None
+        else:
+            result=self._taskresult[taskid]
+        return result
 
     def _report_crash(self, node, result=None):
         if result and result['traceback']:
@@ -178,7 +194,7 @@ class MultiProcPlugin(DistributedPluginBase):
             return report_crash(node)
 
     def _clear_task(self, taskid):
-        del self._taskresult[taskid]
+        del self._task_obj[taskid]
 
     def _submit_job(self, node, updatehash=False):
         self._taskid += 1
@@ -186,10 +202,10 @@ class MultiProcPlugin(DistributedPluginBase):
             if node.inputs.terminal_output == 'stream':
                 node.inputs.terminal_output = 'allatonce'
 
-        self._taskresult[self._taskid] = \
+        self._task_obj[self._taskid] = \
             self.pool.apply_async(run_node,
-                                  (node, updatehash),
-                                  callback=release_lock)
+                                  (node, updatehash, self._taskid),
+                                  callback=self._async_callback)
         return self._taskid
 
     def _send_procs_to_workers(self, updatehash=False, graph=None):
@@ -199,23 +215,29 @@ class MultiProcPlugin(DistributedPluginBase):
         executing_now = []
 
         # Check to see if a job is available
-        jobids = np.flatnonzero((self.proc_pending == True) & \
+        currently_running_jobids = np.flatnonzero((self.proc_pending == True) & \
                                 (self.depidx.sum(axis=0) == 0).__array__())
 
         # Check available system resources by summing all threads and memory used
         busy_memory_gb = 0
         busy_processors = 0
-        for jobid in jobids:
-            busy_memory_gb += self.procs[jobid]._interface.estimated_memory_gb
-            busy_processors += self.procs[jobid]._interface.num_threads
+        for jobid in currently_running_jobids:
+            if self.procs[jobid]._interface.estimated_memory_gb <= self.memory_gb and self.procs[jobid]._interface.num_threads <= self.processors:
+
+                busy_memory_gb += self.procs[jobid]._interface.estimated_memory_gb
+                busy_processors += self.procs[jobid]._interface.num_threads
+
+            else:
+                raise ValueError("Resources required by jobid %d (%f GB, %d threads) exceed what is available on the system (%f GB, %d threads)"%(self.procs[jobid].__interface.estimated_memory_gb,
+                    self.procs[jobid].__interface.num_threads,self.memory_gb,self.processors))
 
         free_memory_gb = self.memory_gb - busy_memory_gb
         free_processors = self.processors - busy_processors
 
         # Check all jobs without dependency not run
         jobids = np.flatnonzero((self.proc_done == False) & \
-                                (self.depidx.sum(axis=0) == 0).__array__())
-
+            (self.depidx.sum(axis=0) == 0).__array__())
+            
         # Sort jobs ready to run first by memory and then by number of threads
         # The most resource consuming jobs run first
         jobids = sorted(jobids,
@@ -228,6 +250,8 @@ class MultiProcPlugin(DistributedPluginBase):
 
         # While have enough memory and processors for first job
         # Submit first job on the list
+
+
         for jobid in jobids:
             if str2bool(config.get('execution', 'profile_runtime')):
                 logger.debug('Next Job: %d, memory (GB): %d, threads: %d' \
@@ -239,8 +263,8 @@ class MultiProcPlugin(DistributedPluginBase):
                self.procs[jobid]._interface.num_threads <= free_processors:
                 logger.info('Executing: %s ID: %d' %(self.procs[jobid]._id, jobid))
                 executing_now.append(self.procs[jobid])
-
                 if isinstance(self.procs[jobid], MapNode):
+
                     try:
                         num_subnodes = self.procs[jobid].num_subnodes()
                     except Exception:
@@ -299,7 +323,7 @@ class MultiProcPlugin(DistributedPluginBase):
                     self._remove_node_dirs()
 
                 else:
-                    logger.debug('submitting %s' % str(jobid))
+                    logger.debug('MultiProcPlugin submitting %s' % str(jobid))
                     tid = self._submit_job(deepcopy(self.procs[jobid]),
                                            updatehash=updatehash)
                     if tid is None:
@@ -308,4 +332,4 @@ class MultiProcPlugin(DistributedPluginBase):
                     else:
                         self.pending_tasks.insert(0, (tid, jobid))
             else:
-                break
+                break     

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -40,7 +40,7 @@ def test_run_multiproc():
     cur_dir = os.getcwd()
     temp_dir = mkdtemp(prefix='test_engine_')
     os.chdir(temp_dir)
-
+    global pipe
     pipe = pe.Workflow(name='pipe')
     mod1 = pe.Node(interface=TestInterface(), name='mod1')
     mod2 = pe.MapNode(interface=TestInterface(),
@@ -50,6 +50,7 @@ def test_run_multiproc():
     pipe.base_dir = os.getcwd()
     mod1.inputs.input1 = 1
     pipe.config['execution']['poll_sleep_duration'] = 2
+    global execgraph
     execgraph = pipe.run(plugin="MultiProc")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
     node = execgraph.nodes()[names.index('pipe.mod1')]
@@ -57,6 +58,8 @@ def test_run_multiproc():
     yield assert_equal, result, [1, 1]
     os.chdir(cur_dir)
     rmtree(temp_dir)
+    del pipe
+    del execgraph
 
 
 class InputSpecSingleNode(nib.TraitedSpec):
@@ -135,6 +138,7 @@ def test_no_more_memory_than_specified():
     my_logger.addHandler(handler)
 
     max_memory = 1
+    global pipe
     pipe = pe.Workflow(name='pipe')
     n1 = pe.Node(interface=TestInterfaceSingleNode(), name='n1')
     n2 = pe.Node(interface=TestInterfaceSingleNode(), name='n2')
@@ -182,6 +186,7 @@ def test_no_more_memory_than_specified():
           "using more threads than system has (threads is not specified by user)"
 
     os.remove(LOG_FILENAME)
+    del pipe
 
 # Disabled until https://github.com/nipy/nipype/issues/1692 is resolved
 @skipif(os.environ.get('TRAVIS_PYTHON_VERSION') == '2.7')
@@ -196,6 +201,7 @@ def test_no_more_threads_than_specified():
     my_logger.addHandler(handler)
 
     max_threads = 4
+    global pipe
     pipe = pe.Workflow(name='pipe')
     n1 = pe.Node(interface=TestInterfaceSingleNode(), name='n1')
     n2 = pe.Node(interface=TestInterfaceSingleNode(), name='n2')
@@ -239,3 +245,4 @@ def test_no_more_threads_than_specified():
           "using more memory than system has (memory is not specified by user)"
 
     os.remove(LOG_FILENAME)
+    del pipe

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -38,7 +38,7 @@ def test_run_multiproc():
     cur_dir = os.getcwd()
     temp_dir = mkdtemp(prefix='test_engine_')
     os.chdir(temp_dir)
-    global pipe
+
     pipe = pe.Workflow(name='pipe')
     mod1 = pe.Node(interface=TestInterface(), name='mod1')
     mod2 = pe.MapNode(interface=TestInterface(),
@@ -48,7 +48,7 @@ def test_run_multiproc():
     pipe.base_dir = os.getcwd()
     mod1.inputs.input1 = 1
     pipe.config['execution']['poll_sleep_duration'] = 2
-    global execgraph
+
     execgraph = pipe.run(plugin="MultiProc")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
     node = execgraph.nodes()[names.index('pipe.mod1')]
@@ -56,8 +56,6 @@ def test_run_multiproc():
     yield assert_equal, result, [1, 1]
     os.chdir(cur_dir)
     rmtree(temp_dir)
-    del pipe
-    del execgraph
 
 
 class InputSpecSingleNode(nib.TraitedSpec):
@@ -134,7 +132,6 @@ def test_no_more_memory_than_specified():
     my_logger.addHandler(handler)
 
     max_memory = 1
-    global pipe 
     pipe = pe.Workflow(name='pipe')
     n1 = pe.Node(interface=TestInterfaceSingleNode(), name='n1')
     n2 = pe.Node(interface=TestInterfaceSingleNode(), name='n2')
@@ -182,7 +179,6 @@ def test_no_more_memory_than_specified():
           "using more threads than system has (threads is not specified by user)"
 
     os.remove(LOG_FILENAME)
-    del pipe
 
 
 @skipif(nib.runtime_profile == False)
@@ -196,7 +192,6 @@ def test_no_more_threads_than_specified():
     my_logger.addHandler(handler)
 
     max_threads = 4
-    global pipe
     pipe = pe.Workflow(name='pipe')
     n1 = pe.Node(interface=TestInterfaceSingleNode(), name='n1')
     n2 = pe.Node(interface=TestInterfaceSingleNode(), name='n2')
@@ -240,4 +235,3 @@ def test_no_more_threads_than_specified():
           "using more memory than system has (memory is not specified by user)"
 
     os.remove(LOG_FILENAME)
-    del pipe

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -138,7 +138,7 @@ def test_no_more_memory_than_specified():
     my_logger.addHandler(handler)
 
     max_memory = 1
-    global pipe
+    global pipe 
     pipe = pe.Workflow(name='pipe')
     n1 = pe.Node(interface=TestInterfaceSingleNode(), name='n1')
     n2 = pe.Node(interface=TestInterfaceSingleNode(), name='n2')

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -34,8 +34,6 @@ class TestInterface(nib.BaseInterface):
         outputs['output1'] = [1, self.inputs.input1]
         return outputs
 
-# Disabled until https://github.com/nipy/nipype/issues/1692 is resolved
-@skipif(os.environ.get('TRAVIS_PYTHON_VERSION', '') == '2.7')
 def test_run_multiproc():
     cur_dir = os.getcwd()
     temp_dir = mkdtemp(prefix='test_engine_')
@@ -126,8 +124,6 @@ def find_metrics(nodes, last_node):
 
     return total_memory, total_threads
 
-# Disabled until https://github.com/nipy/nipype/issues/1692 is resolved
-@skipif(os.environ.get('TRAVIS_PYTHON_VERSION') == '2.7')
 def test_no_more_memory_than_specified():
     LOG_FILENAME = 'callback.log'
     my_logger = logging.getLogger('callback')
@@ -188,8 +184,7 @@ def test_no_more_memory_than_specified():
     os.remove(LOG_FILENAME)
     del pipe
 
-# Disabled until https://github.com/nipy/nipype/issues/1692 is resolved
-@skipif(os.environ.get('TRAVIS_PYTHON_VERSION') == '2.7')
+
 @skipif(nib.runtime_profile == False)
 def test_no_more_threads_than_specified():
     LOG_FILENAME = 'callback.log'


### PR DESCRIPTION
We have narrowed the problem down pretty well. The completion signal is being received from the threadpool worker process, but once the distributedplugin base class's run loop checks the return value of the node, it appears to have not completed. The loop then puts itself back to sleep, but since the signal has already been sent, it will never be woken up again. This appears to be some weird interaction within the threadpool and how it calls async jobs. We have simplified the implementation of the multiproc plugin to remove as many places were deadlocking can occur, and it still happens every now and then. Best we can tell this is an issue within the threadpool itself, that has been fixed in python 3 by replacing a mutex lock with an event. 

To fix the symptom, we have switched the scheduling semaphore with an event so that we can have a timeout in the wait. So no more deadlock.