### PR TITLE
more concise and flexible parameter passing, increased parametrization

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -41,7 +41,8 @@ class Level1DesignInputSpec(BaseInterfaceInputSpec):
         traits.Dict(traits.Enum(
             'dgamma'), traits.Dict(traits.Enum('derivs'), traits.Bool)),
         traits.Dict(traits.Enum('gamma'), traits.Dict(
-                    traits.Enum('derivs'), traits.Bool)),
+                    traits.Enum('derivs', 'gammasigma', 'gammadelay'))),
+        traits.Dict(traits.Enum('none'), traits.Dict()),
         traits.Dict(traits.Enum('none'), traits.Enum(None)),
         mandatory=True,
         desc=("name of basis function and options e.g., "
@@ -122,7 +123,7 @@ class Level1Design(BaseInterface):
         f.close()
 
     def _create_ev_files(
-        self, cwd, runinfo, runidx, usetd, contrasts,
+        self, cwd, runinfo, runidx, ev_parameters, contrasts,
             do_tempfilter, basis_key):
         """Creates EV files from condition and regressor information.
 
@@ -134,9 +135,9 @@ class Level1Design(BaseInterface):
                about events and other regressors.
            runidx  : int
                Index to run number
-           usetd   : int
-               Whether or not to use temporal derivatives for
-               conditions
+           ev_parameters : dict
+               A dictionary containing the model parameters for the
+               given design type.
            contrasts : list of lists
                Information on contrasts to be evaluated
         """
@@ -144,6 +145,15 @@ class Level1Design(BaseInterface):
         evname = []
         if basis_key == "dgamma":
             basis_key = "hrf"
+        elif basis_key == "gamma":
+            try:
+                 _ = ev_parameters['gammasigma']
+            except KeyError:
+                 ev_parameters['gammasigma'] = 3
+            try:
+                 _ = ev_parameters['gammadelay']
+            except KeyError:
+                 ev_parameters['gammadelay'] = 6
         ev_template = load_template('feat_ev_'+basis_key+'.tcl')
         ev_none = load_template('feat_ev_none.tcl')
         ev_ortho = load_template('feat_ev_ortho.tcl')
@@ -174,22 +184,18 @@ class Level1Design(BaseInterface):
                             evinfo.insert(j, [onset, cond['duration'][j], amp])
                         else:
                             evinfo.insert(j, [onset, cond['duration'][0], amp])
-                    if basis_key == "none":
-                        ev_txt += ev_template.substitute(
-                            ev_num=num_evs[0],
-                            ev_name=name,
-                            tempfilt_yn=do_tempfilter,
-                            cond_file=evfname)
-                    else:
-                        ev_txt += ev_template.substitute(
-                            ev_num=num_evs[0],
-                            ev_name=name,
-                            tempfilt_yn=do_tempfilter,
-                            temporalderiv=usetd,
-                            cond_file=evfname)
-                    if usetd:
+                    ev_parameters['ev_num'] = num_evs[0]
+                    ev_parameters['ev_name'] = name
+                    ev_parameters['tempfilt_yn'] = do_tempfilter
+                    ev_parameters['cond_file'] = evfname
+                    try:
+                        ev_parameters['temporalderiv'] = int(bool(ev_parameters.pop('derivs')))
+                    except KeyError:
+                        pass
+                    if ev_parameters['temporalderiv']:
                         evname.append(name + 'TD')
                         num_evs[1] += 1
+                    ev_txt += ev_template.substitute(ev_parameters)
                 elif field == 'regress':
                     evinfo = [[j] for j in cond['val']]
                     ev_txt += ev_none.substitute(ev_num=num_evs[0],
@@ -297,10 +303,8 @@ class Level1Design(BaseInterface):
         prewhiten = 0
         if isdefined(self.inputs.model_serial_correlations):
             prewhiten = int(self.inputs.model_serial_correlations)
-        usetd = 0
         basis_key = list(self.inputs.bases.keys())[0]
-        if basis_key in ['dgamma', 'gamma']:
-            usetd = int(self.inputs.bases[basis_key]['derivs'])
+        ev_parameters = dict(self.inputs.bases[basis_key])
         session_info = self._format_session_info(self.inputs.session_info)
         func_files = self._get_func_files(session_info)
         n_tcon = 0
@@ -316,7 +320,7 @@ class Level1Design(BaseInterface):
             do_tempfilter = 1
             if info['hpf'] == np.inf:
                 do_tempfilter = 0
-            num_evs, cond_txt = self._create_ev_files(cwd, info, i, usetd,
+            num_evs, cond_txt = self._create_ev_files(cwd, info, i, ev_parameters,
                                                       self.inputs.contrasts,
                                                       do_tempfilter, basis_key)
             nim = load(func_files[i])
@@ -348,10 +352,8 @@ class Level1Design(BaseInterface):
         cwd = os.getcwd()
         outputs['fsf_files'] = []
         outputs['ev_files'] = []
-        usetd = 0
         basis_key = list(self.inputs.bases.keys())[0]
-        if basis_key in ['dgamma', 'gamma']:
-            usetd = int(self.inputs.bases[basis_key]['derivs'])
+        ev_parameters = dict(self.inputs.bases[basis_key])
         for runno, runinfo in enumerate(
                 self._format_session_info(self.inputs.session_info)):
             outputs['fsf_files'].append(os.path.join(cwd, 'run%d.fsf' % runno))
@@ -365,7 +367,11 @@ class Level1Design(BaseInterface):
                         cwd, 'ev_%s_%d_%d.txt' % (name, runno,
                                                   len(evname)))
                     if field == 'cond':
-                        if usetd:
+                        try:
+                            ev_parameters['temporalderiv'] = int(bool(ev_parameters.pop('derivs')))
+                        except KeyError:
+                            pass
+                        if ev_parameters['temporalderiv']:
                             evname.append(name + 'TD')
                     outputs['ev_files'][runno].append(
                         os.path.join(cwd, evfname))

--- a/nipype/interfaces/fsl/tests/test_Level1Design_functions.py
+++ b/nipype/interfaces/fsl/tests/test_Level1Design_functions.py
@@ -10,12 +10,13 @@ def test_level1design():
                           'duration':[10, 10]}],regress=[])
     runidx = 0
     contrasts = Undefined
-    usetd = False
     do_tempfilter = False
+    ev_parameters = {"temporalderiv":False}
     for key, val in [('hrf', 3), ('dgamma', 3), ('gamma', 2), ('none', 0)]:
         output_num, output_txt = Level1Design._create_ev_files(l, os.getcwd(),
                                                                runinfo, runidx,
-                                                               usetd, contrasts,
+                                                               ev_parameters,
+                                                               contrasts,
                                                                do_tempfilter,
                                                                key)
         assert "set fmri(convolve1) {0}".format(val) in output_txt

--- a/nipype/interfaces/script_templates/feat_ev_gamma.tcl
+++ b/nipype/interfaces/script_templates/feat_ev_gamma.tcl
@@ -33,7 +33,7 @@ set fmri(deriv_yn$ev_num) $temporalderiv
 set fmri(custom$ev_num) "$cond_file"
 
 # Gamma sigma
-set fmri(gammasigma$ev_num) 3
+set fmri(gammasigma$ev_num) $gammasigma
 
 # Gamma delay
-set fmri(gammadelay$ev_num) 6
+set fmri(gammadelay$ev_num) $gammadelay


### PR DESCRIPTION
The FSL model parameter passing to substitute the variables in the template EV files is very clunky and difficult to extend. I have streamlined parameter passing by putting all the EV file variable parameters in a dict. Also, using this new and easier paremeterization system, I have added parameters for gammadelay and gammasigma.

After this PR more even parameters can be added very easily and without cluttering the code.