### PR TITLE
fix sge plugin __repr__

### DIFF
--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -52,7 +52,7 @@ class QJobInfo(object):
 
     def __repr__(self):
         return '{:<8d}{:12}{:<3d}{:20}{:8}{}'.format(
-            self._job_num, self._queue_state, self._job_slots,
+            self._job_num, self._job_queue_state, self._job_slots,
             time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(self._job_time)),
             self._job_queue_name, self._qsub_command_line)
 


### PR DESCRIPTION
attribute mistyped causing crashes:
```
AttributeError: 'QJobInfo' object has no attribute '_queue_state'
```