### PR TITLE
simplifying tests, removing some try/except blocks

### DIFF
--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -512,11 +512,16 @@ def test_node_hash(tmpdir):
     # create dummy distributed plugin class
     from nipype.pipeline.plugins.base import DistributedPluginBase
 
+    # create a custom exception 
+    class EngineTestException(Exception):
+        pass
+
     class RaiseError(DistributedPluginBase):
         def _submit_job(self, node, updatehash=False):
-            raise Exception('Submit called')
+            raise EngineTestException('Submit called')
 
-    with pytest.raises(Exception) as excinfo:
+    # check if a proper exception is raised
+    with pytest.raises(EngineTestException) as excinfo:
         w1.run(plugin=RaiseError())
     assert 'Submit called' == str(excinfo.value)        
 

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -646,14 +646,7 @@ def test_serial_input(tmpdir):
     assert n1.num_subnodes() == len(n1.inputs.in1)
 
     # test running the workflow on default conditions
-    error_raised = False
-    try:
-        w1.run(plugin='MultiProc')
-    except Exception as e:
-        from nipype.pipeline.engine.base import logger
-        logger.info('Exception: %s' % str(e))
-        error_raised = True
-    assert not error_raised
+    w1.run(plugin='MultiProc')
 
     # test output of num_subnodes method when serial is True
     n1._serial = True

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -43,7 +43,7 @@ class EngineTestInterface(nib.BaseInterface):
 
 
 def test_init():
-    with pytest.raises(Exception): pe.Workflow()
+    with pytest.raises(TypeError): pe.Workflow()
     pipe = pe.Workflow(name='pipe')
     assert type(pipe._graph) == nx.DiGraph
 
@@ -326,11 +326,16 @@ def test_doubleconnect():
     flow1 = pe.Workflow(name='test')
     flow1.connect(a, 'a', b, 'a')
     x = lambda: flow1.connect(a, 'b', b, 'a')
-    with pytest.raises(Exception): x()
+    with pytest.raises(Exception) as excinfo: 
+        x()
+    assert "Trying to connect" in str(excinfo.value)
+
     c = pe.Node(IdentityInterface(fields=['a', 'b']), name='c')
     flow1 = pe.Workflow(name='test2')
     x = lambda: flow1.connect([(a, c, [('b', 'b')]), (b, c, [('a', 'b')])])
-    with pytest.raises(Exception): x()
+    with pytest.raises(Exception) as excinfo: 
+        x()
+    assert "Trying to connect" in str(excinfo.value)
 
 
 '''
@@ -476,8 +481,9 @@ def test_mapnode_nested(tmpdir):
                  name='n1')
     n2.inputs.in1 = [[1, [2]], 3, [4, 5]]
 
-    with pytest.raises(Exception): n2.run()
-
+    with pytest.raises(Exception) as excinfo: 
+        n2.run()
+    assert "can only concatenate list" in str(excinfo.value)
 
 
 def test_node_hash(tmpdir):


### PR DESCRIPTION
* I left the try/except blocks in `test_node_init` and  `test_io_subclass`: it looks like the tests should fail only for some exceptions, and others are ok

* I removed also `logger.info('Exception: %s' % str(e))` parts, most other test don't have it anyway. I can bring it back if needed. 