### PR TITLE
added support for orthogonalization

### DIFF
--- a/nipype/interfaces/fsl/tests/test_Level1Design_functions.py
+++ b/nipype/interfaces/fsl/tests/test_Level1Design_functions.py
@@ -11,11 +11,13 @@ def test_level1design():
     runidx = 0
     contrasts = Undefined
     do_tempfilter = False
+    orthogonalization = {}
     ev_parameters = {"temporalderiv":False}
     for key, val in [('hrf', 3), ('dgamma', 3), ('gamma', 2), ('none', 0)]:
         output_num, output_txt = Level1Design._create_ev_files(l, os.getcwd(),
                                                                runinfo, runidx,
                                                                ev_parameters,
+                                                               orthogonalization,
                                                                contrasts,
                                                                do_tempfilter,
                                                                key)

--- a/nipype/interfaces/script_templates/feat_ev_ortho.tcl
+++ b/nipype/interfaces/script_templates/feat_ev_ortho.tcl
@@ -1,2 +1,2 @@
 # Orthogonalise EV $c0 wrt EV $c1
-set fmri(ortho$c0.$c1) 0
+set fmri(ortho$c0.$c1) $orthogonal


### PR DESCRIPTION
Currently FEAT's orthogonalization function is entirely unaccessible via nipype.
This PR makes it accessible via a dict.