### PR TITLE
Cast DVARS float outputs to avoid memmap error

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -127,9 +127,9 @@ Bradley L. and Petersen, Steven E.},
         dvars = compute_dvars(self.inputs.in_file, self.inputs.in_mask,
                               remove_zerovariance=self.inputs.remove_zerovariance)
 
-        self._results['avg_std'] = dvars[0].mean()
-        self._results['avg_nstd'] = dvars[1].mean()
-        self._results['avg_vxstd'] = dvars[2].mean()
+        self._results['avg_std'] = float(dvars[0].mean())
+        self._results['avg_nstd'] = float(dvars[1].mean())
+        self._results['avg_vxstd'] = float(dvars[2].mean())
 
         tr = None
         if isdefined(self.inputs.series_tr):


### PR DESCRIPTION
When the input files are not compressed, numpy wraps memmap around the
dtype. This makes the traits.Float validation to fail.

An more robust way would be overloading traits.Float to validate also
these memmap objects. But this is probably overkilling the problem.

For now, this casting is the easiest and safest solution.