### PR TITLE
DOC: update docs to reflect default hash_method value

### DIFF
--- a/doc/users/config_file.rst
+++ b/doc/users/config_file.rst
@@ -55,7 +55,7 @@ Execution
 	Should the input files be checked for changes using their content (slow, but
 	100% accurate) or just their size and modification date (fast, but
 	potentially prone to errors)? (possible values: ``content`` and
-	``timestamp``; default value: ``content``)
+	``timestamp``; default value: ``timestamp``)
 
 *keep_inputs*
     Ensures that all inputs that are created in the nodes working directory are


### PR DESCRIPTION
Looks like hash_method has defaulted to ``timestamp`` for a while:
https://github.com/nipy/nipype/blob/master/nipype/utils/config.py

Updating the config documentation.