### PR TITLE
tst: not defining specific icu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   conda config --add channels conda-forge &&
   conda update --yes conda &&
   conda update --all -y python=$TRAVIS_PYTHON_VERSION &&
-  conda install -y nipype icu==56.1 &&
+  conda install -y nipype icu &&
   rm -r /home/travis/miniconda/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/nipype* &&
   pip install -r requirements.txt &&
   pip install -e .[$NIPYPE_EXTRAS]; }

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1273,7 +1273,7 @@ def split_rois(in_file, mask=None, roishape=None):
         if fill > 0:
             droi = np.vstack((droi, np.zeros((int(fill), int(nvols)), dtype=np.float32)))
             partialmsk = np.ones((roisize,), dtype=np.uint8)
-            partialmsk[-fill:] = 0
+            partialmsk[-int(fill):] = 0
             partname = op.abspath('partialmask.nii.gz')
             nb.Nifti1Image(partialmsk.reshape(roishape), None,
                            None).to_filename(partname)

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1271,7 +1271,7 @@ def split_rois(in_file, mask=None, roishape=None):
         np.savez(iname, (nzels[0][first:last],))
 
         if fill > 0:
-            droi = np.vstack((droi, np.zeros((fill, nvols), dtype=np.float32)))
+            droi = np.vstack((droi, np.zeros(int(fill, nvols), dtype=np.float32)))
             partialmsk = np.ones((roisize,), dtype=np.uint8)
             partialmsk[-fill:] = 0
             partname = op.abspath('partialmask.nii.gz')

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1271,7 +1271,7 @@ def split_rois(in_file, mask=None, roishape=None):
         np.savez(iname, (nzels[0][first:last],))
 
         if fill > 0:
-            droi = np.vstack((droi, np.zeros(int(fill, nvols), dtype=np.float32)))
+            droi = np.vstack((droi, np.zeros((int(fill), int(nvols)), dtype=np.float32)))
             partialmsk = np.ones((roisize,), dtype=np.uint8)
             partialmsk[-fill:] = 0
             partname = op.abspath('partialmask.nii.gz')

--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -655,12 +655,12 @@ class SpecifySparseModel(SpecifyModel):
             hrf = spm_hrf(dt * 1e-3)
         reg_scale = 1.0
         if self.inputs.scale_regressors:
-            boxcar = np.zeros((50.0 * 1e3 / dt))
+            boxcar = np.zeros(int(50.0 * 1e3 / dt))
             if self.inputs.stimuli_as_impulses:
-                boxcar[1.0 * 1e3 / dt] = 1.0
+                boxcar[int(1.0 * 1e3 / dt)] = 1.0
                 reg_scale = float(TA / dt)
             else:
-                boxcar[(1.0 * 1e3 / dt):(2.0 * 1e3 / dt)] = 1.0
+                boxcar[int(1.0 * 1e3 / dt):int(2.0 * 1e3 / dt)] = 1.0
             if isdefined(self.inputs.model_hrf) and self.inputs.model_hrf:
                 response = np.convolve(boxcar, hrf)
                 reg_scale = 1.0 / response.max()


### PR DESCRIPTION
* defaults to latest icu (58.1)
* removes non-integers from array slicing/initializing in `algorithms/misc` and `algorithms/modelgen` , which now throw hard errors