### PR TITLE
ENH: Enable new BBRegister init options for FSv6+

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -942,6 +942,12 @@ class BBRegisterInputSpec(FSTraitedSpec):
                                     desc='output warped sourcefile either True or filename')
 
 
+class BBRegisterInputSpec6(BBRegisterInputSpec):
+    init = traits.Enum('coreg', 'rr', 'spm', 'fsl', 'header', 'best', argstr='--init-%s',
+                       usedefault=True, xor=['init_reg_file'],
+                       desc='initialize registration with mri_coreg, spm, fsl, or header')
+
+
 class BBRegisterOutputSpec(TraitedSpec):
     out_reg_file = File(exists=True, desc='Output registration file')
     out_fsl_file = File(desc='Output FLIRT-style registration file')
@@ -968,7 +974,10 @@ class BBRegister(FSCommand):
     """
 
     _cmd = 'bbregister'
-    input_spec = BBRegisterInputSpec
+    if LooseVersion(FSVersion) < LooseVersion("6.0.0"):
+        input_spec = BBRegisterInputSpec
+    else:
+        input_spec = BBRegisterInputSpec6
     output_spec = BBRegisterOutputSpec
 
     def _list_outputs(self):


### PR DESCRIPTION
`bbregister` has new initialization options, including an implicit default of using `mri_coreg`, as of version 6.0.0.

This change updates the `init` trait if FreeSurfer is version 6 or newer, following the example from [FSL](https://github.com/nipy/nipype/blob/f5ed4d68fc922fa3eea6a43036b09f79bfa94acb/nipype/interfaces/fsl/model.py#L589).

Is there a good way to test this?