### PR TITLE
Unset default init for BBRegister in FS 6+

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -944,7 +944,7 @@ class BBRegisterInputSpec(FSTraitedSpec):
 
 class BBRegisterInputSpec6(BBRegisterInputSpec):
     init = traits.Enum('coreg', 'rr', 'spm', 'fsl', 'header', 'best', argstr='--init-%s',
-                       usedefault=True, xor=['init_reg_file'],
+                       xor=['init_reg_file'],
                        desc='initialize registration with mri_coreg, spm, fsl, or header')
 
 
@@ -974,7 +974,7 @@ class BBRegister(FSCommand):
     """
 
     _cmd = 'bbregister'
-    if LooseVersion(FSVersion) < LooseVersion("6.0.0"):
+    if FSVersion and LooseVersion(FSVersion) < LooseVersion("6.0.0"):
         input_spec = BBRegisterInputSpec
     else:
         input_spec = BBRegisterInputSpec6

--- a/nipype/interfaces/freesurfer/tests/test_auto_BBRegister.py
+++ b/nipype/interfaces/freesurfer/tests/test_auto_BBRegister.py
@@ -17,7 +17,6 @@ def test_BBRegister_inputs():
     usedefault=True,
     ),
     init=dict(argstr='--init-%s',
-    mandatory=True,
     xor=[u'init_reg_file'],
     ),
     init_reg_file=dict(argstr='--init-reg %s',


### PR DESCRIPTION
Instead of replicating FS default of `--init-coreg`, set `init` as non-mandatory.

Follow-up to #1811.