### PR TITLE
removed obligatory xvfbwrapper dependency

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -164,6 +164,7 @@ EXTRA_REQUIRES = {
     'fmri': ['nitime', 'nilearn', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil'],
     'duecredit': ['duecredit'],
+    'xvfbwrapper': ['xvfbwrapper'],
     # 'mesh': ['mayavi']  # Enable when it works
 }
 
@@ -171,4 +172,3 @@ EXTRA_REQUIRES = {
 EXTRA_REQUIRES['all'] = [val for _, val in list(EXTRA_REQUIRES.items())]
 
 STATUS = 'stable'
-

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -143,7 +143,6 @@ REQUIRES = [
     'simplejson>=%s' % SIMPLEJSON_MIN_VERSION,
     'prov>=%s' % PROV_MIN_VERSION,
     'click>=%s' % CLICK_MIN_VERSION,
-    'xvfbwrapper',
     'funcsigs',
     'configparser',
     'pytest>=%s' % PYTEST_MIN_VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ future>=0.15.2
 simplejson>=3.8.0
 prov>=1.4.0
 click>=6.6.0
-xvfbwrapper
 psutil
 funcsigs
 configparser

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -9,7 +9,6 @@ pytest-cov
 future>=0.15.2
 simplejson>=3.8.0
 prov>=1.4.0
-xvfbwrapper
 psutil
 funcsigs
 configparser


### PR DESCRIPTION
On an otherwise headless server, xvfbwrapper pulls in a significant stack totalling at least 42 dependencies:

```
[ebuild  N     ] sys-libs/mtdev-1.1.5::gentoo  USE="-static-libs" 268 KiB
[ebuild  N     ] media-libs/libepoxy-1.4.0::gentoo  USE="{-test}" ABI_X86="(64) -32 (-x32)" 301 KiB
[ebuild  N     ] x11-proto/fontsproto-2.1.3::gentoo  USE="-doc" 151 KiB
[ebuild  N     ] x11-proto/xineramaproto-1.2.1-r1::gentoo  ABI_X86="(64) -32 (-x32)" 94 KiB
[ebuild  N     ] x11-proto/randrproto-1.5.0::gentoo  ABI_X86="(64) -32 (-x32)" 139 KiB
[ebuild  N     ] x11-proto/videoproto-2.3.3::gentoo  ABI_X86="(64) -32 (-x32)" 119 KiB
[ebuild  N     ] x11-libs/libxkbfile-1.0.9-r1::gentoo  USE="-static-libs" ABI_X86="(64) -32 (-x32)" 340 KiB
[ebuild  N     ] x11-apps/xauth-1.0.10::gentoo  USE="ipv6 {-test}" 159 KiB
[ebuild  N     ] x11-proto/resourceproto-1.2.0::gentoo  101 KiB
[ebuild  N     ] x11-proto/scrnsaverproto-1.2.2-r1::gentoo  USE="-doc" ABI_X86="(64) -32 (-x32)" 117 KiB
[ebuild  N     ] x11-proto/trapproto-3.4.3::gentoo  48 KiB
[ebuild  N     ] x11-proto/compositeproto-0.4.2-r1::gentoo  ABI_X86="(64) -32 (-x32)" 99 KiB
[ebuild  N     ] x11-proto/bigreqsproto-1.1.2::gentoo  USE="-doc" 111 KiB
[ebuild  N     ] x11-proto/xf86dgaproto-2.1-r2::gentoo  ABI_X86="(64) -32 (-x32)" 84 KiB
[ebuild  N     ] x11-proto/xf86rushproto-1.1.2-r1::gentoo  37 KiB
[ebuild  N     ] x11-apps/rgb-1.0.6::gentoo  136 KiB
[ebuild  N     ] x11-misc/xkeyboard-config-2.20::gentoo  956 KiB
[ebuild  N     ] x11-proto/recordproto-1.14.2-r1::gentoo  USE="-doc" ABI_X86="(64) -32 (-x32)" 121 KiB
[ebuild  N     ] x11-proto/xcmiscproto-1.2.2::gentoo  USE="-doc" 110 KiB
[ebuild  N     ] x11-apps/iceauth-1.0.7::gentoo  133 KiB
[ebuild  N     ] dev-libs/libevdev-1.5.6::gentoo  USE="-static-libs" ABI_X86="(64) -32 (-x32)" 398 KiB
[ebuild  N     ] x11-apps/xrdb-1.1.0::gentoo  135 KiB
[ebuild  N     ] x11-libs/libfontenc-1.1.3::gentoo  USE="-static-libs" 295 KiB
[ebuild  N     ] x11-libs/libXfont2-2.0.1::gentoo  USE="bzip2 ipv6 -doc -static-libs -truetype" 462 KiB
[ebuild  N     ] x11-apps/xkbcomp-1.3.1::gentoo  242 KiB
[ebuild  N     ] x11-apps/xinit-1.3.4-r1::gentoo  USE="minimal -systemd" 162 KiB
[ebuild  N     ] x11-libs/libXScrnSaver-1.2.2-r1::gentoo  USE="-static-libs" ABI_X86="(64) -32 (-x32)" 284 KiB
[ebuild     UD ] sys-fs/udev-230-r1::gentoo [232-r2::gentoo] USE="acl kmod (-selinux) -static-libs%" ABI_X86="($4) -32 (-x32)" 4'188 KiB
[ebuild  N     ] dev-libs/libinput-1.6.1:0/10::gentoo  USE="{-test}" INPUT_DEVICES="-wacom" 906 KiB
[ebuild  N     ] x11-base/xorg-server-1.19.1:0/1.19.1::gentoo  USE="glamor ipv6 suid udev xorg xvfb -debug -dmx
-doc -kdrive -libressl -minimal (-selinux) -static-libs -systemd -tslib -unwind -wayland -xephyr -xnest" 5'901 $iB
[ebuild  N     ] x11-base/xorg-drivers-1.19::gentoo  INPUT_DEVICES="keyboard libinput mouse -acecad -aiptek -el$graphics -evdev -fpit -hyperpen -joystick -mutouch -penmount -synaptics -tslib -vmmouse -void -wacom" VIDEO_CAR$S="amdgpu dummy fbdev intel nouveau radeon radeonsi vesa -apm -ark -ast -chips -cirrus -epson (-fglrx) (-freedr$no) (-geode) -glint -i128 (-i740) -i965 -mach64 -mga -neomagic (-newport) -nv -nvidia (-omap) (-omapfb) -qxl -r$28 -rendition -s3 -s3virge -savage -siliconmotion -sis -sisusb (-sunbw2) (-suncg14) (-suncg3) (-suncg6) (-sunff$) (-sunleo) (-suntcx) -tdfx (-tegra) -tga -trident -tseng -via -virtualbox -vmware (-voodoo)" 0 KiB
[ebuild  N     ] x11-drivers/xf86-video-dummy-0.3.8::gentoo  USE="-dga" 296 KiB
[ebuild  N     ] x11-drivers/xf86-input-libinput-0.24.0::gentoo  359 KiB
[ebuild  N     ] x11-drivers/xf86-video-fbdev-0.4.4::gentoo  287 KiB
[ebuild  N     ] x11-drivers/xf86-video-intel-2.99.917_p20161206::gentoo  USE="dri sna udev -debug -dri3 -uxa -$vmc" 924 KiB
[ebuild  N     ] x11-drivers/xf86-video-vesa-2.3.4::gentoo  279 KiB
[ebuild  N     ] x11-drivers/xf86-input-mouse-1.9.2::gentoo  369 KiB
[ebuild  N     ] x11-drivers/xf86-video-nouveau-1.0.13::gentoo  603 KiB
[ebuild  N     ] x11-drivers/xf86-video-amdgpu-1.2.0::gentoo  USE="-glamor" 380 KiB
[ebuild  N     ] x11-drivers/xf86-input-keyboard-1.9.0::gentoo  334 KiB
[ebuild  N     ] x11-drivers/xf86-video-ati-7.8.0::gentoo  USE="glamor -udev" 826 KiB
[ebuild  N     ] dev-python/xvfbwrapper-0.2.8::gentoo  USE="{-test}" PYTHON_TARGETS="python2_7 python3_4 -pypy"
5 KiB
```

A number of these packages might be nontrivial to handle depending on how and whether there is any video support/emulation on the machine. This is not good if we want to be lightweight and well suited for compact reproducible data analysis environments.

The only xvfbwrapper import is this:

```
nipype/interfaces/base.py
1014-    def _run_wrapper(self, runtime):
1015-        sysdisplay = os.getenv('DISPLAY')
1016-        if self._redirect_x:
1017-            try:
1018:                from xvfbwrapper import Xvfb
```

I don't have a quantitative estimate, but only very few interfaces actually use `_redirect_x`. Similarly to FSL, SPM, AFNI, and many other dependencies, xvfbwrapper is thus:

* nontrivial to build and carries numerous dependencies of its own
* not needed by very many users

Accordingly, I think it should be treated similarly to these packages and not list it as a mandatory dependency.