### PR TITLE
FIX: Import NUMPY_MMAP inside functions

### DIFF
--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -16,7 +16,6 @@ import numpy as np
 from ... import logging
 from ..base import (traits, TraitedSpec, File, isdefined)
 from .base import DipyBaseInterface
-from ...utils import NUMPY_MMAP
 
 IFLOGGER = logging.getLogger('interface')
 
@@ -180,6 +179,7 @@ def resample_proxy(in_file, order=3, new_zooms=None, out_file=None):
     Performs regridding of an image to set isotropic voxel sizes using dipy.
     """
     from dipy.align.reslice import reslice
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -223,6 +223,7 @@ def nlmeans_proxy(in_file, settings,
     from dipy.denoise.nlmeans import nlmeans
     from scipy.ndimage.morphology import binary_erosion
     from scipy import ndimage
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))

--- a/nipype/workflows/dmri/dipy/denoise.py
+++ b/nipype/workflows/dmri/dipy/denoise.py
@@ -4,7 +4,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
 from builtins import range
-from nipype.utils import NUMPY_MMAP
 from ....pipeline import engine as pe
 from ....interfaces import utility as niu
 from ....interfaces import dipy
@@ -57,6 +56,7 @@ def csf_mask(in_file, in_mask, out_file=None):
     from scipy.ndimage import binary_erosion, binary_opening, label
     import scipy.ndimage as nd
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_file))
@@ -100,6 +100,7 @@ def bg_mask(in_file, in_mask, out_file=None):
     from scipy.ndimage import binary_dilation
     import scipy.ndimage as nd
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_file))

--- a/nipype/workflows/dmri/fsl/epi.py
+++ b/nipype/workflows/dmri/fsl/epi.py
@@ -5,7 +5,6 @@ from builtins import open, str
 
 import warnings
 
-from nipype.utils import NUMPY_MMAP
 from ....pipeline import engine as pe
 from ....interfaces import utility as niu
 from ....interfaces import fsl as fsl
@@ -722,6 +721,7 @@ def _prepare_phasediff(in_file):
     import nibabel as nb
     import os
     import numpy as np
+    from nipype.utils import NUMPY_MMAP
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     max_diff = np.max(img.get_data().reshape(-1))
     min_diff = np.min(img.get_data().reshape(-1))
@@ -741,6 +741,7 @@ def _dilate_mask(in_file, iterations=4):
     import nibabel as nb
     import scipy.ndimage as ndimage
     import os
+    from nipype.utils import NUMPY_MMAP
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     img._data = ndimage.binary_dilation(img.get_data(), iterations=iterations)
 
@@ -756,6 +757,7 @@ def _fill_phase(in_file):
     import nibabel as nb
     import os
     import numpy as np
+    from nipype.utils import NUMPY_MMAP
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     dumb_img = nb.Nifti1Image(np.zeros(img.shape), img.affine, img.header)
     out_nii = nb.funcs.concat_images((img, dumb_img))
@@ -772,6 +774,7 @@ def _vsm_remove_mean(in_file, mask_file, in_unwarped):
     import os
     import numpy as np
     import numpy.ma as ma
+    from nipype.utils import NUMPY_MMAP
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     msk = nb.load(mask_file, mmap=NUMPY_MMAP).get_data()
     img_data = img.get_data()
@@ -794,6 +797,7 @@ def _ms2sec(val):
 def _split_dwi(in_file):
     import nibabel as nb
     import os
+    from nipype.utils import NUMPY_MMAP
     out_files = []
     frames = nb.funcs.four_to_three(nb.load(in_file, mmap=NUMPY_MMAP))
     name, fext = os.path.splitext(os.path.basename(in_file))

--- a/nipype/workflows/dmri/fsl/tbss.py
+++ b/nipype/workflows/dmri/fsl/tbss.py
@@ -5,7 +5,6 @@
 import os
 from warnings import warn
 
-from nipype.utils import NUMPY_MMAP
 from ....pipeline import engine as pe
 from ....interfaces import utility as util
 from ....interfaces import fsl as fsl
@@ -13,6 +12,7 @@ from ....interfaces import fsl as fsl
 
 def tbss1_op_string(in_files):
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
     op_strings = []
     for infile in in_files:
         img = nb.load(infile, mmap=NUMPY_MMAP)

--- a/nipype/workflows/dmri/fsl/utils.py
+++ b/nipype/workflows/dmri/fsl/utils.py
@@ -6,8 +6,6 @@
 from __future__ import print_function, division, unicode_literals, absolute_import
 from builtins import zip, next, range, str
 
-from nipype.utils import NUMPY_MMAP
-
 from ....pipeline import engine as pe
 from ....interfaces import utility as niu
 from ....interfaces import fsl
@@ -209,6 +207,7 @@ def extract_bval(in_dwi, in_bval, b=0, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_dwi))
@@ -244,6 +243,7 @@ def hmc_split(in_file, in_bval, ref_num=0, lowbval=5.0):
     import nibabel as nb
     import os.path as op
     from nipype.interfaces.base import isdefined
+    from nipype.utils import NUMPY_MMAP
 
     im = nb.load(in_file, mmap=NUMPY_MMAP)
     data = im.get_data()
@@ -288,6 +288,7 @@ def remove_comp(in_file, in_bval, volid=0, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_file))
@@ -337,6 +338,7 @@ def recompose_dwi(in_dwi, in_bval, in_corrected, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_dwi))
@@ -397,6 +399,7 @@ def time_avg(in_file, index=[0], out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_file))
@@ -444,6 +447,7 @@ def b0_average(in_dwi, in_bval, max_b=10.0, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, ext = op.splitext(op.basename(in_dwi))
@@ -623,6 +627,7 @@ def rads2radsec(in_file, delta_te, out_file=None):
     import nibabel as nb
     import os.path as op
     import math
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -644,6 +649,7 @@ def demean_image(in_file, in_mask=None, out_file=None):
     import nibabel as nb
     import os.path as op
     import math
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -674,6 +680,7 @@ def add_empty_vol(in_file, out_file=None):
     import os.path as op
     import numpy as np
     import math
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -696,6 +703,7 @@ def reorient_bvecs(in_dwi, old_dwi, in_bvec):
     import os
     import numpy as np
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
 
     name, fext = os.path.splitext(os.path.basename(in_bvec))
     if fext == '.gz':
@@ -721,6 +729,7 @@ def copy_hdr(in_file, in_file_hdr, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -744,6 +753,7 @@ def enhance(in_file, clip_limit=0.010, in_mask=None, out_file=None):
     import nibabel as nb
     import os.path as op
     from skimage import exposure, img_as_int
+    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))

--- a/nipype/workflows/misc/utils.py
+++ b/nipype/workflows/misc/utils.py
@@ -4,11 +4,11 @@
 from __future__ import print_function, division, unicode_literals, absolute_import
 
 from builtins import map, range
-from nipype.utils import NUMPY_MMAP
 
 
 def get_vox_dims(volume):
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume, mmap=NUMPY_MMAP)
@@ -19,6 +19,7 @@ def get_vox_dims(volume):
 
 def get_data_dims(volume):
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
     if isinstance(volume, list):
         volume = volume[0]
     nii = nb.load(volume, mmap=NUMPY_MMAP)
@@ -29,6 +30,7 @@ def get_data_dims(volume):
 
 def get_affine(volume):
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
     nii = nb.load(volume, mmap=NUMPY_MMAP)
     return nii.affine
 
@@ -50,6 +52,7 @@ def select_aparc_annot(list_of_files):
 def region_list_from_volume(in_file):
     import nibabel as nb
     import numpy as np
+    from nipype.utils import NUMPY_MMAP
     segmentation = nb.load(in_file, mmap=NUMPY_MMAP)
     segmentationdata = segmentation.get_data()
     rois = np.unique(segmentationdata)


### PR DESCRIPTION
Follow-up to #1796. Some imports were at the file level when they should have been at the function level. My criterion for moving was whether there are other function-local imports.

Addresses issue discovered in poldracklab/fmriprep#362 (and poldracklab/fmriprep#363).