### PR TITLE
FIX: AntsJointFusion unicode command line formatting

### DIFF
--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -1129,11 +1129,28 @@ ants_joint_fusion_posterior_%d.nii.gz, ants_joint_fusion_voting_weight_%d.nii.gz
             retval = ''
             if not isdefined(self.inputs.out_label_fusion):
                 retval = '-o {0}'.format(self.inputs.out_intensity_fusion_name_format)
+        elif opt == 'atlas_image':
+            atlas_image_cmd=" ".join(
+                [ '-g [{0}]'.format(",".join(
+                    fn for fn in ai) ) for ai in self.inputs.atlas_image]
+            )
+            retval = atlas_image_cmd
+        elif opt == 'target_image':
+            target_image_cmd=" ".join(
+                [ '-t [{0}]'.format(",".join(
+                    fn for fn in ai) ) for ai in self.inputs.target_image]
+            )
+            retval = target_image_cmd
+        elif opt == 'atlas_segmentation_image':
+            assert len(val) == len(self.inputs.atlas_image), "Number of specified " \
+                "segmentations should be identical to the number of atlas image " \
+                "sets {0}!={1}".format(len(val), len(self.inputs.atlas_image))
+            atlas_segmentation_image_cmd=" ".join(
+                [ '-t [{0}]'.format( fn ) for fn in self.inputs.atlas_segmentation_image ]
+            )
+            retval = atlas_segmentation_image_cmd
         else:
-            if opt == 'atlas_segmentation_image':
-                assert len(val) == len(self.inputs.atlas_image), "Number of specified " \
-                    "segmentations should be identical to the number of atlas image " \
-                    "sets {0}!={1}".format(len(val), len(self.inputs.atlas_image))
+
             return super(ANTSCommand, self)._format_arg(opt, spec, val)
         return retval
 


### PR DESCRIPTION
When strings are formatted in unicode, then the format
of the AntsJointFusion -g, -t flags is not the same
as the python string representations of lists.  These
flags need to be unpacked one-by-one and a new string
representation needs to be provided on the command line.