### PR TITLE
Estimated transform files in spm realign output directory for 4D files

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -30,7 +30,7 @@ fmlogger = logging.getLogger("filemanip")
 
 
 related_filetype_sets = [
-    ('.hdr', '.img', '.mat'),
+    ('.hdr', '.img', '.mat', '.nii'),
     ('.BRIK', '.HEAD'),
 ]
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -30,7 +30,8 @@ fmlogger = logging.getLogger("filemanip")
 
 
 related_filetype_sets = [
-    ('.hdr', '.img', '.mat', '.nii'),
+    ('.hdr', '.img', '.mat'),
+    ('.nii', '.mat'),
     ('.BRIK', '.HEAD'),
 ]
 

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -324,7 +324,7 @@ def test_json():
         ('/path/test.hdr',  3, ['/path/test.hdr', '/path/test.img', '/path/test.mat']),
         ('/path/test.BRIK', 2, ['/path/test.BRIK', '/path/test.HEAD']),
         ('/path/test.HEAD', 2, ['/path/test.BRIK', '/path/test.HEAD']),
-        ('/path/foo.nii',   1, [])
+        ('/path/foo.nii',   2, ['/path/foo.nii', '/path/foo.mat'])
         ])
 def test_related_files(file, length, expected_files):
     related_files = get_related_files(file)


### PR DESCRIPTION
Hello,

I'm working with 4D files and SPM and I didn't find a way to copy the header files generated by spm realign into the output folder of my workflow.

Also, I found that when these header files are not in the working directory of another node (eg, normalization), then the results of Nipype are different from those when the same workflow is executed in SPM Matlab. 

I hope these modifications are useful.

Cheers,
Jaime