### PR TITLE
[RTM] Support GIFTI outputs in SampleToSurface

### DIFF
--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -363,7 +363,7 @@ class SurfaceTransformInputSpec(FSTraitedSpec):
     source_type = traits.Enum(filetypes, argstr='--sfmt %s',
                               requires=['source_file'],
                               desc="source file format")
-    target_type = traits.Enum(filetypes, argstr='--tfmt %s',
+    target_type = traits.Enum(filetypes + implicit_filetypes, argstr='--tfmt %s',
                               desc="output format")
     reshape = traits.Bool(argstr="--reshape",
                           desc="reshape output surface to conform with Nifti")
@@ -399,6 +399,11 @@ class SurfaceTransform(FSCommand):
     _cmd = "mri_surf2surf"
     input_spec = SurfaceTransformInputSpec
     output_spec = SurfaceTransformOutputSpec
+
+    def _format_arg(self, name, spec, value):
+        if name == "target_type" and value in implicit_filetypes:
+            return ""
+        return super(SurfaceTransform, self)._format_arg(name, spec, value)
 
     def _list_outputs(self):
         outputs = self._outputs().get()


### PR DESCRIPTION
This PR creates "implicit" output types for Freesurfer utilities, where no explicit `--out_type` is supported, but a filename with the associated extension will be correctly produced as that type.

At present, I've only tested this with GIFTI on `mri_vol2surf`. I expect `mri_surf2surf` will have the same level of support. I also suspect that any of the `mris_convert` outputs would work fine.

Note that `.gii.gz` actually produces a `.mgz` file with `.gii.gz` extension, and so any additional output types need to be checked for correctness. Similarly, not all files seem to produce a correct GIFTI; for example, `--srchit test.gii` produces a valid GIFTI file with completely different data.