### PR TITLE
ENH: Add a verbose tag for newer ANTs versions

### DIFF
--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -378,6 +378,8 @@ class RegistrationInputSpec(ANTSCommandInputSpec):
     winsorize_lower_quantile = traits.Range(
         low=0.0, high=1.0, value=0.0, argstr='%s', usedefault=True, desc="The Lower quantile to clip image ranges")
 
+    verbose = traits.Bool(argstr='-v', default=False)
+
 
 class RegistrationOutputSpec(TraitedSpec):
     forward_transforms = traits.List(


### PR DESCRIPTION
Newer ANTs versions aren't verbose by default, but take a verbose flag.