### PR TITLE
ENH: Disable symlinks on CIFS filesystems

### DIFF
--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -15,6 +15,7 @@ from ...testing import TempFATFS
 from ...utils.filemanip import (save_json, load_json,
                                 fname_presuffix, fnames_presuffix,
                                 hash_rename, check_forhash,
+                                _cifs_table, on_cifs,
                                 copyfile, copyfiles,
                                 filename_to_list, list_to_filename,
                                 check_depends,
@@ -334,3 +335,28 @@ def test_related_files(file, length, expected_files):
     for ef in expected_files:
         assert ef in related_files
 
+
+def test_cifs_check():
+    assert isinstance(_cifs_table, list)
+    assert isinstance(on_cifs('/'), bool)
+    fake_table = [('/scratch/tmp', 'ext4'), ('/scratch', 'cifs')]
+    cifs_targets = [('/scratch/tmp/x/y', False),
+                    ('/scratch/tmp/x', False),
+                    ('/scratch/x/y', True),
+                    ('/scratch/x', True),
+                    ('/x/y', False),
+                    ('/x', False),
+                    ('/', False)]
+
+    orig_table = _cifs_table[:]
+    _cifs_table.clear()
+
+    for target, _ in cifs_targets:
+        assert on_cifs(target) is False
+
+    _cifs_table.extend(fake_table)
+    for target, expected in cifs_targets:
+        assert on_cifs(target) is expected
+
+    _cifs_table.clear()
+    _cifs_table.extend(orig_table)

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -349,7 +349,7 @@ def test_cifs_check():
                     ('/', False)]
 
     orig_table = _cifs_table[:]
-    _cifs_table.clear()
+    _cifs_table[:] = []
 
     for target, _ in cifs_targets:
         assert on_cifs(target) is False
@@ -358,5 +358,5 @@ def test_cifs_check():
     for target, expected in cifs_targets:
         assert on_cifs(target) is expected
 
-    _cifs_table.clear()
+    _cifs_table[:] = []
     _cifs_table.extend(orig_table)


### PR DESCRIPTION
There appear to be cases where hacks to make symlinks work on filesystems that don't directly support them can cause `FileNotFoundError`s. In particular, the CIFS network filesystem driver for Linux supports the `mfsymlinks` option, which enables symlinks at the VFS level, having the effect that symlinking can be subject to network timeouts or temporary inconsistencies.

CIFS+`mfsymlinks` is the Docker-supported way to mount filesystems into a container from a Windows host, which means this may be increasingly a problem for Nipype users, as containers are becoming a more popular environment for running workflows. An [error](https://github.com/poldracklab/fmriprep/pull/398#issuecomment-291723199) reported on poldracklab/fmriprep#398 ran into this issue when running an interface that requires 4 symlinks, which split into two `mapflow` directories (per dataset being analyzed), using the `MultiProc` plugin.

This PR permits users to disable symlinking in the config file with the `disable_symbolic_links` option.

Closes #1938.