### PR TITLE
WIP - BF -  give sdc_fmb access to ants reg settings (esp  initial_moving_transform_com)

### DIFF
--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -904,7 +904,7 @@ def antreg_fmm2b0(alternatives=dict()):
     Example
     -------
 
-    >>> from nipype.workflows.dmri.fsl.artifacts import sdc_fmb
+    >>> from nipype.workflows.dmri.fsl.artifacts import sdc_fmb, antreg_fmm2b0
     >>> fmm2b0 = antreg_fmm2b0({'initial_moving_transform_com': 1})
     >>> fmb = sdc_fmb(fmm2b0=fmm2b0)
     >>> fmb.inputs.inputnode.in_file = 'diffusion.nii'


### PR DESCRIPTION
Running `sdc_fmb` where `in_file` and `bmap_mag` or `phase` are not close in coordinate space results in error running ants

> Description: itk::ERROR: MattesMutualInformationImageToImageMetricv4(0x2600ad0): Too many samples map outside moving image buffer. There are only 151 valid points out of 2473 total points. The images do not sufficiently overlap. They need to be initialized to have more overlap before this metric will work. For instance, you can align the image centers by translation.

Setting `initial_moving_transform_com = 1` resolves this error. 

This pull request creates a new function `antreg_fmm2b0` where ant settings can be changed or added.  `sdc_fmb` is parameterized to to use the new function.
