### PR TITLE
Centralize FreeSurfer version parsing

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -36,13 +36,9 @@ from .utils import copy2subjdir
 __docformat__ = 'restructuredtext'
 iflogger = logging.getLogger('interface')
 
-FSVersion = "0"
-_ver = Info.version()
-if _ver:
-    if 'dev' in _ver:
-        FSVersion = _ver.rstrip().split('-')[-1] + '.dev'
-    else:
-        FSVersion = _ver.rstrip().split('-v')[-1]
+# Keeping this to avoid breaking external programs that depend on it, but
+# this should not be used internally
+FSVersion = Info.looseversion()
 
 
 class ParseDICOMDirInputSpec(FSTraitedSpec):
@@ -724,7 +720,7 @@ class ReconAll(CommandLine):
                         'mri/brainmask.auto.mgz',
                         'mri/brainmask.mgz'], []),
         ]
-    if LooseVersion(FSVersion) < LooseVersion("6.0.0"):
+    if Info.looseversion() < LooseVersion("6.0.0"):
         _autorecon2_steps = [
             ('gcareg', ['mri/transforms/talairach.lta'], []),
             ('canorm', ['mri/norm.mgz'], []),
@@ -1072,7 +1068,7 @@ class BBRegister(FSCommand):
     """
 
     _cmd = 'bbregister'
-    if FSVersion and LooseVersion(FSVersion) < LooseVersion("6.0.0"):
+    if LooseVersion('0.0.0') < Info.looseversion() < LooseVersion("6.0.0"):
         input_spec = BBRegisterInputSpec
     else:
         input_spec = BBRegisterInputSpec6

--- a/nipype/interfaces/freesurfer/tests/test_preprocess.py
+++ b/nipype/interfaces/freesurfer/tests/test_preprocess.py
@@ -7,7 +7,7 @@ import pytest
 from nipype.testing.fixtures import create_files_in_directory
 
 from nipype.interfaces import freesurfer
-from nipype.interfaces.freesurfer.preprocess import FSVersion
+from nipype.interfaces.freesurfer import Info
 from nipype import LooseVersion
 
 
@@ -138,7 +138,7 @@ def test_bbregister(create_files_in_directory):
     bbr.inputs.contrast_type = 't2'
 
     # Check that 'init' is mandatory in FS < 6, but not in 6+
-    if LooseVersion(FSVersion) < LooseVersion("6.0.0"):
+    if Info.looseversion() < LooseVersion("6.0.0"):
         with pytest.raises(ValueError):
             bbr.cmdline
     else:


### PR DESCRIPTION
This change replaces `interfaces.freesurfer.preprocess.FSVersion` with `interfaces.freesurfer.Info.looseversion()`, and makes the corresponding updates throughout the code.

The goal is to get a well-behaved version string that is comparable across versions, including no installation. `LooseVersion` is used in anticipation of the most common use case.

`FSCommand().version` is updated to pull the version string out of `Info.looseversion()` to ensure that the same logic is applied whenever a parsed version string is used.

Release versions use simple version strings (no githash). Post-v6 `dev` versions follow format suggested by @satra in #1928: `6.0.0-dev.GITHASH`. `dev` versions without githashes are parsed as before.

Closes #1928.