### PR TITLE
FIX: Restore FSVersion to string

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -38,7 +38,7 @@ iflogger = logging.getLogger('interface')
 
 # Keeping this to avoid breaking external programs that depend on it, but
 # this should not be used internally
-FSVersion = Info.looseversion()
+FSVersion = Info.looseversion().vstring
 
 
 class ParseDICOMDirInputSpec(FSTraitedSpec):


### PR DESCRIPTION
#1958 changed `FSVersion` from a string to a `LooseVersion` object. This change corrects this issue.