### PR TITLE
FIX: Return simple filename from export_graph if simple form is requested

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1041,7 +1041,8 @@ def export_graph(graph_in, base_dir=None, show=False, use_execgraph=False,
 
     if format != 'dot':
         outfname += '.%s' % format
-    return outfname
+        simplefname += '.%s' % format
+    return simplefname if simple_form else outfname
 
 
 def format_dot(dotfilename, format=None):


### PR DESCRIPTION
Currently the detailed graph is always returned, so code that depends on the return value of `export_graph`, such as the Sphinx workflow extension.

`export_graph()` currently always writes out a detailed graph and a (potentially) simple one. I didn't change this, because I'm not sure if anybody is expecting both graphs.

Related: poldracklab/fmriprep#463