### PR TITLE
changing backend in ArtifactDetect

### DIFF
--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -330,6 +330,8 @@ class ArtifactDetect(BaseInterface):
         return outputs
 
     def _plot_outliers_with_wave(self, wave, outliers, name):
+        import matplotlib
+        matplotlib.use(config.get("execution", "matplotlib_backend"))
         import matplotlib.pyplot as plt
         plt.plot(wave)
         plt.ylim([wave.min(), wave.max()])


### PR DESCRIPTION
not sure if this cause the #1965, but I believe that the backend should be set there anyway.