### PR TITLE
remove bug to have a temporal derivative for multiple variables

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -209,9 +209,9 @@ class Level1Design(BaseInterface):
                             raise Exception('FSL environment variables not set')
                         else:
                             ev_parameters['fsldir'] = '/usr/share/fsl'
-                    try:
-                        ev_parameters['temporalderiv'] = int(bool(ev_parameters.pop('derivs')))
-                    except KeyError:
+                    if 'derivs' in ev_parameters.keys():
+                        ev_parameters['temporalderiv'] = int(bool(ev_parameters['derivs']))
+                    else:
                         ev_parameters['temporalderiv'] = False
                     if ev_parameters['temporalderiv']:
                         evname.append(name + 'TD')
@@ -393,9 +393,9 @@ class Level1Design(BaseInterface):
                         cwd, 'ev_%s_%d_%d.txt' % (name, runno,
                                                   len(evname)))
                     if field == 'cond':
-                        try:
-                            ev_parameters['temporalderiv'] = int(bool(ev_parameters.pop('derivs')))
-                        except KeyError:
+                        if 'derivs' in ev_parameters.keys():
+                            ev_parameters['temporalderiv'] = int(bool(ev_parameters['derivs']))
+                        else:
                             ev_parameters['temporalderiv'] = False
                         if ev_parameters['temporalderiv']:
                             evname.append(name + 'TD')

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -209,10 +209,7 @@ class Level1Design(BaseInterface):
                             raise Exception('FSL environment variables not set')
                         else:
                             ev_parameters['fsldir'] = '/usr/share/fsl'
-                    if 'derivs' in ev_parameters.keys():
-                        ev_parameters['temporalderiv'] = int(bool(ev_parameters['derivs']))
-                    else:
-                        ev_parameters['temporalderiv'] = False
+                    ev_parameters['temporalderiv'] = bool(ev_parameters.get('derivs', False))
                     if ev_parameters['temporalderiv']:
                         evname.append(name + 'TD')
                         num_evs[1] += 1


### PR DESCRIPTION
`ev_parameters.pop('derivs')` removes `'derivs'` from the `ev_parameters`.  As a consequence, only for the first regressor, a temporal derivative is added.  This fixes the issue.
