### PR TITLE
debug 'folder does not exist' error when running feat

### DIFF
--- a/nipype/interfaces/script_templates/feat_header_l1.tcl
+++ b/nipype/interfaces/script_templates/feat_header_l1.tcl
@@ -52,7 +52,7 @@ set fmri(multiple) 1
 # Higher-level input type
 # 1 : Inputs are lower-level FEAT directories
 # 2 : Inputs are cope images from FEAT directories
-set fmri(inputtype) 1
+set fmri(inputtype) 2
 
 # Carry out pre-stats processing?
 set fmri(filtering_yn) 0


### PR DESCRIPTION
Feat was expecting lower level .feat folders, when running interfaces.fsl.model.FEATModel().  This suggestion fixes the bug.