### PR TITLE
Re-added nose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ configparser
 pytest>=3.0
 mock
 pydotplus
+nose>=1.2


### PR DESCRIPTION
After using a docker container, generated from the dockerfile in the repository, but changed for use with python 2.7, got the following error:

```
Traceback (most recent call last):
  File "CNP_analysis.py", line 1, in <module>
    from nipype.interfaces.fsl import model,Level1Design, FEATModel, FEAT
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/__init__.py", line 71, in <module>
    from .pipeline import Node, MapNode, JoinNode, Workflow
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/pipeline/__init__.py", line 10, in <module>
    from .engine import Node, MapNode, JoinNode, Workflow

  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/pipeline/engine/__init__.py", line 12, in <module>
    from .workflows import Workflow
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/pipeline/engine/workflows.py", line 41, in <module>
    from ...interfaces.base import (traits, InputMultiPath, CommandLine,
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/interfaces/__init__.py", line 13, in <module>
    from .utility import IdentityInterface, Rename, Function, Select, Merge
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/interfaces/utility.py", line 28, in <module>
    from ..testing import assert_equal
  File "/home/jdurnez/.local/lib/python2.7/site-packages/nipype/testing/__init__.py", line 29, in <module>
    from nose.tools import *
ImportError: No module named nose.tools
```