### PR TITLE
command file required by FSL FEAT

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -100,6 +100,7 @@ RUN apt-get update && \
                     apt-utils \
                     fusefat \
                     make \
+                    file \
                     # Added g++ to compile dipy in py3.6
                     g++=4:5.3.1-1ubuntu1 \
                     ruby=1:2.3.0+1 && \


### PR DESCRIPTION
FSL's FEAT uses (in FSLFixText) the file command to check file type.