### PR TITLE
FIX: Correctly populate output spec for ICA_AROMA

### DIFF
--- a/nipype/interfaces/fsl/ICA_AROMA.py
+++ b/nipype/interfaces/fsl/ICA_AROMA.py
@@ -107,6 +107,7 @@ class ICA_AROMA(CommandLine):
     output_spec = ICA_AROMAOutputSpec
 
     def _list_outputs(self):
+        outputs = self.output_spec().get()
         out_dir = os.path.abspath(self.inputs.out_dir)
         outputs['out_dir'] = out_dir
 


### PR DESCRIPTION
Fixes #2026

Changes proposed in this pull request
added `outputs = self.output_spec().get` to _list_outputs
May or may not fix the other error message.