### PR TITLE
ENH: Permit external packages to deprecate interfaces

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -45,7 +45,7 @@ def get_nipype_gitversion():
 if __version__.endswith('-dev'):
     gitversion = get_nipype_gitversion()
     if gitversion:
-        __version__ = __version__.replace('-dev', '-' + gitversion + '.dev')
+        __version__ = '{}+{}'.format(__version__, gitversion)
 
 CLASSIFIERS = ['Development Status :: 5 - Production/Stable',
                'Environment :: Console',
@@ -141,7 +141,8 @@ REQUIRES = [
     'funcsigs',
     'pytest>=%s' % PYTEST_MIN_VERSION,
     'mock',
-    'pydotplus'
+    'pydotplus',
+    'packaging',
 ]
 
 if sys.version_info <= (3, 4):

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -31,6 +31,7 @@ from textwrap import wrap
 from warnings import warn
 import simplejson as json
 from dateutil.parser import parse as parseutc
+from packaging.version import Version
 
 from .. import config, logging, LooseVersion, __version__
 from ..utils.provenance import write_provenance
@@ -43,7 +44,7 @@ from .traits_extension import (
 from ..external.due import due
 
 runtime_profile = str2bool(config.get('execution', 'profile_runtime'))
-nipype_version = LooseVersion(__version__)
+nipype_version = Version(__version__)
 iflogger = logging.getLogger('interface')
 
 FLOAT_FORMAT = '{:.10f}'.format
@@ -445,7 +446,7 @@ class BaseTraitedSpec(traits.HasTraits):
             else:
                 msg3 = ''
             msg = ' '.join((msg1, msg2, msg3))
-            if LooseVersion(str(trait_spec.deprecated)) < self.package_version:
+            if Version(str(trait_spec.deprecated)) < self.package_version:
                 raise TraitError(msg)
             else:
                 if trait_spec.new_name:

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -352,6 +352,7 @@ class BaseTraitedSpec(traits.HasTraits):
     XXX Reconsider this in the long run, but it seems like the best
     solution to move forward on the refactoring.
     """
+    package_version = nipype_version
 
     def __init__(self, **kwargs):
         """ Initialize handlers and inputs"""
@@ -444,7 +445,7 @@ class BaseTraitedSpec(traits.HasTraits):
             else:
                 msg3 = ''
             msg = ' '.join((msg1, msg2, msg3))
-            if LooseVersion(str(trait_spec.deprecated)) < nipype_version:
+            if LooseVersion(str(trait_spec.deprecated)) < self.package_version:
                 raise TraitError(msg)
             else:
                 if trait_spec.new_name:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ configparser
 pytest>=3.0
 mock
 pydotplus
+packaging

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -14,3 +14,4 @@ mock
 pydotplus
 psutil
 matplotlib
+packaging


### PR DESCRIPTION
External projects, such as [poldracklab/niworkflows](https://github.com/poldracklab/niworkflows), may maintain a set of interfaces, that over time require deprecating portions of their input and output specs. At present, the deprecation machinery is intrinsically tied to nipype's version number.

This PR adds a `package_version` attribute to each interface, which defaults to nipype's, but allows other packages easily to add their own versioning information to specs with a deprecation schedule.