### PR TITLE
fix+enh: support for Bayesian spm.ModelEstimate, add write_residuals for Classical

### DIFF
--- a/nipype/interfaces/spm/tests/test_auto_EstimateModel.py
+++ b/nipype/interfaces/spm/tests/test_auto_EstimateModel.py
@@ -23,6 +23,8 @@ def test_EstimateModel_inputs():
     use_v8struct=dict(min_ver='8',
     usedefault=True,
     ),
+    write_residuals=dict(field='write_residuals',
+    ),
     )
     inputs = EstimateModel.input_spec()
 
@@ -36,6 +38,7 @@ def test_EstimateModel_outputs():
     beta_images=dict(),
     mask_image=dict(),
     residual_image=dict(),
+    residual_images=dict(),
     spm_mat_file=dict(),
     )
     outputs = EstimateModel.output_spec()

--- a/nipype/interfaces/spm/tests/test_auto_EstimateModel.py
+++ b/nipype/interfaces/spm/tests/test_auto_EstimateModel.py
@@ -34,8 +34,13 @@ def test_EstimateModel_inputs():
 
 
 def test_EstimateModel_outputs():
-    output_map = dict(RPVimage=dict(),
+    output_map = dict(ARcoef=dict(),
+    Cbetas=dict(),
+    RPVimage=dict(),
+    SDbetas=dict(),
+    SDerror=dict(),
     beta_images=dict(),
+    labels=dict(),
     mask_image=dict(),
     residual_image=dict(),
     residual_images=dict(),


### PR DESCRIPTION
Fixes #2029 + #1786 .

Changes proposed in this pull request
- FIX: `inputs.flags` is now a dictionary and works as intended
- ENH: `inputs.write_residuals` is a boolean that will write create an image for each residual
- ENH: supports `Bayesian` estimation outputs