### PR TITLE
ENH: Add LTA output to BBRegister

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -1155,6 +1155,8 @@ class BBRegisterInputSpec(FSTraitedSpec):
                         desc='degrees of freedom for initial registration (FSL)')
     out_fsl_file = traits.Either(traits.Bool, File, argstr="--fslmat %s",
                                  desc="write the transformation matrix in FSL FLIRT format")
+    out_lta_file = traits.Either(traits.Bool, File, argstr="--lta %s", min_ver='5.2.0',
+                                 desc="write the transformation matrix in LTA format")
     registered_file = traits.Either(traits.Bool, File, argstr='--o %s',
                                     desc='output warped sourcefile either True or filename')
 
@@ -1171,6 +1173,7 @@ class BBRegisterInputSpec6(BBRegisterInputSpec):
 class BBRegisterOutputSpec(TraitedSpec):
     out_reg_file = File(exists=True, desc='Output registration file')
     out_fsl_file = File(desc='Output FLIRT-style registration file')
+    out_lta_file = File(desc='Output LTA-style registration file')
     min_cost_file = File(exists=True, desc='Output registration minimum cost file')
     registered_file = File(desc='Registered and resampled source file')
 
@@ -1219,6 +1222,16 @@ class BBRegister(FSCommand):
             else:
                 outputs['registered_file'] = op.abspath(_in.registered_file)
 
+        if isdefined(_in.out_lta_file):
+            if isinstance(_in.out_fsl_file, bool):
+                suffix = '_bbreg_%s.lta' % _in.subject_id
+                out_lta_file = fname_presuffix(_in.source_file,
+                                               suffix=suffix,
+                                               use_ext=False)
+                outputs['out_lta_file'] = out_lta_file
+            else:
+                outputs['out_lta_file'] = op.abspath(_in.out_lta_file)
+
         if isdefined(_in.out_fsl_file):
             if isinstance(_in.out_fsl_file, bool):
                 suffix = '_bbreg_%s.mat' % _in.subject_id
@@ -1234,7 +1247,7 @@ class BBRegister(FSCommand):
 
     def _format_arg(self, name, spec, value):
 
-        if name in ['registered_file', 'out_fsl_file']:
+        if name in ['registered_file', 'out_fsl_file', 'out_lta_file']:
             if isinstance(value, bool):
                 fname = self._list_outputs()[name]
             else:

--- a/nipype/interfaces/freesurfer/tests/test_BBRegister.py
+++ b/nipype/interfaces/freesurfer/tests/test_BBRegister.py
@@ -15,6 +15,7 @@ def test_BBRegister_inputs():
         init_reg_file=dict(argstr='--init-reg %s', mandatory=True, xor=['init'],),
         intermediate_file=dict(argstr='--int %s',),
         out_fsl_file=dict(argstr='--fslmat %s',),
+        out_lta_file=dict(argstr='--lta %s', min_ver='5.2.0',),
         out_reg_file=dict(argstr='--reg %s', genfile=True,),
         reg_frame=dict(argstr='--frame %d', xor=['reg_middle_frame'],),
         reg_middle_frame=dict(argstr='--mid-frame', xor=['reg_frame'],),
@@ -37,6 +38,7 @@ def test_BBRegister_inputs():
         init_reg_file=dict(argstr='--init-reg %s', xor=['init'],),
         intermediate_file=dict(argstr='--int %s',),
         out_fsl_file=dict(argstr='--fslmat %s',),
+        out_lta_file=dict(argstr='--lta %s', min_ver='5.2.0',),
         out_reg_file=dict(argstr='--reg %s', genfile=True,),
         reg_frame=dict(argstr='--frame %d', xor=['reg_middle_frame'],),
         reg_middle_frame=dict(argstr='--mid-frame', xor=['reg_frame'],),
@@ -62,6 +64,7 @@ def test_BBRegister_inputs():
 def test_BBRegister_outputs():
     output_map = dict(min_cost_file=dict(),
                       out_fsl_file=dict(),
+                      out_lta_file=dict(),
                       out_reg_file=dict(),
                       registered_file=dict(),
                       )


### PR DESCRIPTION
To make up for over-eager issue closing. This PR adds `out_lta_file` to the `BBRegister` interface.

Set `min_ver=5.2.0` based on [this tag](https://github.com/freesurfer/freesurfer/blob/release_5_2_0/scripts/bbregister).

Fixes #266
