### PR TITLE
BF: Do not double % the field for hash in COMMIT_INFO.txt

### DIFF
--- a/nipype/COMMIT_INFO.txt
+++ b/nipype/COMMIT_INFO.txt
@@ -1,6 +1,6 @@
 # This is an ini file that may contain information about the code state
 [commit hash]
 # The line below may contain a valid hash if it has been substituted during 'git archive'
-archive_subst_hash=$Format:%%h$
+archive_subst_hash=$Format:%h$
 # This line may be modified by the install process
 install_hash=


### PR DESCRIPTION
Addresses an issue listed in #1970

Before:
```shell
$> git archive HEAD nipype/COMMIT_INFO.txt | grep -a archive_su 
archive_subst_hash=%h
```

After:
```shell
$> git archive HEAD nipype/COMMIT_INFO.txt | grep -a archive_su                             
archive_subst_hash=df035ac81
```
but imho correct fix to code should also allow for that line still stay with original value `archive_subst_hash=$Format:%h$`