### PR TITLE
ENH: Handle PBSPro message when job completed

### DIFF
--- a/nipype/pipeline/plugins/pbs.py
+++ b/nipype/pipeline/plugins/pbs.py
@@ -49,8 +49,13 @@ class PBSPlugin(SGELikeBatchManagerBase):
                              environ=dict(os.environ),
                              terminal_output='allatonce',
                              ignore_exception=True).run()
+        stderr = result.runtime.stderr
         errmsg = 'Unknown Job Id'  # %s' % taskid
-        return errmsg not in result.runtime.stderr
+        success = 'Job has finished'
+        if success in e:  # Fix for my PBS
+            return False
+        else:
+            return errmsg not in e
 
     def _submit_batchtask(self, scriptfile, node):
         cmd = CommandLine('qsub', environ=dict(os.environ),


### PR DESCRIPTION
Changes proposed in this pull request
- PBSPro version listed below does not return Unknown Job Id when a job has finished to stderr, instead it returns a message to stderr saying that the job has finished, recommending a command to access completed job details.
- This means that the _is_pending command continually reruns every 2 seconds (waiting for the job to complete)
- the _fix_ for this is to check explicitly for the job finished message, and pass along that the job is no longer pending.

```bash
$ qstat --version
pbs_version = PBSPro_13.1.0.160576
```

All tests passed successfully with make check_before_commit