### PR TITLE
FIX: Import mmap into inner function for all_fsl_pipeline

### DIFF
--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -236,6 +236,7 @@ def all_fsl_pipeline(name='fsl_all_correct',
         import numpy as np
         import nibabel as nb
         import os
+        from nipype.utils import NUMPY_MMAP
         out_file = os.path.abspath('index.txt')
         vols = nb.load(in_file, mmap=NUMPY_MMAP).get_data().shape[-1]
         np.savetxt(out_file, np.ones((vols,)).T)


### PR DESCRIPTION
Rationale:

Similar to pull request #1831 (and follow up to #1796) there was a function level import for NUMPY_MMAP that was missing, causing a `NameError`

Changes proposed in this pull request
- import `NUMPY_MMAP` into `_gen_index` [inner function of `all_fsl_pipeline`]
