### PR TITLE
ENH: Reduce within-package absolute imports

### DIFF
--- a/nipype/algorithms/icc.py
+++ b/nipype/algorithms/icc.py
@@ -8,7 +8,7 @@ import nibabel as nb
 from scipy.linalg import pinv
 from ..interfaces.base import BaseInterfaceInputSpec, TraitedSpec, \
     BaseInterface, traits, File
-from nipype.utils import NUMPY_MMAP
+from ..utils import NUMPY_MMAP
 
 
 class ICCInputSpec(BaseInterfaceInputSpec):

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -30,7 +30,7 @@ from ..utils.misc import package_check
 from ..interfaces.base import (BaseInterface, traits, TraitedSpec, File,
                                InputMultiPath,
                                BaseInterfaceInputSpec, isdefined)
-from nipype.utils import NUMPY_MMAP
+from ..utils import NUMPY_MMAP
 
 iflogger = logging.getLogger('interface')
 

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -34,7 +34,7 @@ from ..interfaces.base import (BaseInterface, traits, TraitedSpec, File,
                                BaseInterfaceInputSpec, isdefined,
                                DynamicTraitedSpec, Undefined)
 from ..utils.filemanip import fname_presuffix, split_filename
-from nipype.utils import NUMPY_MMAP
+from ..utils import NUMPY_MMAP
 
 from . import confounds
 

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -13,6 +13,8 @@ import os.path as op
 import nibabel as nb
 import numpy as np
 
+from ...utils import NUMPY_MMAP
+
 from ... import logging
 from ..base import (traits, TraitedSpec, File, isdefined)
 from .base import DipyBaseInterface
@@ -179,7 +181,6 @@ def resample_proxy(in_file, order=3, new_zooms=None, out_file=None):
     Performs regridding of an image to set isotropic voxel sizes using dipy.
     """
     from dipy.align.reslice import reslice
-    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -223,7 +224,6 @@ def nlmeans_proxy(in_file, settings,
     from dipy.denoise.nlmeans import nlmeans
     from scipy.ndimage.morphology import binary_erosion
     from scipy import ndimage
-    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))

--- a/nipype/interfaces/fsl/ICA_AROMA.py
+++ b/nipype/interfaces/fsl/ICA_AROMA.py
@@ -10,6 +10,7 @@
     ...                            '../../testing/data'))
     >>> os.chdir(datadir)
 """
+from __future__ import print_function, division, unicode_literals, absolute_import
 from ..base import (TraitedSpec, CommandLineInputSpec, CommandLine,
                     File, Directory, traits)
 import os

--- a/nipype/interfaces/fsl/ICA_AROMA.py
+++ b/nipype/interfaces/fsl/ICA_AROMA.py
@@ -10,16 +10,10 @@
     ...                            '../../testing/data'))
     >>> os.chdir(datadir)
 """
-from nipype.interfaces.base import (
-    TraitedSpec,
-    CommandLineInputSpec,
-    CommandLine,
-    File,
-    Directory,
-    traits,
-    OutputMultiPath
-)
+from ..base import (TraitedSpec, CommandLineInputSpec, CommandLine,
+                    File, Directory, traits)
 import os
+
 
 class ICA_AROMAInputSpec(CommandLineInputSpec):
     feat_dir = Directory(exists=True, mandatory=True,

--- a/nipype/interfaces/fsl/fix.py
+++ b/nipype/interfaces/fsl/fix.py
@@ -54,7 +54,7 @@ outgraph = fix_pipeline.run()
 
 """
 
-from nipype.interfaces.base import (
+from ..base import (
     TraitedSpec,
     CommandLineInputSpec,
     CommandLine,
@@ -64,11 +64,8 @@ from nipype.interfaces.base import (
     BaseInterfaceInputSpec,
     traits
 )
-from nipype.interfaces.traits_extension import (
-    Directory,
-    File,
-    isdefined
-)
+from ..traits_extension import Directory, File, isdefined
+
 import os
 
 class TrainingSetCreatorInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/fsl/fix.py
+++ b/nipype/interfaces/fsl/fix.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """The fix module provides classes for interfacing with the `FSL FIX
@@ -53,6 +54,7 @@ fix_pipeline.write_graph()
 outgraph = fix_pipeline.run()
 
 """
+from __future__ import print_function, division, unicode_literals, absolute_import
 
 from ..base import (
     TraitedSpec,
@@ -65,8 +67,8 @@ from ..base import (
     traits
 )
 from ..traits_extension import Directory, File, isdefined
-
 import os
+
 
 class TrainingSetCreatorInputSpec(BaseInterfaceInputSpec):
     mel_icas_in = InputMultiPath(Directory(exists=True), copyfile=False,

--- a/nipype/interfaces/niftyseg/base.py
+++ b/nipype/interfaces/niftyseg/base.py
@@ -16,8 +16,8 @@ Examples
 See the docstrings of the individual classes for examples.
 """
 
-from nipype.interfaces.niftyreg.base import no_nifty_package
-from nipype.interfaces.niftyfit.base import NiftyFitCommand
+from ..niftyreg.base import no_nifty_package
+from ..niftyfit.base import NiftyFitCommand
 import subprocess
 import warnings
 

--- a/nipype/interfaces/niftyseg/base.py
+++ b/nipype/interfaces/niftyseg/base.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
@@ -15,6 +16,7 @@ Examples
 --------
 See the docstrings of the individual classes for examples.
 """
+from __future__ import print_function, division, unicode_literals, absolute_import
 
 from ..niftyreg.base import no_nifty_package
 from ..niftyfit.base import NiftyFitCommand

--- a/nipype/interfaces/petpvc.py
+++ b/nipype/interfaces/petpvc.py
@@ -13,7 +13,8 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 import os
 
 from .base import TraitedSpec, CommandLineInputSpec, CommandLine, File, isdefined, traits
-from ..external.due import due, Doi, BibTeX
+from ..utils.filemanip import fname_presuffix
+from ..external.due import BibTeX
 
 pvc_methods = ['GTM',
                'IY',
@@ -200,8 +201,6 @@ class PETPVC(CommandLine):
             New filename based on given parameters.
 
         """
-        from nipype.utils.filemanip import fname_presuffix
-
         if basename == '':
             msg = 'Unable to generate filename for command %s. ' % self.cmd
             msg += 'basename is not set!'

--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -21,7 +21,7 @@ from builtins import str, bytes
 
 from ... import logging
 from ..base import (traits, DynamicTraitedSpec, Undefined, isdefined, runtime_profile,
-                    BaseInterfaceInputSpec)
+                    BaseInterfaceInputSpec, get_max_resources_used)
 from ..io import IOBase, add_traits
 from ...utils.filemanip import filename_to_list
 from ...utils.misc import getsource, create_function_from_source
@@ -138,7 +138,6 @@ class Function(IOBase):
 
     def _run_interface(self, runtime):
         # Get workflow logger for runtime profile error reporting
-        from nipype import logging
         logger = logging.getLogger('workflow')
 
         # Create function handle
@@ -163,7 +162,6 @@ class Function(IOBase):
 
         # Profile resources if set
         if runtime_profile:
-            from nipype.interfaces.base import get_max_resources_used
             import multiprocessing
             # Init communication queue and proc objs
             queue = multiprocessing.Queue()

--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -19,7 +19,7 @@ standard_library.install_aliases()
 
 from builtins import str, bytes
 
-from nipype import logging
+from ... import logging
 from ..base import (traits, DynamicTraitedSpec, Undefined, isdefined, runtime_profile,
                     BaseInterfaceInputSpec)
 from ..io import IOBase, add_traits

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -24,7 +24,7 @@ import re
 import pickle
 from functools import reduce
 import numpy as np
-from nipype.utils.misc import package_check
+from ...utils.misc import package_check
 
 package_check('networkx', '1.3')
 

--- a/nipype/utils/__init__.py
+++ b/nipype/utils/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from .config import NUMPY_MMAP
 from .onetime import OneTimeProperty, setattr_on_read
 from .tmpdirs import TemporaryDirectory, InTemporaryDirectory

--- a/nipype/utils/__init__.py
+++ b/nipype/utils/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
-from nipype.utils.config import NUMPY_MMAP
-from nipype.utils.onetime import OneTimeProperty, setattr_on_read
-from nipype.utils.tmpdirs import TemporaryDirectory, InTemporaryDirectory
+from .config import NUMPY_MMAP
+from .onetime import OneTimeProperty, setattr_on_read
+from .tmpdirs import TemporaryDirectory, InTemporaryDirectory

--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -9,6 +9,8 @@ from ....interfaces import utility as niu
 from ....interfaces import ants
 from ....interfaces import fsl
 from ....pipeline import engine as pe
+from ...data import get_flirt_schedule
+
 from .utils import (b0_indices, time_avg, apply_all_corrections, b0_average,
                     hmc_split, dwi_flirt, eddy_rotate_bvecs, rotate_bvecs,
                     insert_mat, extract_bval, recompose_dwi, recompose_xfm,
@@ -352,8 +354,6 @@ should be taken as reference
         outputnode.out_xfms - list of transformation matrices
 
     """
-    from nipype.workflows.data import get_flirt_schedule
-
     params = dict(dof=6, bgvalue=0, save_log=True, no_search=True,
                   # cost='mutualinfo', cost_func='mutualinfo', bins=64,
                   schedule=get_flirt_schedule('hmc'))
@@ -454,7 +454,6 @@ head-motion correction)
         outputnode.out_xfms - list of transformation matrices
     """
 
-    from nipype.workflows.data import get_flirt_schedule
     params = dict(dof=12, no_search=True, interp='spline', bgvalue=0,
                   schedule=get_flirt_schedule('ecc'))
     # cost='normmi', cost_func='normmi', bins=64,

--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-from __future__ import division
+from __future__ import print_function, division, unicode_literals, absolute_import
 
 from ....interfaces.io import JSONFileGrabber
 from ....interfaces import utility as niu

--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -4,8 +4,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import division
 
-from nipype.utils import NUMPY_MMAP
-
 from ....interfaces.io import JSONFileGrabber
 from ....interfaces import utility as niu
 from ....interfaces import ants
@@ -903,6 +901,7 @@ def _xfm_jacobian(in_xfm):
 
 def _get_zoom(in_file, enc_dir):
     import nibabel as nb
+    from nipype.utils import NUMPY_MMAP
 
     zooms = nb.load(in_file, mmap=NUMPY_MMAP).header.get_zooms()
 

--- a/nipype/workflows/smri/freesurfer/autorecon1.py
+++ b/nipype/workflows/smri/freesurfer/autorecon1.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from nipype.utils import NUMPY_MMAP
-from nipype.interfaces.utility import Function,IdentityInterface
-import nipype.pipeline.engine as pe  # pypeline engine
-from nipype.interfaces.freesurfer import *
+from ....utils import NUMPY_MMAP
+from ....pipeline import engine as pe
+from ....interfaces.utility import Function, IdentityInterface
+from ....interfaces.freesurfer import *
 from .utils import copy_file
 
 

--- a/nipype/workflows/smri/freesurfer/autorecon1.py
+++ b/nipype/workflows/smri/freesurfer/autorecon1.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import print_function, division, unicode_literals, absolute_import
 from ....utils import NUMPY_MMAP
 from ....pipeline import engine as pe
 from ....interfaces.utility import Function, IdentityInterface

--- a/nipype/workflows/smri/freesurfer/autorecon2.py
+++ b/nipype/workflows/smri/freesurfer/autorecon2.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from nipype.interfaces.utility import Function, IdentityInterface, Merge
-import nipype.pipeline.engine as pe  # pypeline engine
-from nipype.interfaces.freesurfer import *
+from ....interfaces.utility import Function, IdentityInterface, Merge
+from ....pipeline import engine as pe
+from ....interfaces.freesurfer import *
 from .utils import copy_file
 
 def copy_ltas(in_file, subjects_dir, subject_id, long_template):

--- a/nipype/workflows/smri/freesurfer/autorecon2.py
+++ b/nipype/workflows/smri/freesurfer/autorecon2.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division, unicode_literals, absolute_import
 from ....interfaces.utility import Function, IdentityInterface, Merge
 from ....pipeline import engine as pe
 from ....interfaces.freesurfer import *

--- a/nipype/workflows/smri/freesurfer/autorecon3.py
+++ b/nipype/workflows/smri/freesurfer/autorecon3.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from nipype.interfaces.utility import IdentityInterface, Merge, Function
-import nipype.pipeline.engine as pe  # pypeline engine
-from nipype.interfaces.freesurfer import *
+from ....interfaces.utility import IdentityInterface, Merge, Function
+from ....pipeline import engine as pe
+from ....interfaces.freesurfer import *
 from .ba_maps import create_ba_maps_wf
-from nipype.interfaces.io import DataGrabber
+from ....interfaces.io import DataGrabber
 
 def create_AutoRecon3(name="AutoRecon3", qcache=False, plugin_args=None,
                       th3=True, exvivo=True, entorhinal=True, fsvernum=5.3):

--- a/nipype/workflows/smri/freesurfer/autorecon3.py
+++ b/nipype/workflows/smri/freesurfer/autorecon3.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division, unicode_literals, absolute_import
 from ....interfaces.utility import IdentityInterface, Merge, Function
 from ....pipeline import engine as pe
 from ....interfaces.freesurfer import *

--- a/nipype/workflows/smri/freesurfer/ba_maps.py
+++ b/nipype/workflows/smri/freesurfer/ba_maps.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-import nipype
-from nipype.interfaces.utility import Function,IdentityInterface
-import nipype.pipeline.engine as pe  # pypeline engine
-from nipype.interfaces.freesurfer import *
-from nipype.interfaces.io import DataGrabber
-from nipype.interfaces.utility import Merge
+from ....interfaces.utility import Function, IdentityInterface
+from ....pipeline import engine as pe  # pypeline engine
+from ....interfaces.freesurfer import *
+from ....interfaces.io import DataGrabber
+from ....interfaces.utility import Merge
 
 def create_ba_maps_wf(name="Brodmann_Area_Maps", th3=True, exvivo=True,
                       entorhinal=True):

--- a/nipype/workflows/smri/freesurfer/ba_maps.py
+++ b/nipype/workflows/smri/freesurfer/ba_maps.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division, unicode_literals, absolute_import
 import os
 from ....interfaces.utility import Function, IdentityInterface
 from ....pipeline import engine as pe  # pypeline engine

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function, division, unicode_literals, absolute_import
 from ....pipeline import engine as pe
 from ....interfaces import freesurfer as fs
 from ....interfaces import utility as niu

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -206,7 +206,6 @@ def create_reconall_workflow(name="ReconAll", plugin_args=None):
                   awk_file=None,
                   rb_date=None):
         """Set optional configurations to the default"""
-        from nipype.workflows.smri.freesurfer.utils import getdefaultconfig
         def checkarg(arg, default):
             """Returns the value if defined; otherwise default"""
             if arg:

--- a/nipype/workflows/smri/niftyreg/groupwise.py
+++ b/nipype/workflows/smri/niftyreg/groupwise.py
@@ -7,9 +7,9 @@ pipelines. Including linear and non-linear image co-registration
 """
 
 from builtins import str, range
-import nipype.interfaces.utility as niu
-import nipype.interfaces.niftyreg as niftyreg
-import nipype.pipeline.engine as pe
+from ....interfaces import utility as niu
+from ....interfaces import niftyreg as niftyreg
+from ....pipeline import engine as pe
 
 
 def create_linear_gw_step(name="linear_gw_niftyreg",

--- a/nipype/workflows/smri/niftyreg/groupwise.py
+++ b/nipype/workflows/smri/niftyreg/groupwise.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 
@@ -6,6 +7,7 @@ Example of registration workflows using niftyreg, useful for a variety of
 pipelines. Including linear and non-linear image co-registration
 """
 
+from __future__ import print_function, division, unicode_literals, absolute_import
 from builtins import str, range
 from ....interfaces import utility as niu
 from ....interfaces import niftyreg as niftyreg


### PR DESCRIPTION
With our (FMRIPREP/MRIQC) mismatched release cycles, we're running into the situation where correctly managing dependencies puts an undue burden on users (at least those installing natively, rather than running the Docker/Singularity images). We're attempting to move to include nipype as a submodule in niworkflows. Our projects will then import from `niworkflows.nipype`, which will avoid clashing with other installs of nipype.

Absolute imports assume that the root module is named `nipype`, where relative imports will permit (relatively) easy use as a submodule.

This should not affect the actual behavior of nipype at all, but will require that future PRs refrain from using absolute imports.

Changes proposed in this pull request:
- Move to relative imports in non-testing code