### PR TITLE
FIX: typo in ICA_AROMA.py

### DIFF
--- a/nipype/interfaces/fsl/ICA_AROMA.py
+++ b/nipype/interfaces/fsl/ICA_AROMA.py
@@ -55,7 +55,7 @@ class ICA_AROMAInputSpec(CommandLineInputSpec):
     denoise_type = traits.Enum('nonaggr', 'aggr', 'both', 'no', usedefault=True,
                                mandatory=True, argstr='-den %s',
                                desc='Type of denoising strategy:\n'
-                               '-none: only classification, no denoising\n'
+                               '-no: only classification, no denoising\n'
                                '-nonaggr (default): non-aggresssive denoising, i.e. partial component regression\n'
                                '-aggr: aggressive denoising, i.e. full component regression\n'
                                '-both: both aggressive and non-aggressive denoising (two outputs)')


### PR DESCRIPTION
Changes proposed in this pull request
I had a typo in the ICA_AROMA.py denoising documentation
none becomes no.
