### PR TITLE
ENH: Parse SelectFiles format keys to allow attribute access

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -1256,8 +1256,10 @@ class SelectFiles(IOBase):
         infields = []
         for name, template in list(templates.items()):
             for _, field_name, _, _ in string.Formatter().parse(template):
-                if field_name is not None and field_name not in infields:
-                    infields.append(field_name)
+                if field_name is not None:
+                    field_name = re.match("\w+", field_name).group()
+                    if field_name not in infields:
+                        infields.append(field_name)
 
         self._infields = infields
         self._outfields = list(templates)

--- a/nipype/interfaces/tests/test_io.py
+++ b/nipype/interfaces/tests/test_io.py
@@ -11,6 +11,7 @@ import shutil
 import os.path as op
 from subprocess import Popen
 import hashlib
+from collections import namedtuple
 
 import pytest
 import nipype
@@ -62,6 +63,7 @@ def test_s3datagrabber():
 templates1 = {"model": "interfaces/{package}/model.py",
              "preprocess": "interfaces/{package}/pre*.py"}
 templates2 = {"converter": "interfaces/dcm{to!s}nii.py"}
+templates3 = {"model": "interfaces/{package.name}/model.py"}
 
 @pytest.mark.parametrize("SF_args, inputs_att, expected", [
         ({"templates":templates1}, {"package":"fsl"},
@@ -75,6 +77,11 @@ templates2 = {"converter": "interfaces/dcm{to!s}nii.py"}
 
         ({"templates":templates2}, {"to":2},
          {"infields":["to"], "outfields":["converter"], "run_output":{"converter":op.join(op.dirname(nipype.__file__), "interfaces/dcm2nii.py")}, "node_output":["converter"]}),
+
+        ({"templates": templates3}, {"package": namedtuple("package", ["name"])("fsl")},
+        {"infields": ["package"], "outfields": ["model"],
+         "run_output": {"model": op.join(op.dirname(nipype.__file__), "interfaces/fsl/model.py")},
+         "node_output": ["model"]}),
         ])
 def test_selectfiles(SF_args, inputs_att, expected):
     base_dir = op.dirname(nipype.__file__)


### PR DESCRIPTION
I ran into an issue where I wanted to use attribute access in the string format template I pass to `SelectFiles`, but due to some (imo, bizarre) [aspects](http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/) of how format strings are implemented, the template key names were not getting properly parsed and turned into input fields.

If I have a template `"{group.name}'s template"`, then when the `string.Formatter().parse(template)` is called, it returns a key `"group.name"`. Python's string formatting then additionally processes this string with a private function that lives in different places on Python 2 and 3. The result of that processing grabs the `group` kwarg from call to `.format()` and accesses its `name` attribute. Rather than deal with private Python functions, I chose to add an additional processing step in `SelectFiles` that runs a regular expression match with the pattern `"\w+"` over each format key before adding it as an input to the `Interface`. This will strip the trailing accessor syntax, and makes sense anyway in that it turns the input field into a term that can be used as a Python attribute.

I would have liked to add a test case for this new behavior, but honestly gave up after staring at [this fixture](https://github.com/nipy/nipype/blob/ed9af31d2d5cda1cf51a1fd59c3553bbdb65efa8/nipype/interfaces/tests/test_io.py#L66) for 2 minutes trying to process it.