### PR TITLE
WIP: Allow dicts as Interface input and output specs

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -760,6 +760,7 @@ class BaseInterface(Interface):
     This class cannot be instantiated.
 
     """
+    input_spec = BaseInterfaceInputSpec
     _version = None
     _additional_metadata = []
     _redirect_x = False

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -8,7 +8,7 @@ Exaples  FSL, matlab/SPM , afni
 
 Requires Packages to be installed
 """
-from __future__ import print_function, division, unicode_literals, absolute_import
+from __future__ import print_function, division, absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import range, object, open, str, bytes
@@ -760,7 +760,6 @@ class BaseInterface(Interface):
     This class cannot be instantiated.
 
     """
-    input_spec = BaseInterfaceInputSpec
     _version = None
     _additional_metadata = []
     _redirect_x = False
@@ -770,6 +769,16 @@ class BaseInterface(Interface):
         if not self.input_spec:
             raise Exception('No input_spec in class: %s' %
                             self.__class__.__name__)
+
+        if isinstance(self.input_spec, dict):
+            self.input_spec = type("AnonyomousInputSpec",
+                                   (BaseInterfaceInputSpec,),
+                                   self.input_spec)
+
+        if isinstance(self.output_spec, dict):
+            self.output_spec = type("AnonyomousOutputSpec",
+                                    (TraitedSpec,),
+                                    self.output_spec)
 
         self.inputs = self.input_spec(**inputs)
         self.estimated_memory_gb = 0.25


### PR DESCRIPTION
See #2081 for motivation. Here is a basic proof of principle:

```python
import os
import nibabel as nib
from nipype.interfaces.base import BaseInterface, traits


class MeanImage(BaseInterface):

    input_spec = dict(in_file=traits.File())
    output_spec = dict(mean_val=traits.Float())

    def _list_outputs(self):

        outputs = self._outputs().get()
        outputs["mean_val"] = self._mean_val
        return outputs

    def _run_interface(self, runtime):

        data = nib.load(self.inputs.in_file).get_data()
        self._mean_val = data.mean()
        return runtime


if __name__ == "__main__":

    fname = "/home/mwaskom/code/nipype/nipype/testing/data/tpm_00.nii.gz"
    interface = MeanImage(in_file=fname)
    print(interface.run().outputs)
```

I did run into some issues in type() with `__future__.unicode_literals` and then what I am guessing is whatever cross 2/3 magic nipype does to `str()` that will need to be sorted out...