### PR TITLE
ENH: Add cosine-basis high-pass-filter to CompCor

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -457,7 +457,7 @@ class CompCor(BaseInterface):
         if save_hpf_basis:
             if isinstance(save_hpf_basis, bool):
                 save_hpf_basis = os.path.abspath('hpf_basis.txt')
-            outputs['save_hpf_basis'] = save_hpf_basis
+            outputs['hpf_basis_file'] = save_hpf_basis
 
         return outputs
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -364,7 +364,7 @@ class CompCor(BaseInterface):
     >>> ccinterface.inputs.realigned_file = 'functional.nii'
     >>> ccinterface.inputs.mask_files = 'mask.nii'
     >>> ccinterface.inputs.num_components = 1
-    >>> ccinterface.inputs.use_regress_poly = True
+    >>> ccinterface.inputs.pre_filter = 'polynomial'
     >>> ccinterface.inputs.regress_poly_degree = 2
 
     """

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -442,7 +442,9 @@ class CompCor(BaseInterface):
 
         if self.inputs.save_hpf_basis:
             hpf_basis_file = self._list_outputs()['hpf_basis_file']
-            np.savetxt(hpf_basis_file, hpf_basis, fmt=b'%.10f', delimiter='\t')
+            header = ['cos{:02d}'.format(i) for i in range(hpf_basis.shape[1])]
+            np.savetxt(hpf_basis_file, hpf_basis, fmt=b'%.10f', delimiter='\t',
+                       header='\t'.join(header), comments='')
 
         return runtime
 
@@ -456,7 +458,7 @@ class CompCor(BaseInterface):
         save_hpf_basis = self.inputs.save_hpf_basis
         if save_hpf_basis:
             if isinstance(save_hpf_basis, bool):
-                save_hpf_basis = os.path.abspath('hpf_basis.txt')
+                save_hpf_basis = os.path.abspath('hpf_basis.tsv')
             outputs['hpf_basis_file'] = save_hpf_basis
 
         return outputs

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -543,7 +543,7 @@ class TCompCor(CompCor):
         for i, img in enumerate(mask_images):
             mask = img.get_data().astype(np.bool)
             imgseries = timeseries[mask, :]
-            imgseries = regress_poly(2, imgseries)
+            imgseries = regress_poly(2, imgseries)[0]
             tSTD = _compute_tSTD(imgseries, 0, axis=-1)
             threshold_std = np.percentile(tSTD, np.round(100. *
                            (1. - self.inputs.percentile_threshold)).astype(int))
@@ -618,7 +618,7 @@ class TSNR(BaseInterface):
             data = data.astype(np.float32)
 
         if isdefined(self.inputs.regress_poly):
-            data = regress_poly(self.inputs.regress_poly, data, remove_mean=False)
+            data = regress_poly(self.inputs.regress_poly, data, remove_mean=False)[0]
             img = nb.Nifti1Image(data, img.affine, header)
             nb.save(img, op.abspath(self.inputs.detrended_file))
 
@@ -734,9 +734,10 @@ research/nichols/scripts/fsl/standardizeddvars.pdf>`_, 2013.
         func_sd = func_sd[func_sd != 0]
 
     # Compute (non-robust) estimate of lag-1 autocorrelation
-    ar1 = np.apply_along_axis(AR_est_YW, 1,
-                              regress_poly(0, mfunc, remove_mean=True).astype(
-                                  np.float32), 1)[:, 0]
+    ar1 = np.apply_along_axis(
+        AR_est_YW, 1,
+        regress_poly(0, mfunc, remove_mean=True)[0].astype(np.float32),
+        1)[:, 0]
 
     # Compute (predicted) standard deviation of temporal difference time series
     diff_sdhat = np.squeeze(np.sqrt(((1 - ar1) * 2).tolist())) * func_sd

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -667,7 +667,7 @@ class NonSteadyStateDetector(BaseInterface):
         global_signal = in_nii.get_data()[:,:,:,:50].mean(axis=0).mean(axis=0).mean(axis=0)
 
         self._results = {
-            'n_volumes_to_discard': _is_outlier(global_signal)
+            'n_volumes_to_discard': is_outlier(global_signal)
         }
 
         return runtime

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -846,7 +846,7 @@ def cosine_filter(data, timestep, period_cut, remove_mean=False, axis=-1):
 
     frametimes = timestep * np.arange(timepoints)
     X = _full_rank(_cosine_drift(period_cut, frametimes))[0]
-    non_constant_regressors = X[:, :-1]
+    non_constant_regressors = X[:, :-1] if X.shape[1] > 1 else np.array([])
 
     betas = np.linalg.lstsq(X, data.T)[0]
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -842,19 +842,18 @@ def cosine_filter(data, timestep, remove_mean=False, axis=-1):
     data = data.reshape((-1, timepoints))
 
     frametimes = timestep * np.arange(timepoints)
-    design_matrix = _full_rank(_cosine_drift(128, frametimes))[0]
+    X = _full_rank(_cosine_drift(128, frametimes))[0]
+    non_constant_regressors = X[:, :-1]
 
-    betas = np.linalg.lstsq(design_matrix, data.T)[0]
+    betas = np.linalg.lstsq(X, data.T)[0]
 
     if not remove_mean:
-        X = design_matrix[:, :-1]
+        X = X[:, :-1]
         betas = betas[:-1]
 
     residuals = data - X.dot(betas).T
 
-    # Return non-constant regressors
-    return residuals.reshape(datashape), design_matrix[:, :-1]
-
+    return residuals.reshape(datashape), non_constant_regressors
 
 
 def regress_poly(degree, data, remove_mean=True, axis=-1):

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -464,11 +464,9 @@ class CompCor(BaseInterface):
         return outputs
 
     def _make_headers(self, num_col):
-        headers = []
         header = self.inputs.header_prefix if \
             isdefined(self.inputs.header_prefix) else self._header
-        for i in range(num_col):
-            headers.append(header + '{:02d}'.format(i))
+        headers = ['{}{:02d}'.format(header, i) for i in range(num_col)]
         return '\t'.join(headers)
 
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -449,8 +449,8 @@ class CompCor(BaseInterface):
             pre_filter_file = self._list_outputs()['pre_filter_file']
             ftype = {'polynomial': 'poly',
                      'cosine': 'cos'}[self.inputs.pre_filter]
-            header = ['{}{:02d}'.format(ftype, i)
-                      for i in range(filter_basis.shape[1])]
+            ncols = filter_basis.shape[1] if filter_basis.size > 0 else 0
+            header = ['{}{:02d}'.format(ftype, i) for i in range(ncols)]
             np.savetxt(pre_filter_file, filter_basis, fmt=b'%.10f',
                        delimiter='\t', header='\t'.join(header), comments='')
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -1048,7 +1048,8 @@ def _cosine_drift(period_cut, frametimes):
     hfcut = 1./ period_cut # input parameter is the period
 
     dt = frametimes[1] - frametimes[0] # frametimes.max() should be (len_tim-1)*dt
-    order = int(np.floor(2*len_tim*hfcut*dt)) # s.t. hfcut = 1/(2*dt) yields len_tim
+    # If series is too short, return constant regressor
+    order = max(int(np.floor(2*len_tim*hfcut*dt)), 1) # s.t. hfcut = 1/(2*dt) yields len_tim
     cdrift = np.zeros((len_tim, order))
     nfct = np.sqrt(2.0/len_tim)
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -422,10 +422,10 @@ class CompCor(BaseInterface):
                 # Derive TR from NIfTI header, if possible
                 try:
                     TR = imgseries.header.get_zooms()[3]
-                    if self.inputs.get_xyzt_units()[1] == 'msec':
+                    if imgseries.get_xyzt_units()[1] == 'msec':
                         TR /= 1000
-                except AttributeError, IndexError:
-                    pass
+                except (AttributeError, IndexError):
+                    TR = 0
 
                 if TR == 0:
                     raise ValueError(

--- a/nipype/algorithms/tests/test_auto_ACompCor.py
+++ b/nipype/algorithms/tests/test_auto_ACompCor.py
@@ -7,6 +7,8 @@ def test_ACompCor_inputs():
     input_map = dict(components_file=dict(usedefault=True,
     ),
     header_prefix=dict(),
+    high_pass_filter=dict(usedefault=True,
+    ),
     ignore_exception=dict(nohash=True,
     usedefault=True,
     ),
@@ -23,6 +25,9 @@ def test_ACompCor_inputs():
     ),
     regress_poly_degree=dict(usedefault=True,
     ),
+    repetition_time=dict(),
+    save_hpf_basis=dict(requires=['high_pass_filter'],
+    ),
     use_regress_poly=dict(usedefault=True,
     ),
     )
@@ -35,6 +40,7 @@ def test_ACompCor_inputs():
 
 def test_ACompCor_outputs():
     output_map = dict(components_file=dict(),
+    hpf_basis_file=dict(),
     )
     outputs = ACompCor.output_spec()
 

--- a/nipype/algorithms/tests/test_auto_ACompCor.py
+++ b/nipype/algorithms/tests/test_auto_ACompCor.py
@@ -7,7 +7,7 @@ def test_ACompCor_inputs():
     input_map = dict(components_file=dict(usedefault=True,
     ),
     header_prefix=dict(),
-    high_pass_filter=dict(usedefault=True,
+    high_pass_cutoff=dict(usedefault=True,
     ),
     ignore_exception=dict(nohash=True,
     usedefault=True,
@@ -21,14 +21,16 @@ def test_ACompCor_inputs():
     ),
     num_components=dict(usedefault=True,
     ),
+    pre_filter=dict(usedefault=True,
+    ),
     realigned_file=dict(mandatory=True,
     ),
     regress_poly_degree=dict(usedefault=True,
     ),
     repetition_time=dict(),
-    save_hpf_basis=dict(requires=['high_pass_filter'],
-    ),
-    use_regress_poly=dict(usedefault=True,
+    save_pre_filter=dict(),
+    use_regress_poly=dict(deprecated='0.15.0',
+    new_name='pre_filter',
     ),
     )
     inputs = ACompCor.input_spec()
@@ -40,7 +42,7 @@ def test_ACompCor_inputs():
 
 def test_ACompCor_outputs():
     output_map = dict(components_file=dict(),
-    hpf_basis_file=dict(),
+    pre_filter_file=dict(),
     )
     outputs = ACompCor.output_spec()
 

--- a/nipype/algorithms/tests/test_auto_TCompCor.py
+++ b/nipype/algorithms/tests/test_auto_TCompCor.py
@@ -7,7 +7,7 @@ def test_TCompCor_inputs():
     input_map = dict(components_file=dict(usedefault=True,
     ),
     header_prefix=dict(),
-    high_pass_filter=dict(usedefault=True,
+    high_pass_cutoff=dict(usedefault=True,
     ),
     ignore_exception=dict(nohash=True,
     usedefault=True,
@@ -23,14 +23,16 @@ def test_TCompCor_inputs():
     ),
     percentile_threshold=dict(usedefault=True,
     ),
+    pre_filter=dict(usedefault=True,
+    ),
     realigned_file=dict(mandatory=True,
     ),
     regress_poly_degree=dict(usedefault=True,
     ),
     repetition_time=dict(),
-    save_hpf_basis=dict(requires=['high_pass_filter'],
-    ),
-    use_regress_poly=dict(usedefault=True,
+    save_pre_filter=dict(),
+    use_regress_poly=dict(deprecated='0.15.0',
+    new_name='pre_filter',
     ),
     )
     inputs = TCompCor.input_spec()
@@ -43,7 +45,7 @@ def test_TCompCor_inputs():
 def test_TCompCor_outputs():
     output_map = dict(components_file=dict(),
     high_variance_masks=dict(),
-    hpf_basis_file=dict(),
+    pre_filter_file=dict(),
     )
     outputs = TCompCor.output_spec()
 

--- a/nipype/algorithms/tests/test_auto_TCompCor.py
+++ b/nipype/algorithms/tests/test_auto_TCompCor.py
@@ -7,6 +7,8 @@ def test_TCompCor_inputs():
     input_map = dict(components_file=dict(usedefault=True,
     ),
     header_prefix=dict(),
+    high_pass_filter=dict(usedefault=True,
+    ),
     ignore_exception=dict(nohash=True,
     usedefault=True,
     ),
@@ -25,6 +27,9 @@ def test_TCompCor_inputs():
     ),
     regress_poly_degree=dict(usedefault=True,
     ),
+    repetition_time=dict(),
+    save_hpf_basis=dict(requires=['high_pass_filter'],
+    ),
     use_regress_poly=dict(usedefault=True,
     ),
     )
@@ -38,6 +43,7 @@ def test_TCompCor_inputs():
 def test_TCompCor_outputs():
     output_map = dict(components_file=dict(),
     high_variance_masks=dict(),
+    hpf_basis_file=dict(),
     )
     outputs = TCompCor.output_spec()
 

--- a/nipype/algorithms/tests/test_compcor.py
+++ b/nipype/algorithms/tests/test_compcor.py
@@ -80,7 +80,7 @@ class TestCompCor():
         self.run_cc(CompCor(realigned_file=self.realigned_file,
                             mask_files=self.mask_files,
                             mask_index=0,
-                            use_regress_poly=False),
+                            pre_filter=False),
                     [['0.4451946442', '-0.7683311482'],
                      ['-0.4285129505', '-0.0926034137'],
                      ['0.5721540256', '0.5608764842'],

--- a/nipype/workflows/rsfmri/fsl/resting.py
+++ b/nipype/workflows/rsfmri/fsl/resting.py
@@ -120,7 +120,7 @@ def create_resting_preproc(name='restpreproc', base_dir=None):
                         name='getthreshold')
     threshold_stddev = pe.Node(fsl.Threshold(), name='threshold')
     compcor = pe.Node(confounds.ACompCor(components_file="noise_components.txt",
-                                  use_regress_poly=False),
+                                         pre_filter=False),
                       name='compcor')
     remove_noise = pe.Node(fsl.FilterRegressor(filter_all=True),
                            name='remove_noise')


### PR DESCRIPTION
Changes proposed in this pull request
- Adds a high-pass filter using the discrete cosine transform
- Enabled with `high_pass_filter`
- TR can be specified as an input or derived from the NIfTI header
- Cosine regressors can be saved

Todo:

* [x] `make specs`
* [x] Downstream testing (poldracklab/fmriprep#577