### PR TITLE
WIP/ENH: Dask plugin

### DIFF
--- a/nipype/pipeline/plugins/__init__.py
+++ b/nipype/pipeline/plugins/__init__.py
@@ -18,6 +18,7 @@ from .sgegraph import SGEGraphPlugin
 from .lsf import LSFPlugin
 from .slurm import SLURMPlugin
 from .slurmgraph import SLURMGraphPlugin
+from .dask import DaskPlugin
 
 from .callback_log import log_nodes_cb
 from . import  semaphore_singleton

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Parallel workflow execution via dask
+
+"""
+from __future__ import print_function, division, unicode_literals, absolute_import
+
+from .base import PluginBase
+
+
+class DaskPlugin(PluginBase):
+    """
+    Base class for plugins
+    """
+
+    def run(self, graph, config, updatehash=False):
+        pass

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -8,7 +8,6 @@ Parallel workflow execution via dask
 from __future__ import print_function, division, unicode_literals, absolute_import
 
 import sys
-import os
 from traceback import format_exception
 from functools import partial
 from dask.dot import dot_graph
@@ -35,7 +34,7 @@ def run_node(node, updatehash, *args):
     """
 
     # Init variables
-    result = dict(result=None, traceback=None)
+    result = {'traceback': None}
 
     if hasattr(node, 'get_subnodes'):
         subnodes = node.get_subnodes()
@@ -43,8 +42,9 @@ def run_node(node, updatehash, *args):
             snode.fullname: (partial(run_node, snode, updatehash), [])
             for snode in subnodes}
         client = dd.get_client()
-        dd.secede()
-        res = client.get(dask_graph, list(dask_graph.keys()))
+        dd.secede()  # Give up our worker status
+        client.get(dask_graph, list(dask_graph.keys()))  # Wait
+        # Fall of the end, to let MapNode collate and save results
 
     # Try and execute the node via node.run()
     try:

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -63,11 +63,14 @@ class DaskPlugin(PluginBase):
     def run(self, graph, config, updatehash=False):
         edges = graph.edges()
         dask_graph = {}
+        leafs = []
         for node in graph.nodes():
             parents = [edge[0].fullname for edge in edges if edge[1] is node]
             edges = [edge for edge in edges if edge[1] is not node]
+            if graph.succesors(node) == []:
+                leafs.append(node.fullname)
 
             dask_graph[node.fullname] = (partial(run_node, node, updatehash),
                                          parents)
 
-        self.dask_get(dask_graph, 'final')
+        self.dask_get(dask_graph, leafs)

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -7,7 +7,41 @@ Parallel workflow execution via dask
 """
 from __future__ import print_function, division, unicode_literals, absolute_import
 
+import dask.distributed as dd
+
 from .base import PluginBase
+
+
+def run_node(node, updatehash, *args):
+    """Function to execute node.run(), catch and log any errors and
+    return the result dictionary
+
+    Parameters
+    ----------
+    node : nipype Node instance
+        the node to run
+    updatehash : boolean
+        flag for updating hash
+
+    Returns
+    -------
+    result : dictionary
+        dictionary containing the node runtime results and stats
+    """
+
+    # Init variables
+    result = dict(result=None, traceback=None)
+
+    # Try and execute the node via node.run()
+    try:
+        result['result'] = node.run(updatehash=updatehash)
+    except:
+        etype, eval, etr = sys.exc_info()
+        result['traceback'] = format_exception(etype, eval, etr)
+        result['result'] = node.result
+
+    # Return the result dictionary
+    return result
 
 
 class DaskPlugin(PluginBase):
@@ -15,5 +49,18 @@ class DaskPlugin(PluginBase):
     Base class for plugins
     """
 
+    def __init__(self, plugin_args=None):
+        super(DaskPlugin, self).__init__(plugin_args=plugin_args)
+        self.client = dd.client(**plugin_args)
+        self.dask_get = dd.get
+
     def run(self, graph, config, updatehash=False):
-        pass
+        edges = graph.edges()
+        dask_graph = {}
+        for node in graph.nodes():
+            parents = [edge[0].fullname for edge in edges if edge[1] is node]
+            edges = [edge for edge in edges if edge[1] is not node]
+
+            dask_graph[node.fullname] = (partial(run_node, node, updatehash), parents)
+
+        self.dask_get(dask_graph, 'final')

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -11,6 +11,7 @@ import sys
 from traceback import format_exception
 from functools import partial
 import dask
+from dask.dot import dot_graph
 import dask.distributed as dd
 
 from .base import PluginBase
@@ -75,4 +76,5 @@ class DaskPlugin(PluginBase):
             dask_graph[node.fullname] = (partial(run_node, node, updatehash),
                                          parents)
 
+        dot_graph(dask_graph)
         dask.get(dask_graph, leafs)

--- a/nipype/pipeline/plugins/dask.py
+++ b/nipype/pipeline/plugins/dask.py
@@ -7,6 +7,9 @@ Parallel workflow execution via dask
 """
 from __future__ import print_function, division, unicode_literals, absolute_import
 
+import sys
+from traceback import format_exception
+from functools import partial
 import dask.distributed as dd
 
 from .base import PluginBase
@@ -64,6 +67,7 @@ class DaskPlugin(PluginBase):
             parents = [edge[0].fullname for edge in edges if edge[1] is node]
             edges = [edge for edge in edges if edge[1] is not node]
 
-            dask_graph[node.fullname] = (partial(run_node, node, updatehash), parents)
+            dask_graph[node.fullname] = (partial(run_node, node, updatehash),
+                                         parents)
 
         self.dask_get(dask_graph, 'final')

--- a/resource_test.py
+++ b/resource_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from nipype.pipeline import engine as pe
+import nipype.interfaces.utility as niu
+from functools import partial
+import time
+
+def timeit(func):
+    tic = time.time()
+    func()
+    toc = time.time()
+    return toc - tic
+
+def sleeper(arg):
+    import time
+    time.sleep(5)
+
+if __name__ == '__main__':
+    wf1 = pe.Workflow(base_dir='/tmp/nipype', name='wf1')
+    node1 = pe.Node(niu.Function(function=sleeper), name='node1')
+    node2 = pe.Node(niu.Function(function=sleeper), name='node2')
+    node1.inputs.arg = 1
+    node2.inputs.arg = 2
+    node1.interface.num_threads = 5
+    node2.interface.num_threads = 5
+    wf1.add_nodes([node1, node2])
+    
+    wf2 = pe.Workflow(base_dir='/tmp/nipype', name='wf2')
+    mapnode = pe.MapNode(niu.Function(function=sleeper), iterfield='arg', name='mapnode')
+    mapnode.inputs.arg = [3, 4]
+    mapnode.interface.num_threads = 5
+    wf2.add_nodes([mapnode])
+    
+    tic = time.time()
+    wf1.run(plugin='Dask')
+    toc = time.time()
+    time1 = toc - tic
+    tic = time.time()
+    wf2.run(plugin='Dask')
+    toc = time.time()
+    time2 = toc - tic
+    
+    print("Two Nodes: {:.1f}s".format(time1))
+    print("MapNode: {:.1f}s".format(time2))

--- a/test.py
+++ b/test.py
@@ -7,9 +7,9 @@ def increment(x):
     return x + 1
 
 if __name__ == '__main__':
-    sq = pe.Node(niu.Function(function=square), name='sq')
-    inc = pe.Node(niu.Function(function=increment), name='inc')
-    sq.inputs.x = 5
+    sq = pe.MapNode(niu.Function(function=square), iterfield=['x'], name='sq')
+    sq.inputs.x = [5, 4, 3]
+    inc = pe.MapNode(niu.Function(function=increment), iterfield=['x'], name='inc')
     wf = pe.Workflow(name='fun_wf', base_dir='/tmp')
     wf.connect([(sq, inc, [('out', 'x')])])
     wf.run(plugin='Dask')

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
+def square(x):
+    return x ** 2
+def increment(x):
+    return x + 1
+
+if __name__ == '__main__':
+    sq = pe.Node(niu.Function(function=square), name='sq')
+    inc = pe.Node(niu.Function(function=increment), name='inc')
+    sq.inputs.x = 5
+    wf = pe.Workflow(name='fun_wf', base_dir='/tmp')
+    wf.connect([(sq, inc, [('out', 'x')])])
+    wf.run(plugin='Dask')


### PR DESCRIPTION
This is a new plugin using [dask](http://dask.pydata.org/en/latest/), a parallel distribution engine that handles a huge amount of the details of intra- and inter-node IPC with a common interface. Its default invocation is effectively synonymous with `MultiProc`, although it's a little heavier since it uses Tornado under the hood.

The basic goal is to push a lot of the scheduling down the stack. For instance, we're not limited to the vagaries of a topological sort; dask does heuristic timing of nodes and can predict (some) node runtimes and adjust the run order. Further, it allows us to pass new jobs from within workers (which is how I've implemented `MapNode` distribution). This may be a useful avenue for implementing conditional or other control-flow nodes.

Finally, there are built-in profiling and job-completion report features, which would be very nice to have available in large nipype pipelines.

@oesteban is working on a launcher-like wrapper that spins up workers across nodes in a TACC job. By changing the plugin parameters, nipype could distribute jobs across nodes with the same plugin.

This preliminary work was built at the SciPy 2017 sprint.

TODO:

* [ ] Engage in resource management
* [ ] Possibly enable using `dask.multiprocessing` instead of `dask.distributed` to allow users to avoid Tornado overhead on local runs
* [ ] Remove debug code