### PR TITLE
ENH: Subclass RobustTemplate from FSCommandOpenMP

### DIFF
--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -13,7 +13,6 @@
 from __future__ import print_function, division, unicode_literals, absolute_import
 
 import os
-#import itertools
 
 from ... import logging
 from ..base import (TraitedSpec, File, traits,
@@ -27,42 +26,53 @@ iflogger = logging.getLogger('interface')
 
 class RobustTemplateInputSpec(FSTraitedSpecOpenMP):
     # required
-    in_files = InputMultiPath(File(exists=True), mandatory=True, argstr='--mov %s',
-                             desc='input movable volumes to be aligned to common mean/median template')
+    in_files = InputMultiPath(
+        File(exists=True), mandatory=True, argstr='--mov %s',
+        desc='input movable volumes to be aligned to common mean/median '
+             'template')
     out_file = File('mri_robust_template_out.mgz', mandatory=True,
                     usedefault=True, argstr='--template %s',
                     desc='output template volume (final mean/median image)')
-    auto_detect_sensitivity = traits.Bool(argstr='--satit', xor=['outlier_sensitivity'], mandatory=True,
-                                          desc='auto-detect good sensitivity (recommended for head or full brain scans)')
-    outlier_sensitivity = traits.Float(argstr='--sat %.4f', xor=['auto_detect_sensitivity'], mandatory=True,
-                                       desc='set outlier sensitivity manually (e.g. "--sat 4.685" ). Higher values mean ' +
-                                       'less sensitivity.')
+    auto_detect_sensitivity = traits.Bool(
+        argstr='--satit', xor=['outlier_sensitivity'], mandatory=True,
+        desc='auto-detect good sensitivity (recommended for head or full '
+             'brain scans)')
+    outlier_sensitivity = traits.Float(
+        argstr='--sat %.4f', xor=['auto_detect_sensitivity'], mandatory=True,
+        desc='set outlier sensitivity manually (e.g. "--sat 4.685" ). Higher '
+             'values mean less sensitivity.')
     # optional
-    transform_outputs = InputMultiPath(File(exists=False),
-                                       argstr='--lta %s',
-                                       desc='output xforms to template (for each input)')
-    intensity_scaling = traits.Bool(default_value=False,
-                                    argstr='--iscale',
-                                    desc='allow also intensity scaling (default off)')
-    scaled_intensity_outputs = InputMultiPath(File(exists=False),
-                                              argstr='--iscaleout %s',
-                                              desc='final intensity scales (will activate --iscale)')
-    subsample_threshold = traits.Int(argstr='--subsample %d',
-                                     desc='subsample if dim > # on all axes (default no subs.)')
-    average_metric = traits.Enum('median', 'mean', argstr='--average %d',
-                                 desc='construct template from: 0 Mean, 1 Median (default)')
-    initial_timepoint = traits.Int(argstr='--inittp %d',
-                                   desc='use TP# for spacial init (default random), 0: no init')
-    fixed_timepoint = traits.Bool(default_value=False, argstr='--fixtp',
-                                  desc='map everthing to init TP# (init TP is not resampled)')
-    no_iteration = traits.Bool(default_value=False, argstr='--noit',
-                               desc='do not iterate, just create first template')
-    initial_transforms = InputMultiPath(File(exists=True),
-                                        argstr='--ixforms %s',
-                                        desc='use initial transforms (lta) on source')
-    in_intensity_scales = InputMultiPath(File(exists=True),
-                                         argstr='--iscalein %s',
-                                         desc='use initial intensity scales')
+    transform_outputs = InputMultiPath(
+        File(exists=False), argstr='--lta %s',
+        desc='output xforms to template (for each input)')
+    intensity_scaling = traits.Bool(
+        default_value=False, argstr='--iscale',
+        desc='allow also intensity scaling (default off)')
+    scaled_intensity_outputs = InputMultiPath(
+        File(exists=False), argstr='--iscaleout %s',
+        desc='final intensity scales (will activate --iscale)')
+    subsample_threshold = traits.Int(
+        argstr='--subsample %d',
+        desc='subsample if dim > # on all axes (default no subs.)')
+    average_metric = traits.Enum(
+        'median', 'mean', argstr='--average %d',
+        desc='construct template from: 0 Mean, 1 Median (default)')
+    initial_timepoint = traits.Int(
+        argstr='--inittp %d',
+        desc='use TP# for spacial init (default random), 0: no init')
+    fixed_timepoint = traits.Bool(
+        default_value=False, argstr='--fixtp',
+        desc='map everthing to init TP# (init TP is not resampled)')
+    no_iteration = traits.Bool(
+        default_value=False, argstr='--noit',
+        desc='do not iterate, just create first template')
+    initial_transforms = InputMultiPath(
+        File(exists=True), argstr='--ixforms %s',
+        desc='use initial transforms (lta) on source')
+    in_intensity_scales = InputMultiPath(
+        File(exists=True), argstr='--iscalein %s',
+        desc='use initial intensity scales')
+
 
 class RobustTemplateOutputSpec(TraitedSpec):
     out_file = File(
@@ -93,8 +103,10 @@ class RobustTemplate(FSCommandOpenMP):
     >>> template.cmdline  #doctest: +NORMALIZE_WHITESPACE +ALLOW_UNICODE
     'mri_robust_template --satit --average 0 --fixtp --mov structural.nii functional.nii --inittp 1 --noit --template T1.nii --subsample 200'
 
-    >>> template.inputs.transform_outputs = ['structural.lta', 'functional.lta']
-    >>> template.inputs.scaled_intensity_outputs = ['structural-iscale.txt', 'functional-iscale.txt']
+    >>> template.inputs.transform_outputs = ['structural.lta',
+    ...                                      'functional.lta']
+    >>> template.inputs.scaled_intensity_outputs = ['structural-iscale.txt',
+    ...                                             'functional-iscale.txt']
     >>> template.cmdline    #doctest: +NORMALIZE_WHITESPACE +ALLOW_UNICODE
     'mri_robust_template --satit --average 0 --fixtp --mov structural.nii functional.nii --inittp 1 --noit --template T1.nii --iscaleout structural-iscale.txt functional-iscale.txt --subsample 200 --lta structural.lta functional.lta'
 
@@ -152,8 +164,10 @@ class FuseSegmentationsInputSpec(FSTraitedSpec):
         must include the corresponding norm file for all given timepoints \
         as well as for the current subject")
 
+
 class FuseSegmentationsOutputSpec(TraitedSpec):
     out_file = File(exists=False, desc="output fused segmentation file")
+
 
 class FuseSegmentations(FSCommand):
 

--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -18,13 +18,14 @@ import os
 from ... import logging
 from ..base import (TraitedSpec, File, traits,
                     InputMultiPath, OutputMultiPath, isdefined)
-from .base import FSCommand, FSTraitedSpec
+from .base import (FSCommand, FSTraitedSpec, FSCommandOpenMP,
+                   FSTraitedSpecOpenMP)
 
 __docformat__ = 'restructuredtext'
 iflogger = logging.getLogger('interface')
 
 
-class RobustTemplateInputSpec(FSTraitedSpec):
+class RobustTemplateInputSpec(FSTraitedSpecOpenMP):
     # required
     in_files = InputMultiPath(File(exists=True), mandatory=True, argstr='--mov %s',
                              desc='input movable volumes to be aligned to common mean/median template')
@@ -72,7 +73,7 @@ class RobustTemplateOutputSpec(TraitedSpec):
         File(exists=True), desc="output final intensity scales")
 
 
-class RobustTemplate(FSCommand):
+class RobustTemplate(FSCommandOpenMP):
     """ construct an unbiased robust template for longitudinal volumes
 
     Examples

--- a/nipype/interfaces/freesurfer/tests/test_auto_RobustTemplate.py
+++ b/nipype/interfaces/freesurfer/tests/test_auto_RobustTemplate.py
@@ -33,6 +33,7 @@ def test_RobustTemplate_inputs():
     ),
     no_iteration=dict(argstr='--noit',
     ),
+    num_threads=dict(),
     out_file=dict(argstr='--template %s',
     mandatory=True,
     usedefault=True,


### PR DESCRIPTION
Changes proposed in this pull request
- Subclassing from FSCommandOpenMP enables the `num_threads` input

954f3b3 is the commit that matters. The style commit should have no semantic changes.