### PR TITLE
ENH: Add default transform, intensity scaling files to RobustTemplate

### DIFF
--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -144,12 +144,14 @@ class RobustTemplate(FSCommandOpenMP):
         if isdefined(self.inputs.transform_outputs):
             fnames = self.inputs.transform_outputs
             if fnames is True:
-                fnames = [fmt.format('tp', i, 'lta') for i in range(n_files)]
+                fnames = [fmt.format('tp', i + 1, 'lta')
+                          for i in range(n_files)]
             outputs['transform_outputs'] = [os.path.abspath(x) for x in fnames]
         if isdefined(self.inputs.scaled_intensity_outputs):
             fnames = self.inputs.scaled_intensity_outputs
             if fnames is True:
-                fnames = [fmt.format('is', i, 'txt') for i in range(n_files)]
+                fnames = [fmt.format('is', i + 1, 'txt')
+                          for i in range(n_files)]
             outputs['scaled_intensity_outputs'] = [os.path.abspath(x)
                                                    for x in fnames]
         return outputs

--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -42,14 +42,15 @@ class RobustTemplateInputSpec(FSTraitedSpecOpenMP):
         desc='set outlier sensitivity manually (e.g. "--sat 4.685" ). Higher '
              'values mean less sensitivity.')
     # optional
-    transform_outputs = InputMultiPath(
-        File(exists=False), argstr='--lta %s',
+    transform_outputs = traits.Either(
+        InputMultiPath(File(exists=False)), traits.Bool, argstr='--lta %s',
         desc='output xforms to template (for each input)')
     intensity_scaling = traits.Bool(
         default_value=False, argstr='--iscale',
         desc='allow also intensity scaling (default off)')
-    scaled_intensity_outputs = InputMultiPath(
-        File(exists=False), argstr='--iscaleout %s',
+    scaled_intensity_outputs = traits.Either(
+        InputMultiPath(File(exists=False)), traits.Bool,
+        argstr='--iscaleout %s',
         desc='final intensity scales (will activate --iscale)')
     subsample_threshold = traits.Int(
         argstr='--subsample %d',
@@ -126,18 +127,26 @@ class RobustTemplate(FSCommandOpenMP):
         if name == 'average_metric':
             # return enumeration value
             return spec.argstr % {"mean": 0, "median": 1}[value]
+        if name in ('transform_outputs', 'scaled_intensity_outputs'):
+            value = self._list_outputs()[name]
         return super(RobustTemplate, self)._format_arg(name, spec, value)
 
     def _list_outputs(self):
         outputs = self.output_spec().get()
-        outputs['out_file'] = os.path.abspath(
-            self.inputs.out_file)
+        outputs['out_file'] = os.path.abspath(self.inputs.out_file)
+        n_files = len(self.inputs.in_files)
+        fmt = '{}{:02d}.{}' if n_files > 9 else '{}{:d}.{}'
         if isdefined(self.inputs.transform_outputs):
-            outputs['transform_outputs'] = [os.path.abspath(
-                x) for x in self.inputs.transform_outputs]
+            fnames = self.inputs.transform_outputs
+            if fnames is True:
+                fnames = [fmt.format('tp', i, 'lta') for i in range(n_files)]
+            outputs['transform_outputs'] = [os.path.abspath(x) for x in fnames]
         if isdefined(self.inputs.scaled_intensity_outputs):
-            outputs['scaled_intensity_outputs'] = [os.path.abspath(
-                x) for x in self.inputs.scaled_intensity_outputs]
+            fnames = self.inputs.scaled_intensity_outputs
+            if fnames is True:
+                fnames = [fmt.format('is', i, 'txt') for i in range(n_files)]
+            outputs['scaled_intensity_outputs'] = [os.path.abspath(x)
+                                                   for x in fnames]
         return outputs
 
 

--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -108,8 +108,13 @@ class RobustTemplate(FSCommandOpenMP):
     ...                                      'functional.lta']
     >>> template.inputs.scaled_intensity_outputs = ['structural-iscale.txt',
     ...                                             'functional-iscale.txt']
-    >>> template.cmdline    #doctest: +NORMALIZE_WHITESPACE +ALLOW_UNICODE
-    'mri_robust_template --satit --average 0 --fixtp --mov structural.nii functional.nii --inittp 1 --noit --template T1.nii --iscaleout structural-iscale.txt functional-iscale.txt --subsample 200 --lta structural.lta functional.lta'
+    >>> template.cmdline    #doctest: +NORMALIZE_WHITESPACE +ALLOW_UNICODE +ELLIPSIS
+    'mri_robust_template --satit --average 0 --fixtp --mov structural.nii functional.nii --inittp 1 --noit --template T1.nii --iscaleout .../structural-iscale.txt .../functional-iscale.txt --subsample 200 --lta .../structural.lta .../functional.lta'
+
+    >>> template.inputs.transform_outputs = True
+    >>> template.inputs.scaled_intensity_outputs = True
+    >>> template.cmdline    #doctest: +NORMALIZE_WHITESPACE +ALLOW_UNICODE +ELLIPSIS
+    'mri_robust_template --satit --average 0 --fixtp --mov structural.nii functional.nii --inittp 1 --noit --template T1.nii --iscaleout .../is1.txt .../is2.txt --subsample 200 --lta .../tp1.lta .../tp2.lta'
 
     >>> template.run()  #doctest: +SKIP
 


### PR DESCRIPTION
Changes proposed in this pull request
- Allows `transform_outputs=True` and `scaled_intensity_outputs=True` to create files with default names, rather than pre-specifying.

From the docs:

```
OPTIONAL FLAGGED ARGUMENTS
	--lta <tp1.lta> <tp2.lta> ...
		output xforms to template (for each input)
[...]
	--iscaleout <is1.txt> <is2.txt> ...
		output final intensity scales (will activate --iscale)
```