### PR TITLE
ENH: Speed up S3DataGrabber using prefix arg

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -518,6 +518,11 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "affiliation": "University of Amsterdam",
+      "name": "Lukas Snoek",
+      "orcid": "0000-0001-8972-204X"
     }
   ],
   "keywords": [

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -866,10 +866,11 @@ class S3DataGrabber(IOBase):
                     raise ValueError(msg)
 
         outputs = {}
+
         # get list of all files in s3 bucket
         conn = boto.connect_s3(anon=self.inputs.anon)
         bkt = conn.get_bucket(self.inputs.bucket)
-        bkt_files = list(k.key for k in bkt.list())
+        bkt_files = list(k.key for k in bkt.list(prefix=self.inputs.bucket_path))
 
         # keys are outfields, args are template args for the outfield
         for key, args in list(self.inputs.template_args.items()):

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -866,7 +866,6 @@ class S3DataGrabber(IOBase):
                     raise ValueError(msg)
 
         outputs = {}
-
         # get list of all files in s3 bucket
         conn = boto.connect_s3(anon=self.inputs.anon)
         bkt = conn.get_bucket(self.inputs.bucket)


### PR DESCRIPTION
Changes proposed in this pull request
- When finding files on S3 (using `S3DataGrabber`), the command ...

    `bkt_files = list(k.key for k in bkt.list())`

... finds *all* files in a given bucket, which takes *very* long for the `openneuro` and `openfmri` buckets. On my computer, this command (using the example from `nipype/interfaces/tests/test_io.py`) takes 170 seconds. However, as proposed in my PR, when you use the `prefix` argument with the `bucket_path` in the `bkt.list()` call, it only takes 116 milliseconds. This is because it restricts the filesearch to *only* the files in the specified `bucket_path`. The interface still works when `bucket_path` is not set as input (i.e., it works with the default `''` value of the `bucket_path` parameter).

- Add name/affiliation to zenodo-file (first PR!)
