### PR TITLE
FIX: allow grabbing a single file (fix bug assuming string is not ite…

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -948,12 +948,11 @@ class S3DataGrabber(IOBase):
         # We must convert to the local location specified
         # and download the files.
         for key,val in outputs.items():
-            #This will basically be either list-like or string-like:
-            #if it has the __iter__ attribute, it's list-like (list,
-            #tuple, numpy array) and we iterate through each of its
-            #values. If it doesn't, it's string-like (string,
-            #unicode), and we convert that value directly.
-            if hasattr(val,'__iter__'):
+            # This will basically be either list-like or string-like:
+            # if it's an instance of a list, we'll iterate through it.
+            # If it isn't, it's string-like (string, unicode), we
+            # convert that value directly.
+            if isinstance(val, (list, tuple, set)):
                 for i,path in enumerate(val):
                     outputs[key][i] = self.s3tolocal(path, bkt)
             else:


### PR DESCRIPTION
Changes proposed in this pull request
- Fix bug in `S3DataGrabber` due to the assumption that Python strings are not iterable (they are) as outlined in [nipype.interfaces.io](https://github.com/nipy/nipype/blob/master/nipype/interfaces/io.py#L956). As a consequence, when you only want to grab a single file from S3, it will cause the interface to loop over the characters of the string specifying the S3-path and subsequently break when trying to download the file. I replaced the `hasattr(val, '__iter__')` with:

`isinstance(val, (list, tuple, set))`

which now allows for grabbing of a single file.
