### PR TITLE
FIX: updates input spec to allow 4D images

### DIFF
--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -129,8 +129,8 @@ class GenWarpFields(antsIntroduction):
 
 
 class buildtemplateparallelInputSpec(ANTSCommandInputSpec):
-    dimension = traits.Enum(3, 2, argstr='-d %d', usedefault=True,
-                            desc='image dimension (2 or 3)', position=1)
+    dimension = traits.Enum(3, 2, 4, argstr='-d %d', usedefault=True,
+                            desc='image dimension (2, 3 or 4)', position=1)
     out_prefix = traits.Str('antsTMPL_', argstr='-o %s', usedefault=True,
                             desc=('Prefix that is prepended to all output '
                                   'files (default = antsTMPL_)'))

--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -238,9 +238,9 @@ class LaplacianThickness(ANTSCommand):
 
 
 class N4BiasFieldCorrectionInputSpec(ANTSCommandInputSpec):
-    dimension = traits.Enum(3, 2, argstr='-d %d',
+    dimension = traits.Enum(3, 2, 4, argstr='-d %d',
                             usedefault=True,
-                            desc='image dimension (2 or 3)')
+                            desc='image dimension (2, 3 or 4)')
     input_image = File(argstr='--input-image %s', mandatory=True,
                        desc=('image to apply transformation to (generally a '
                              'coregistered functional)'))


### PR DESCRIPTION
ANTs' ``buildtemplateparallel.sh`` and ``N4BiasFieldCorrection`` allow 4D images as input files. Nipype restricted the inputs to be 2D or 3D.