### PR TITLE
ENH: Allow input weight for afni's volreg.

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -119,7 +119,7 @@ class AlignEpiAnatPyOutputSpec(TraitedSpec):
         desc="matrix to volume register and align epi"
              "to anatomy and put into standard space")
     epi_vr_motion = File(
-        desc="motion parameters from EPI time-series" 
+        desc="motion parameters from EPI time-series"
              "registration (tsh included in name if slice"
              "timing correction is also included).")
     skullstrip = File(
@@ -131,20 +131,20 @@ class AlignEpiAnatPy(AFNIPythonCommand):
     an EPI and an anatomical structural dataset, and applies the resulting
     transformation to one or the other to bring them into alignment.
 
-    This script computes the transforms needed to align EPI and  
-    anatomical datasets using a cost function designed for this purpose. The  
-    script combines multiple transformations, thereby minimizing the amount of 
+    This script computes the transforms needed to align EPI and
+    anatomical datasets using a cost function designed for this purpose. The
+    script combines multiple transformations, thereby minimizing the amount of
     interpolation applied to the data.
-    
+
     Basic Usage:
       align_epi_anat.py -anat anat+orig -epi epi+orig -epi_base 5
-    
+
     The user must provide EPI and anatomical datasets and specify the EPI
-    sub-brick to use as a base in the alignment.  
+    sub-brick to use as a base in the alignment.
 
     Internally, the script always aligns the anatomical to the EPI dataset,
-    and the resulting transformation is saved to a 1D file. 
-    As a user option, the inverse of this transformation may be applied to the 
+    and the resulting transformation is saved to a 1D file.
+    As a user option, the inverse of this transformation may be applied to the
     EPI dataset in order to align it to the anatomical data instead.
 
     This program generates several kinds of output in the form of datasets
@@ -182,7 +182,7 @@ class AlignEpiAnatPy(AFNIPythonCommand):
         epi_prefix = ''.join(self._gen_fname(self.inputs.in_file).split('+')[:-1])
         outputtype = self.inputs.outputtype
         if outputtype == 'AFNI':
-            ext = '.HEAD' 
+            ext = '.HEAD'
         else:
             Info.output_type_to_ext(outputtype)
         matext = '.1D'
@@ -620,7 +620,7 @@ class AutoTLRCInputSpec(CommandLineInputSpec):
         mandatory=True,
         exists=True,
         copyfile=False)
-    base = traits.Str(  
+    base = traits.Str(
         desc = '              Reference anatomical volume'
                 '              Usually this volume is in some standard space like'
                 '              TLRC or MNI space and with afni dataset view of'
@@ -706,7 +706,7 @@ class AutoTLRC(AFNICommand):
         ext = '.HEAD'
         outputs['out_file'] = os.path.abspath(self._gen_fname(self.inputs.in_file, suffix='+tlrc')+ext)
         return outputs
-    
+
 class BandpassInputSpec(AFNICommandInputSpec):
     in_file = File(
         desc='input file to 3dBandpass',

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2547,6 +2547,11 @@ class VolregInputSpec(AFNICommandInputSpec):
         argstr='-base %s',
         position=-6,
         exists=True)
+    in_weight_file = File(
+        desc='File for input weighting volume',
+        argstr="-weight '%s[0]'",
+        exists=True)
+
     zpad = traits.Int(
         desc='Zeropad around the edges by \'n\' voxels during rotations',
         argstr='-zpad %d',

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2547,10 +2547,12 @@ class VolregInputSpec(AFNICommandInputSpec):
         argstr='-base %s',
         position=-6,
         exists=True)
-    in_weight_file = File(
-        desc='File for input weighting volume',
-        argstr="-weight '%s[0]'",
-        exists=True)
+    in_weight_volume = traits.Either(
+        traits.Tuple(File(exists=True), traits.Int),
+        File(exists=True),
+        desc='weights for each voxel. a file with an optional volume number'
+             ' (defaults to 0)',
+        argstr="-weight '%s[%d]'")
 
     zpad = traits.Int(
         desc='Zeropad around the edges by \'n\' voxels during rotations',
@@ -2585,9 +2587,14 @@ class VolregInputSpec(AFNICommandInputSpec):
         keep_extension=True,
         name_source='in_file')
     interp = traits.Enum(
-        ('Fourier', 'cubic', 'heptic', 'quintic','linear'),
+        ('Fourier', 'cubic', 'heptic', 'quintic', 'linear'),
         desc='spatial interpolation methods [default = heptic]',
         argstr='-%s')
+
+    def _format_arg(self, name, trait_spec, value):
+        if name == 'in_weight_volume' and not isinstance(value, traits.Tuple):
+            value = (value, 0)
+        return super(Volreg, self)._format_arg(name, trait_spec, value)
 
 
 class VolregOutputSpec(TraitedSpec):

--- a/nipype/interfaces/afni/tests/test_auto_Volreg.py
+++ b/nipype/interfaces/afni/tests/test_auto_Volreg.py
@@ -22,7 +22,7 @@ def test_Volreg_inputs():
     mandatory=True,
     position=-1,
     ),
-    in_weight_file=dict(argstr="-weight '%s[0]'",
+    in_weight_volume=dict(argstr="-weight '%s[%d]'",
     ),
     interp=dict(argstr='-%s',
     ),

--- a/nipype/interfaces/afni/tests/test_auto_Volreg.py
+++ b/nipype/interfaces/afni/tests/test_auto_Volreg.py
@@ -22,6 +22,8 @@ def test_Volreg_inputs():
     mandatory=True,
     position=-1,
     ),
+    in_weight_file=dict(argstr="-weight '%s[0]'",
+    ),
     interp=dict(argstr='-%s',
     ),
     md1d_file=dict(argstr='-maxdisp1D %s',


### PR DESCRIPTION
This PR should be discussed before accepting.

I've added the following to `VolregInputSpec`:
```
    in_weight_file = File(
        desc='File for input weighting volume',
        argstr="-weight '%s[0]'",
        exists=True)
```
Apparently, `3dvolreg` requires the volume number for the weight. I don't know of a good way to do this with NiPype, so I make it just take the first volume (I think typically someone would only pass a single volume image). Is this sufficient?

Also there doesn't seem to be a standard way for naming the input weights. I went with a more verbose version, but feedback is welcome.

I tried to run `make check-before-commit` and received the error "ImportError: No module named packaging.version". I'm running the code in virtualenv with Python3, using pip to install.