### PR TITLE
FIX: Detecting and apropriately warning about unconnected duplicatlely nodes

### DIFF
--- a/nipype/pipeline/engine/tests/test_workflows.py
+++ b/nipype/pipeline/engine/tests/test_workflows.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""Tests for the engine workflows module
+"""
+import pytest
+
+from ... import engine as pe
+from ....interfaces import utility as niu
+
+
+def test_duplicate_node_check():
+
+    wf = pe.Workflow(name="testidentity")
+
+    original_list = [0,1,2,3,4,5,6,7,8,9]
+
+    selector1 = pe.Node(niu.Select(), name="selector1")
+    selector1.inputs.index = original_list[:-1]
+    selector1.inputs.inlist = original_list
+    selector2 = pe.Node(niu.Select(), name="selector2")
+    selector2.inputs.index = original_list[:-2]
+    selector3 = pe.Node(niu.Select(), name="selector3")
+    selector3.inputs.index = original_list[:-3]
+    selector4 = pe.Node(niu.Select(), name="selector3")
+    selector4.inputs.index = original_list[:-4]
+
+    wf_connections = [
+            (selector1, selector2, [("out","inlist")]),
+            (selector2, selector3, [("out","inlist")]),
+            (selector3, selector4, [("out","inlist")]),
+            ]
+
+    with pytest.raises(IOError) as excinfo:
+        wf.connect(wf_connections)
+    assert 'Duplicate node name "selector3" found.' == str(excinfo.value)

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -700,8 +700,13 @@ connected.
         for node in nodes:
             if node.name in node_names:
                 idx = node_names.index(node.name)
-                if node_lineage[idx] in [node._hierarchy, self.name]:
-                    raise IOError('Duplicate node name %s found.' % node.name)
+                try:
+                    this_node_lineage = node_lineage[idx]
+                except IndexError:
+                    raise IOError('Duplicate node name "%s" found.' % node.name)
+                else:
+                    if this_node_lineage in [node._hierarchy, self.name]:
+                        raise IOError('Duplicate node name "%s" found.' % node.name)
             else:
                 node_names.append(node.name)
 


### PR DESCRIPTION
If the workflow contained an unconnected node with a duplicate name, the check failed with a nondescript `IndexError`, which required the user to either manually re-check their entire connections list for any errors at all, or hack the nipype code with print calls to find out which node is triggering the exception.

Now, the check gives the correct name duplication error and the name of the node, even if the node has no lineage.