### PR TITLE
FIX: missing probtrackx/probtrackx2 outputs

### DIFF
--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -927,7 +927,7 @@ class ProbTrackX2(ProbTrackX):
             out_dir = self.inputs.out_dir
 
         if isdefined(self.inputs.omatrix1):
-            outputs['network_matrix'] = os.path.abspath(os.path.join(out_dir, 'fdt_network_matrix'))
+            outputs['network_matrix'] = os.path.abspath(os.path.join(out_dir, 'matrix_seeds_to_all_targets'))
             outputs['matrix1_dot'] = os.path.abspath(os.path.join(out_dir, 'fdt_matrix1.dot'))
 
         if isdefined(self.inputs.omatrix2):

--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -926,6 +926,8 @@ class ProbTrackX2(ProbTrackX):
         else:
             out_dir = self.inputs.out_dir
 
+        outputs['way_total'] = os.path.abspath(os.path.join(out_dir, 'waytotal'))
+
         if isdefined(self.inputs.omatrix1):
             outputs['network_matrix'] = os.path.abspath(os.path.join(out_dir, 'matrix_seeds_to_all_targets'))
             outputs['matrix1_dot'] = os.path.abspath(os.path.join(out_dir, 'fdt_matrix1.dot'))

--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -812,7 +812,7 @@ class ProbTrackX(FSLCommand):
             out_dir = self.inputs.out_dir
 
         outputs['log'] = os.path.abspath(os.path.join(out_dir, 'probtrackx.log'))
-        #utputs['way_total'] = os.path.abspath(os.path.join(out_dir, 'waytotal'))
+        outputs['way_total'] = os.path.abspath(os.path.join(out_dir, 'waytotal'))
         if isdefined(self.inputs.opd == True):
             if isinstance(self.inputs.seed, list) and isinstance(self.inputs.seed[0], list):
                 outputs['fdt_paths'] = []


### PR DESCRIPTION
Changes proposed in this pull request
- uncommented/fixed probtrackx `outputs['waytotal']`
- added probtrackx2 `outputs['waytotal']`, a default probtrackx2 output
- fixed the target file for probtrackx2 omatrix1 `outputs['network_matrix']`: it now (correctly) looks for `matrix_seeds_to_all_targets`
