### PR TITLE
FIX: update probtrackx2 outputs

### DIFF
--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -797,7 +797,7 @@ class ProbTrackX2(ProbTrackX):
 
         if isdefined(self.inputs.omatrix1):
             outputs['network_matrix'] = os.path.abspath(
-                os.path.join(out_dir, 'fdt_network_matrix'))
+                os.path.join(out_dir, 'matrix_seeds_to_all_targets'))
             outputs['matrix1_dot'] = os.path.abspath(
                 os.path.join(out_dir, 'fdt_matrix1.dot'))
 

--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -795,6 +795,8 @@ class ProbTrackX2(ProbTrackX):
         else:
             out_dir = self.inputs.out_dir
 
+        outputs['way_total'] = os.path.abspath(os.path.join(out_dir, 'waytotal'))
+
         if isdefined(self.inputs.omatrix1):
             outputs['network_matrix'] = os.path.abspath(
                 os.path.join(out_dir, 'matrix_seeds_to_all_targets'))


### PR DESCRIPTION
updated PR from #2168

Changes proposed in this pull request
- added `outputs['way_total']`, a default output
- changed target file for omatrix1's `outputs['network_matrix']` to `matrix_seeds_to_all_targets`, the correct probtrackx2 output file
