### PR TITLE
[ENH] update for networkx dev version (should fix #2159)

### DIFF
--- a/doc/users/install.rst
+++ b/doc/users/install.rst
@@ -47,7 +47,7 @@ use the following command::
 While `all` installs everything, one can also install select components as
 listed below::
 
-    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydotplus'],
+    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydot'],
     'tests': ['pytest-cov', 'codecov'],
     'nipy': ['nitime', 'nilearn', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil'],

--- a/doc/users/install.rst
+++ b/doc/users/install.rst
@@ -47,7 +47,7 @@ use the following command::
 While `all` installs everything, one can also install select components as
 listed below::
 
-    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydot'],
+    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],
     'tests': ['pytest-cov', 'codecov'],
     'nipy': ['nitime', 'nilearn', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil'],

--- a/examples/dmri_dtk_dti.py
+++ b/examples/dmri_dtk_dti.py
@@ -37,7 +37,6 @@ from nipype.utils.misc import package_check
 
 package_check('numpy', '1.3', 'tutorial1')
 package_check('scipy', '0.7', 'tutorial1')
-package_check('networkx', '1.0', 'tutorial1')
 package_check('IPython', '0.10', 'tutorial1')
 
 

--- a/examples/dmri_dtk_odf.py
+++ b/examples/dmri_dtk_odf.py
@@ -37,7 +37,6 @@ from nipype.utils.misc import package_check
 
 package_check('numpy', '1.3', 'tutorial1')
 package_check('scipy', '0.7', 'tutorial1')
-package_check('networkx', '1.0', 'tutorial1')
 package_check('IPython', '0.10', 'tutorial1')
 
 

--- a/examples/dmri_fsl_dti.py
+++ b/examples/dmri_fsl_dti.py
@@ -37,7 +37,6 @@ from nipype.utils.misc import package_check
 
 package_check('numpy', '1.3', 'tutorial1')
 package_check('scipy', '0.7', 'tutorial1')
-package_check('networkx', '1.0', 'tutorial1')
 package_check('IPython', '0.10', 'tutorial1')
 
 

--- a/examples/fmri_slicer_coregistration.py
+++ b/examples/fmri_slicer_coregistration.py
@@ -37,7 +37,6 @@ from nipype.utils.misc import package_check
 
 package_check('numpy', '1.3', 'tutorial1')
 package_check('scipy', '0.7', 'tutorial1')
-package_check('networkx', '1.0', 'tutorial1')
 package_check('IPython', '0.10', 'tutorial1')
 
 """The nipype tutorial contains data for two subjects.  Subject data

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -141,7 +141,7 @@ REQUIRES = [
     'funcsigs',
     'pytest>=%s' % PYTEST_MIN_VERSION,
     'mock',
-    'pydotplus',
+    'pydot',
     'packaging',
 ]
 
@@ -154,7 +154,7 @@ TESTS_REQUIRES = [
 ]
 
 EXTRA_REQUIRES = {
-    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydotplus'],
+    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydot'],
     'tests': TESTS_REQUIRES,
     'nipy': ['nitime', 'nilearn', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil'],

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -107,6 +107,7 @@ FUTURE_MIN_VERSION = '0.16.0'
 SIMPLEJSON_MIN_VERSION = '3.8.0'
 PROV_VERSION = '1.5.0'
 CLICK_MIN_VERSION = '6.6.0'
+PYDOT_MIN_VERSION = '1.2.3'
 
 NAME = 'nipype'
 MAINTAINER = 'nipype developers'
@@ -141,7 +142,8 @@ REQUIRES = [
     'funcsigs',
     'pytest>=%s' % PYTEST_MIN_VERSION,
     'mock',
-    'pydot',
+    'pydotplus',
+    'pydot>=%s' % PYDOT_MIN_VERSION,
     'packaging',
 ]
 
@@ -154,7 +156,7 @@ TESTS_REQUIRES = [
 ]
 
 EXTRA_REQUIRES = {
-    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydot'],
+    'doc': ['Sphinx>=1.4', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],
     'tests': TESTS_REQUIRES,
     'nipy': ['nitime', 'nilearn', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil'],

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -219,7 +219,7 @@ def cmat(track_file, roi_file, resolution_network_file, matrix_name, matrix_mat_
     else:
         G = nx.Graph()
         for u, d in gp.nodes(data=True):
-            G.add_node(int(u), d)
+            G.add_node(int(u), **d)
             # compute a position for the node based on the mean position of the
             # ROI in voxel coordinates (segmentation volume )
             xyz = tuple(np.mean(np.where(np.flipud(roiData) == int(d["dn_correspondence_id"])), axis=1))
@@ -319,7 +319,7 @@ def cmat(track_file, roi_file, resolution_network_file, matrix_name, matrix_mat_
             di['fiber_length_median'] = 0
             di['fiber_length_std'] = 0
         if not u == v:  # Fix for self loop problem
-            G.add_edge(u, v, di)
+            G.add_edge(u, v, **di)
             if 'fiblist' in d:
                 numfib.add_edge(u, v, weight=di['number_of_fibers'])
                 fibmean.add_edge(u, v, weight=di['fiber_length_mean'])
@@ -748,7 +748,7 @@ def create_nodes(roi_file, resolution_network_file, out_filename):
     roiData = roi_image.get_data()
     nROIs = len(gp.nodes())
     for u, d in gp.nodes(data=True):
-        G.add_node(int(u), d)
+        G.add_node(int(u), **d)
         xyz = tuple(np.mean(np.where(np.flipud(roiData) == int(d["dn_correspondence_id"])), axis=1))
         G.nodes[int(u)]['dn_position'] = tuple([xyz[0], xyz[2], -xyz[1]])
     nx.write_gpickle(G, out_filename)

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -214,16 +214,16 @@ def cmat(track_file, roi_file, resolution_network_file, matrix_name, matrix_mat_
     nROIs = len(gp.nodes())
 
     # add node information from parcellation
-    if 'dn_position' in gp.node[gp.nodes()[0]]:
+    if 'dn_position' in gp.nodes[list(gp.nodes())[0]]:
         G = gp.copy()
     else:
         G = nx.Graph()
-        for u, d in gp.nodes_iter(data=True):
+        for u, d in gp.nodes(data=True):
             G.add_node(int(u), d)
             # compute a position for the node based on the mean position of the
             # ROI in voxel coordinates (segmentation volume )
             xyz = tuple(np.mean(np.where(np.flipud(roiData) == int(d["dn_correspondence_id"])), axis=1))
-            G.node[int(u)]['dn_position'] = tuple([xyz[0], xyz[2], -xyz[1]])
+            G.nodes[int(u)]['dn_position'] = tuple([xyz[0], xyz[2], -xyz[1]])
 
     if intersections:
         iflogger.info("Filtering tractography from intersections")
@@ -304,7 +304,7 @@ def cmat(track_file, roi_file, resolution_network_file, matrix_name, matrix_mat_
     fibmean = numfib.copy()
     fibmedian = numfib.copy()
     fibdev = numfib.copy()
-    for u, v, d in G.edges_iter(data=True):
+    for u, v, d in G.edges(data=True):
         G.remove_edge(u, v)
         di = {}
         if 'fiblist' in d:
@@ -747,10 +747,10 @@ def create_nodes(roi_file, resolution_network_file, out_filename):
     roi_image = nb.load(roi_file, mmap=NUMPY_MMAP)
     roiData = roi_image.get_data()
     nROIs = len(gp.nodes())
-    for u, d in gp.nodes_iter(data=True):
+    for u, d in gp.nodes(data=True):
         G.add_node(int(u), d)
         xyz = tuple(np.mean(np.where(np.flipud(roiData) == int(d["dn_correspondence_id"])), axis=1))
-        G.node[int(u)]['dn_position'] = tuple([xyz[0], xyz[2], -xyz[1]])
+        G.nodes[int(u)]['dn_position'] = tuple([xyz[0], xyz[2], -xyz[1]])
     nx.write_gpickle(G, out_filename)
     return out_filename
 

--- a/nipype/interfaces/cmtk/nbs.py
+++ b/nipype/interfaces/cmtk/nbs.py
@@ -113,9 +113,9 @@ class NetworkBasedStatistic(BaseInterface):
         node_network = nx.read_gpickle(node_ntwk_name)
         iflogger.info('Populating node dictionaries with attributes from {node}'.format(node=node_ntwk_name))
 
-        for nid, ndata in node_network.nodes_iter(data=True):
-            nbsgraph.node[nid] = ndata
-            nbs_pval_graph.node[nid] = ndata
+        for nid, ndata in node_network.nodes(data=True):
+            nbsgraph.nodes[nid] = ndata
+            nbs_pval_graph.nodes[nid] = ndata
 
         path = op.abspath('NBS_Result_' + details)
         iflogger.info(path)

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -48,7 +48,7 @@ def read_unknown_ntwk(ntwk):
 
 def remove_all_edges(ntwk):
     ntwktmp = ntwk.copy()
-    edges = ntwktmp.edges_iter()
+    edges = list(ntwktmp.edges())
     for edge in edges:
         ntwk.remove_edge(edge[0], edge[1])
     return ntwk
@@ -60,16 +60,16 @@ def fix_keys_for_gexf(orig):
     """
     import networkx as nx
     ntwk = nx.Graph()
-    nodes = orig.nodes_iter()
-    edges = orig.edges_iter()
+    nodes = list(orig.nodes())
+    edges = list(orig.edges())
     for node in nodes:
         newnodedata = {}
-        newnodedata.update(orig.node[node])
-        if 'dn_fsname' in orig.node[node]:
-            newnodedata['label'] = orig.node[node]['dn_fsname']
+        newnodedata.update(orig.nodes[node])
+        if 'dn_fsname' in orig.nodes[node]:
+            newnodedata['label'] = orig.nodes[node]['dn_fsname']
         ntwk.add_node(str(node), newnodedata)
-        if 'dn_position' in ntwk.node[str(node)] and 'dn_position' in newnodedata:
-            ntwk.node[str(node)]['dn_position'] = str(newnodedata['dn_position'])
+        if 'dn_position' in ntwk.nodes[str(node)] and 'dn_position' in newnodedata:
+            ntwk.nodes[str(node)]['dn_position'] = str(newnodedata['dn_position'])
     for edge in edges:
         data = {}
         data = orig.edge[edge[0]][edge[1]]
@@ -125,7 +125,7 @@ def average_networks(in_files, ntwk_res_file, group_id):
             tmp = nx.read_gpickle(subject)
             iflogger.info(('File {s} has {n} '
                            'edges').format(s=subject, n=tmp.number_of_edges()))
-            edges = tmp.edges_iter()
+            edges = list(tmp.edges())
             for edge in edges:
                 data = {}
                 data = tmp.edge[edge[0]][edge[1]]
@@ -135,27 +135,27 @@ def average_networks(in_files, ntwk_res_file, group_id):
                     current = ntwk.edge[edge[0]][edge[1]]
                     data = add_dicts_by_key(current, data)
                 ntwk.add_edge(edge[0], edge[1], data)
-            nodes = tmp.nodes_iter()
+            nodes = list(nodes())
             for node in nodes:
                 data = {}
-                data = ntwk.node[node]
-                if 'value' in tmp.node[node]:
-                    data['value'] = data['value'] + tmp.node[node]['value']
+                data = ntwk.nodes[node]
+                if 'value' in tmp.nodes[node]:
+                    data['value'] = data['value'] + tmp.nodes[node]['value']
                 ntwk.add_node(node, data)
 
         # Divides each value by the number of files
-        nodes = ntwk.nodes_iter()
-        edges = ntwk.edges_iter()
+        nodes = list(ntwk.nodes())
+        edges = list(ntwk.edges())
         iflogger.info(('Total network has {n} '
                        'edges').format(n=ntwk.number_of_edges()))
         avg_ntwk = nx.Graph()
         newdata = {}
         for node in nodes:
-            data = ntwk.node[node]
+            data = ntwk.nodes[node]
             newdata = data
             if 'value' in data:
                 newdata['value'] = data['value'] / len(in_files)
-                ntwk.node[node]['value'] = newdata
+                ntwk.nodes[node]['value'] = newdata
             avg_ntwk.add_node(node, newdata)
 
         edge_dict = {}
@@ -173,7 +173,7 @@ def average_networks(in_files, ntwk_res_file, group_id):
 
         iflogger.info('After thresholding, the average network has has {n} edges'.format(n=avg_ntwk.number_of_edges()))
 
-        avg_edges = avg_ntwk.edges_iter()
+        avg_edges = avg_ntwk.edges()
         for edge in avg_edges:
             data = avg_ntwk.edge[edge[0]][edge[1]]
             for key in list(data.keys()):
@@ -319,7 +319,7 @@ def compute_network_measures(ntwk):
 def add_node_data(node_array, ntwk):
     node_ntwk = nx.Graph()
     newdata = {}
-    for idx, data in ntwk.nodes_iter(data=True):
+    for idx, data in ntwk.nodes(data=True):
         if not int(idx) == 0:
             newdata['value'] = node_array[int(idx) - 1]
             data.update(newdata)

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -67,13 +67,13 @@ def fix_keys_for_gexf(orig):
         newnodedata.update(orig.nodes[node])
         if 'dn_fsname' in orig.nodes[node]:
             newnodedata['label'] = orig.nodes[node]['dn_fsname']
-        ntwk.add_node(str(node), newnodedata)
+        ntwk.add_node(str(node), **newnodedata)
         if 'dn_position' in ntwk.nodes[str(node)] and 'dn_position' in newnodedata:
             ntwk.nodes[str(node)]['dn_position'] = str(newnodedata['dn_position'])
     for edge in edges:
         data = {}
         data = orig.edge[edge[0]][edge[1]]
-        ntwk.add_edge(str(edge[0]), str(edge[1]), data)
+        ntwk.add_edge(str(edge[0]), str(edge[1]), **data)
         if 'fiber_length_mean' in ntwk.edge[str(edge[0])][str(edge[1])]:
             ntwk.edge[str(edge[0])][str(edge[1])]['fiber_length_mean'] = str(data['fiber_length_mean'])
         if 'fiber_length_std' in ntwk.edge[str(edge[0])][str(edge[1])]:
@@ -134,14 +134,14 @@ def average_networks(in_files, ntwk_res_file, group_id):
                     current = {}
                     current = ntwk.edge[edge[0]][edge[1]]
                     data = add_dicts_by_key(current, data)
-                ntwk.add_edge(edge[0], edge[1], data)
+                ntwk.add_edge(edge[0], edge[1], **data)
             nodes = list(nodes())
             for node in nodes:
                 data = {}
                 data = ntwk.nodes[node]
                 if 'value' in tmp.nodes[node]:
                     data['value'] = data['value'] + tmp.nodes[node]['value']
-                ntwk.add_node(node, data)
+                ntwk.add_node(node, **data)
 
         # Divides each value by the number of files
         nodes = list(ntwk.nodes())
@@ -156,7 +156,7 @@ def average_networks(in_files, ntwk_res_file, group_id):
             if 'value' in data:
                 newdata['value'] = data['value'] / len(in_files)
                 ntwk.nodes[node]['value'] = newdata
-            avg_ntwk.add_node(node, newdata)
+            avg_ntwk.add_node(node, **newdata)
 
         edge_dict = {}
         edge_dict['count'] = np.zeros((avg_ntwk.number_of_nodes(),
@@ -168,7 +168,7 @@ def average_networks(in_files, ntwk_res_file, group_id):
                     if not key == 'count':
                         data[key] = data[key] / len(in_files)
                 ntwk.edge[edge[0]][edge[1]] = data
-                avg_ntwk.add_edge(edge[0], edge[1], data)
+                avg_ntwk.add_edge(edge[0], edge[1], **data)
             edge_dict['count'][edge[0] - 1][edge[1] - 1] = ntwk.edge[edge[0]][edge[1]]['count']
 
         iflogger.info('After thresholding, the average network has has {n} edges'.format(n=avg_ntwk.number_of_edges()))
@@ -323,7 +323,7 @@ def add_node_data(node_array, ntwk):
         if not int(idx) == 0:
             newdata['value'] = node_array[int(idx) - 1]
             data.update(newdata)
-            node_ntwk.add_node(int(idx), data)
+            node_ntwk.add_node(int(idx), **data)
     return node_ntwk
 
 
@@ -339,7 +339,7 @@ def add_edge_data(edge_array, ntwk, above=0, below=0):
                         old_edge_dict = edge_ntwk.edge[x + 1][y + 1]
                         edge_ntwk.remove_edge(x + 1, y + 1)
                         data.update(old_edge_dict)
-                    edge_ntwk.add_edge(x + 1, y + 1, data)
+                    edge_ntwk.add_edge(x + 1, y + 1, **data)
     return edge_ntwk
 
 

--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -213,7 +213,7 @@ def create_roi(subject_id, subjects_dir, fs_dir, parcellation_name, dilation):
     rois = np.zeros((256, 256, 256), dtype=np.int16)
 
     count = 0
-    for brk, brv in pg.nodes_iter(data=True):
+    for brk, brv in pg.nodes(data=True):
         count = count + 1
         iflogger.info(brv)
         iflogger.info(brk)
@@ -429,7 +429,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
     roid = roi.get_data()
     assert roid.shape[0] == wmmask.shape[0]
     pg = nx.read_graphml(pgpath)
-    for brk, brv in pg.nodes_iter(data=True):
+    for brk, brv in pg.nodes(data=True):
         if brv['dn_region'] == 'cortical':
             iflogger.info("Subtracting region %s with intensity value %s" %
                           (brv['dn_region'], brv['dn_correspondence_id']))

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -316,7 +316,7 @@ def test_disconnect():
     flow1 = pe.Workflow(name='test')
     flow1.connect(a, 'a', b, 'a')
     flow1.disconnect(a, 'a', b, 'a')
-    assert flow1._graph.edges() == []
+    assert list(flow1._graph.edges()) == []
 
 
 def test_doubleconnect():
@@ -637,7 +637,7 @@ def test_mapnode_json(tmpdir):
     n1.inputs.in1 = [1]
     eg = w1.run()
 
-    node = eg.nodes()[0]
+    node = list(eg.nodes())[0]
     outjson = glob(os.path.join(node.output_dir(), '_0x*.json'))
     assert len(outjson) == 1
 

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -24,6 +24,7 @@ import pickle
 from functools import reduce
 import numpy as np
 from ...utils.misc import package_check
+from distutils.version import LooseVersion
 
 package_check('networkx', '1.3')
 
@@ -267,7 +268,7 @@ def _write_detailed_dot(graph, dotfilename):
     for n in nx.topological_sort(graph):
         nodename = str(n)
         inports = []
-        for u, v, d in graph.in_edges_iter(nbunch=n, data=True):
+        for u, v, d in graph.in_edges(nbunch=n, data=True):
             for cd in d['connect']:
                 if isinstance(cd[0], (str, bytes)):
                     outport = cd[0]
@@ -287,7 +288,7 @@ def _write_detailed_dot(graph, dotfilename):
             inputstr += '|<in%s> %s' % (replacefunk(ip), ip)
         inputstr += '}'
         outports = []
-        for u, v, d in graph.out_edges_iter(nbunch=n, data=True):
+        for u, v, d in graph.out_edges(nbunch=n, data=True):
             for cd in d['connect']:
                 if isinstance(cd[0], (str, bytes)):
                     outport = cd[0]
@@ -446,7 +447,7 @@ def get_levels(G):
     levels = {}
     for n in nx.topological_sort(G):
         levels[n] = 0
-        for pred in G.predecessors_iter(n):
+        for pred in G.predecessors(n):
             levels[n] = max(levels[n], levels[pred] + 1)
     return levels
 
@@ -491,9 +492,9 @@ def _merge_graphs(supergraph, nodes, subgraph, nodeid, iterables,
         raise Exception(("Execution graph does not have a unique set of node "
                          "names. Please rerun the workflow"))
     edgeinfo = {}
-    for n in subgraph.nodes():
+    for n in list(subgraph.nodes()):
         nidx = ids.index(n._hierarchy + n._id)
-        for edge in supergraph.in_edges_iter(supernodes[nidx]):
+        for edge in supergraph.in_edges(list(supernodes)[nidx]):
                 # make sure edge is not part of subgraph
             if edge[0] not in subgraph.nodes():
                 if n._hierarchy + n._id not in list(edgeinfo.keys()):
@@ -514,7 +515,7 @@ def _merge_graphs(supergraph, nodes, subgraph, nodeid, iterables,
         Gc = deepcopy(subgraph)
         ids = [n._hierarchy + n._id for n in Gc.nodes()]
         nodeidx = ids.index(nodeid)
-        rootnode = Gc.nodes()[nodeidx]
+        rootnode = list(Gc.nodes())[nodeidx]
         paramstr = ''
         for key, val in sorted(params.items()):
             paramstr = '{}_{}_{}'.format(
@@ -613,10 +614,10 @@ def _node_ports(graph, node):
     """
     portinputs = {}
     portoutputs = {}
-    for u, _, d in graph.in_edges_iter(node, data=True):
+    for u, _, d in graph.in_edges(node, data=True):
         for src, dest in d['connect']:
             portinputs[dest] = (u, src)
-    for _, v, d in graph.out_edges_iter(node, data=True):
+    for _, v, d in graph.out_edges(node, data=True):
         for src, dest in d['connect']:
             if isinstance(src, tuple):
                 srcport = src[0]
@@ -682,7 +683,7 @@ def generate_expanded_graph(graph_in):
     logger.debug("PE: expanding iterables")
     graph_in = _remove_nonjoin_identity_nodes(graph_in, keep_iterables=True)
     # standardize the iterables as {(field, function)} dictionaries
-    for node in graph_in.nodes_iter():
+    for node in graph_in.nodes():
         if node.iterables:
             _standardize_iterables(node)
     allprefixes = list('abcdefghijklmnopqrstuvwxyz')
@@ -697,7 +698,7 @@ def generate_expanded_graph(graph_in):
         logger.debug("Expanding the iterable node %s..." % inode)
 
         # the join successor nodes of the current iterable node
-        jnodes = [node for node in graph_in.nodes_iter()
+        jnodes = [node for node in graph_in.nodes()
                   if hasattr(node, 'joinsource') and
                   inode.name == node.joinsource and
                   nx.has_path(graph_in, inode, node)]
@@ -709,7 +710,7 @@ def generate_expanded_graph(graph_in):
         for jnode in jnodes:
             in_edges = jedge_dict[jnode] = {}
             edges2remove = []
-            for src, dest, data in graph_in.in_edges_iter(jnode, True):
+            for src, dest, data in graph_in.in_edges(jnode, True):
                 in_edges[src.itername] = data
                 edges2remove.append((src, dest))
 
@@ -726,7 +727,7 @@ def generate_expanded_graph(graph_in):
                 src_fields = [src_fields]
             # find the unique iterable source node in the graph
             try:
-                iter_src = next((node for node in graph_in.nodes_iter()
+                iter_src = next((node for node in graph_in.nodes()
                                  if node.name == src_name and
                                  nx.has_path(graph_in, node, inode)))
             except StopIteration:
@@ -781,7 +782,11 @@ def generate_expanded_graph(graph_in):
         inode._id += ('.' + iterable_prefix + 'I')
 
         # merge the iterated subgraphs
-        subgraph = graph_in.subgraph(subnodes)
+        # dj: the behaviour of .copy changes in version 2
+        if LooseVersion(nx.__version__) < LooseVersion('2'):
+            subgraph = graph_in.subgraph(subnodes)
+        else:
+            subgraph = graph_in.subgraph(subnodes).copy()
         graph_in = _merge_graphs(graph_in, subnodes,
                                  subgraph, inode._hierarchy + inode._id,
                                  iterables, iterable_prefix, inode.synchronize)
@@ -793,7 +798,7 @@ def generate_expanded_graph(graph_in):
             old_edge_dict = jedge_dict[jnode]
             # the edge source node replicates
             expansions = defaultdict(list)
-            for node in graph_in.nodes_iter():
+            for node in graph_in.nodes():
                 for src_id, edge_data in list(old_edge_dict.items()):
                     if node.itername.startswith(src_id):
                         expansions[src_id].append(node)
@@ -1283,7 +1288,7 @@ def write_workflow_prov(graph, filename=None, format='all'):
 
     # add dependencies (edges)
     # Process->Process
-    for idx, edgeinfo in enumerate(graph.in_edges_iter()):
+    for idx, edgeinfo in enumerate(graph.in_edges()):
         ps.g.wasStartedBy(processes[nodes.index(edgeinfo[1])],
                           starter=processes[nodes.index(edgeinfo[0])])
 
@@ -1295,7 +1300,7 @@ def write_workflow_prov(graph, filename=None, format='all'):
 def topological_sort(graph, depth_first=False):
     """Returns a depth first sorted order if depth_first is True
     """
-    nodesort = nx.topological_sort(graph)
+    nodesort = list(nx.topological_sort(graph))
     if not depth_first:
         return nodesort, None
     logger.debug("Performing depth first search")

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -23,10 +23,7 @@ import re
 import pickle
 from functools import reduce
 import numpy as np
-from ...utils.misc import package_check
 from distutils.version import LooseVersion
-
-package_check('networkx', '1.3')
 
 import networkx as nx
 

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -847,7 +847,7 @@ def generate_expanded_graph(graph_in):
                             logger.debug("Qualified the %s -> %s join field"
                                          " %s as %s." %
                                          (in_node, jnode, dest_field, slot_field))
-                    graph_in.add_edge(in_node, jnode, newdata)
+                    graph_in.add_edge(in_node, jnode, **newdata)
                     logger.debug("Connected the join node %s subgraph to the"
                                  " expanded join point %s" % (jnode, in_node))
 
@@ -1289,8 +1289,8 @@ def write_workflow_prov(graph, filename=None, format='all'):
     # add dependencies (edges)
     # Process->Process
     for idx, edgeinfo in enumerate(graph.in_edges()):
-        ps.g.wasStartedBy(processes[nodes.index(edgeinfo[1])],
-                          starter=processes[nodes.index(edgeinfo[0])])
+        ps.g.wasStartedBy(processes[list(nodes).index(edgeinfo[1])],
+                          starter=processes[list(nodes).index(edgeinfo[0])])
 
     # write provenance
     ps.write_provenance(filename, format=format)

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -36,7 +36,7 @@ import networkx as nx
 
 
 from ... import config, logging
-from ...utils.misc import (unflatten, package_check, str2bool,
+from ...utils.misc import (unflatten, str2bool,
                                getsource, create_function_from_source)
 from ...interfaces.base import (traits, InputMultiPath, CommandLine,
                                 Undefined, TraitedSpec, DynamicTraitedSpec,
@@ -58,7 +58,6 @@ from .utils import (generate_expanded_graph, modify_paths,
 from .base import EngineBase
 from .nodes import Node, MapNode
 
-package_check('networkx', '1.3')
 logger = logging.getLogger('workflow')
 
 class Workflow(EngineBase):

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -185,7 +185,7 @@ class Workflow(EngineBase):
             # check to see which ports of destnode are already
             # connected.
             if not disconnect and (destnode in self._graph.nodes()):
-                for edge in self._graph.in_edges_iter(destnode):
+                for edge in self._graph.in_edges(destnode):
                     data = self._graph.get_edge_data(*edge)
                     for sourceinfo, destname in data['connect']:
                         if destname not in connected_ports[destnode]:
@@ -506,8 +506,8 @@ connected.
                     else:
                         lines.append(line)
                 # write connections
-                for u, _, d in flatgraph.in_edges_iter(nbunch=node,
-                                                       data=True):
+                for u, _, d in flatgraph.in_edges(nbunch=node,
+                                                  data=True):
                     for cd in d['connect']:
                         if isinstance(cd[0], tuple):
                             args = list(cd[0])
@@ -633,7 +633,7 @@ connected.
                                             total=N,
                                             name='Group_%05d' % gid))
         json_dict['maxN'] = maxN
-        for u, v in graph.in_edges_iter():
+        for u, v in graph.in_edges():
             json_dict['links'].append(dict(source=nodes.index(u),
                                            target=nodes.index(v),
                                            value=1))
@@ -654,7 +654,7 @@ connected.
         json_dict = []
         for i, node in enumerate(nodes):
             imports = []
-            for u, v in graph.in_edges_iter(nbunch=node):
+            for u, v in graph.in_edges(nbunch=node):
                 imports.append(getname(u, nodes.index(u)))
             json_dict.append(dict(name=getname(node, i),
                                   size=1,
@@ -669,7 +669,7 @@ connected.
             return
         for node in graph.nodes():
             node.needed_outputs = []
-            for edge in graph.out_edges_iter(node):
+            for edge in graph.out_edges(node):
                 data = graph.get_edge_data(*edge)
                 sourceinfo = [v1[0] if isinstance(v1, tuple) else v1
                               for v1, v2 in data['connect']]
@@ -683,7 +683,7 @@ connected.
         """
         for node in graph.nodes():
             node.input_source = {}
-            for edge in graph.in_edges_iter(node):
+            for edge in graph.in_edges(node):
                 data = graph.get_edge_data(*edge)
                 for sourceinfo, field in data['connect']:
                     node.input_source[field] = \
@@ -758,8 +758,8 @@ connected.
                 setattr(inputdict, node.name, node.inputs)
             else:
                 taken_inputs = []
-                for _, _, d in self._graph.in_edges_iter(nbunch=node,
-                                                         data=True):
+                for _, _, d in self._graph.in_edges(nbunch=node,
+                                                    data=True):
                     for cd in d['connect']:
                         taken_inputs.append(cd[1])
                 unconnectedinputs = TraitedSpec()
@@ -864,7 +864,8 @@ connected.
                 # use in_edges instead of in_edges_iter to allow
                 # disconnections to take place properly. otherwise, the
                 # edge dict is modified.
-                for u, _, d in self._graph.in_edges(nbunch=node, data=True):
+                # dj: added list() for networkx ver.2
+                for u, _, d in list(self._graph.in_edges(nbunch=node, data=True)):
                     logger.debug('in: connections-> %s', to_str(d['connect']))
                     for cd in deepcopy(d['connect']):
                         logger.debug("in: %s", to_str(cd))
@@ -877,7 +878,8 @@ connected.
                         self.disconnect(u, cd[0], node, cd[1])
                         self.connect(srcnode, srcout, dstnode, dstin)
                 # do not use out_edges_iter for reasons stated in in_edges
-                for _, v, d in self._graph.out_edges(nbunch=node, data=True):
+                # dj: for ver 2 use list(out_edges)
+                for _, v, d in list(self._graph.out_edges(nbunch=node, data=True)):
                     logger.debug('out: connections-> %s', to_str(d['connect']))
                     for cd in deepcopy(d['connect']):
                         logger.debug("out: %s", to_str(cd))
@@ -965,7 +967,7 @@ connected.
                                              simple_form=simple_form, level=level + 3))
                 dotlist.append('}')
             else:
-                for subnode in self._graph.successors_iter(node):
+                for subnode in self._graph.successors(node):
                     if node._hierarchy != subnode._hierarchy:
                         continue
                     if not isinstance(subnode, Workflow):
@@ -980,7 +982,7 @@ connected.
                                                           subnodename))
                         logger.debug('connection: %s', dotlist[-1])
         # add between workflow connections
-        for u, v, d in self._graph.edges_iter(data=True):
+        for u, v, d in self._graph.edges(data=True):
             uname = '.'.join(hierarchy + [u.fullname])
             vname = '.'.join(hierarchy + [v.fullname])
             for src, dest in d['connect']:

--- a/nipype/pipeline/plugins/tests/test_linear.py
+++ b/nipype/pipeline/plugins/tests/test_linear.py
@@ -41,6 +41,6 @@ def test_run_in_series(tmpdir):
     mod1.inputs.input1 = 1
     execgraph = pipe.run(plugin="Linear")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
-    node = execgraph.nodes()[names.index('pipe.mod1')]
+    node = list(execgraph.nodes())[names.index('pipe.mod1')]
     result = node.get_output('output1')
     assert result == [1, 1]

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -46,7 +46,7 @@ def test_run_multiproc(tmpdir):
     pipe.config['execution']['poll_sleep_duration'] = 2
     execgraph = pipe.run(plugin="MultiProc")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
-    node = execgraph.nodes()[names.index('pipe.mod1')]
+    node = list(execgraph.nodes())[names.index('pipe.mod1')]
     result = node.get_output('output1')
     assert result == [1, 1]
 

--- a/nipype/pipeline/plugins/tests/test_multiproc_nondaemon.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc_nondaemon.py
@@ -123,7 +123,7 @@ def run_multiproc_nondaemon_with_flag(nondaemon_flag):
                                       'non_daemon': nondaemon_flag})
 
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
-    node = execgraph.nodes()[names.index('pipe.f2')]
+    node = list(execgraph.nodes())[names.index('pipe.f2')]
     result = node.get_output('sum_out')
     os.chdir(cur_dir)
     rmtree(temp_dir)

--- a/nipype/pipeline/plugins/tests/test_oar.py
+++ b/nipype/pipeline/plugins/tests/test_oar.py
@@ -50,7 +50,7 @@ def test_run_oar():
         '.'.join((node._hierarchy, node.name))
         for node in execgraph.nodes()
     ]
-    node = execgraph.nodes()[names.index('pipe.mod1')]
+    node = list(execgraph.nodes())[names.index('pipe.mod1')]
     result = node.get_output('output1')
     assert result == [1, 1]
     os.chdir(cur_dir)

--- a/nipype/pipeline/plugins/tests/test_pbs.py
+++ b/nipype/pipeline/plugins/tests/test_pbs.py
@@ -48,7 +48,7 @@ def test_run_pbsgraph():
     mod1.inputs.input1 = 1
     execgraph = pipe.run(plugin="PBSGraph")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
-    node = execgraph.nodes()[names.index('pipe.mod1')]
+    node = list(execgraph.nodes())[names.index('pipe.mod1')]
     result = node.get_output('output1')
     assert result == [1, 1]
     os.chdir(cur_dir)

--- a/nipype/pipeline/plugins/tests/test_somaflow.py
+++ b/nipype/pipeline/plugins/tests/test_somaflow.py
@@ -46,6 +46,6 @@ def test_run_somaflow(tmpdir):
     mod1.inputs.input1 = 1
     execgraph = pipe.run(plugin="SomaFlow")
     names = ['.'.join((node._hierarchy, node.name)) for node in execgraph.nodes()]
-    node = execgraph.nodes()[names.index('pipe.mod1')]
+    node = list(execgraph.nodes())[names.index('pipe.mod1')]
     result = node.get_output('output1')
     assert result == [1, 1]

--- a/nipype/utils/misc.py
+++ b/nipype/utils/misc.py
@@ -188,7 +188,7 @@ def package_check(pkg_name, version=None, app=None, checker=LooseVersion,
     Examples
     --------
     package_check('numpy', '1.3')
-    package_check('networkx', '1.0', 'tutorial1')
+    package_check('scipy', '0.7', 'tutorial1')
 
     """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ funcsigs
 configparser
 pytest>=3.0
 mock
-pydotplus
+pydot
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ funcsigs
 configparser
 pytest>=3.0
 mock
-pydot
+pydotplus
+pydot>=1.2.3
 packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.9.0
 scipy>=0.11
-networkx>=1.7
+networkx>=1.9
 traits>=4.6
 python-dateutil>=1.5
 nibabel>=2.1.0

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.6.2
 scipy>=0.11
-networkx>=1.7
+networkx>=1.9
 traits>=4.6
 python-dateutil>=1.5
 nibabel>=2.1.0

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -11,7 +11,7 @@ funcsigs
 configparser
 pytest>=3.0
 mock
-pydotplus
+pydot
 psutil
 matplotlib
 packaging

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -11,7 +11,8 @@ funcsigs
 configparser
 pytest>=3.0
 mock
-pydot
+pydotplus
+pydot>=1.2.3
 psutil
 matplotlib
 packaging


### PR DESCRIPTION
The new code should work with both versions -- ver 1.x  and  2.x (dev).

summary of changes:
 - `*_iter` has been removed, changing `nodes_iter` to `nodes`, etc. `nodes` gives dict-like `NodeView` (iterate or change to list first to access a specific element)
 - `.node` has been removed, changing to `nodes[node]`
 - `add_node` and `add_edge` don't have `attr_dict` anymore, have to change `**dict`
 
 - `subgraph` gives a view and `.copy()` has different depth, created two versions of [this part](https://github.com/djarecka/nipype/blob/18a29890c12e25d70915fb14d0219dd75dd7e3ce/nipype/pipeline/engine/utils.py#L786) . Suggestions how to simplify are welcome, don't understand all details of those various copies.

**Note**, I changed also `interfaces.cmtk`, but don't have any tests, so don't know if it works.

Edit (by @effigies):

Closes #2159 
Closes #2194 
 