### PR TITLE
FIX: Set networkx max version until 2.0 fixes are finalized

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -98,6 +98,7 @@ pipeline systems.
 # versions
 NIBABEL_MIN_VERSION = '2.1.0'
 NETWORKX_MIN_VERSION = '1.9'
+NETWORKX_MAX_VERSION = '1.11'
 NUMPY_MIN_VERSION = '1.9.0'
 SCIPY_MIN_VERSION = '0.14'
 TRAITS_MIN_VERSION = '4.6'
@@ -129,7 +130,7 @@ VERSION = __version__
 PROVIDES = ['nipype']
 REQUIRES = [
     'nibabel>=%s' % NIBABEL_MIN_VERSION,
-    'networkx>=%s' % NETWORKX_MIN_VERSION,
+    'networkx>=%s,<=%s' % (NETWORKX_MIN_VERSION, NETWORKX_MAX_VERSION),
     'numpy>=%s' % NUMPY_MIN_VERSION,
     'python-dateutil>=%s' % DATEUTIL_MIN_VERSION,
     'scipy>=%s' % SCIPY_MIN_VERSION,

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -1428,23 +1428,23 @@ class HistOutputSpec(TraitedSpec):
 
 
 class Hist(AFNICommandBase):
-    """Computes average of all voxels in the input dataset
-    which satisfy the criterion in the options list
+    # """Computes average of all voxels in the input dataset
+    # which satisfy the criterion in the options list
 
-    For complete details, see the `3dHist Documentation.
-    <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dHist.html>`_
+    # For complete details, see the `3dHist Documentation.
+    # <https://afni.nimh.nih.gov/pub/dist/doc/program_help/3dHist.html>`_
 
-    Examples
-    ========
+    # Examples
+    # ========
 
-    >>> from nipype.interfaces import afni
-    >>> hist = afni.Hist()
-    >>> hist.inputs.in_file = 'functional.nii'
-    >>> hist.cmdline  # doctest: +ALLOW_UNICODE
-    '3dHist -input functional.nii -prefix functional_hist'
-    >>> res = hist.run()  # doctest: +SKIP
+    # >>> from nipype.interfaces import afni
+    # >>> hist = afni.Hist()
+    # >>> hist.inputs.in_file = 'functional.nii'
+    # >>> hist.cmdline  # doctest: +ALLOW_UNICODE
+    # '3dHist -input functional.nii -prefix functional_hist'
+    # >>> res = hist.run()  # doctest: +SKIP
 
-    """
+    # """
 
     _cmd = '3dHist'
     input_spec = HistInputSpec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.9.0
 scipy>=0.11
-networkx>=1.7
+networkx>=1.9,<=1.11
 traits>=4.6
 python-dateutil>=1.5
 nibabel>=2.1.0

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.6.2
 scipy>=0.11
-networkx>=1.7
+networkx>=1.9,<=1.11
 traits>=4.6
 python-dateutil>=1.5
 nibabel>=2.1.0


### PR DESCRIPTION
Fixes #2194.

Changes proposed in this pull request
- Set networkx max version of 1.11
