### PR TITLE
CI: Add pip install --pre entry to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler"
 - INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler"
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler,duecredit"
+- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler" PIP_FLAGS="--pre"
 before_install:
 - function apt_inst {
   if $INSTALL_DEB_DEPENDECIES; then sudo rm -rf /dev/shm; fi &&
@@ -41,7 +42,7 @@ before_install:
 - travis_retry apt_inst
 - travis_retry conda_inst
 install:
-- travis_retry pip install -e .[$NIPYPE_EXTRAS]
+- travis_retry pip install $PIP_FLAGS -e .[$NIPYPE_EXTRAS]
 script:
 - py.test -v --doctest-modules nipype
 deploy:


### PR DESCRIPTION
This gives our dependencies a chance to break a Travis build before breaking everything downstream. I would treat failures of `--pre` builds as non-blocking for most PRs.