### PR TITLE
RF: Separate mcparam -> affine translation from norm calculation in ArtifactDetect

### DIFF
--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -99,6 +99,29 @@ def _calc_norm(mc, use_differences, source, brain_pts=None):
 
     """
 
+    affines = [_get_affine_matrix(mc[i, :], source)
+               for i in range(mc.shape[0])]
+    return _calc_norm_affine(affines, use_differences, source, brain_pts)
+
+
+def _calc_norm_affine(affines, use_differences, source, brain_pts=None):
+    """Calculates the maximum overall displacement of the midpoints
+    of the faces of a cube due to translation and rotation.
+
+    Parameters
+    ----------
+    affines : list of [4 x 4] affine matrices
+    use_differences : boolean
+    brain_pts : [4 x n_points] of coordinates
+
+    Returns
+    -------
+
+    norm : at each time point
+    displacement : euclidean distance (mm) of displacement at each coordinate
+
+    """
+
     if brain_pts is None:
         respos = np.diag([70, 70, 75])
         resneg = np.diag([-70, -110, -45])
@@ -107,22 +130,19 @@ def _calc_norm(mc, use_differences, source, brain_pts=None):
     else:
         all_pts = brain_pts
     n_pts = all_pts.size - all_pts.shape[1]
-    newpos = np.zeros((mc.shape[0], n_pts))
+    newpos = np.zeros((len(affines), n_pts))
     if brain_pts is not None:
-        displacement = np.zeros((mc.shape[0], int(n_pts / 3)))
-    for i in range(mc.shape[0]):
-        affine = _get_affine_matrix(mc[i, :], source)
-        newpos[i, :] = np.dot(affine,
-                              all_pts)[0:3, :].ravel()
+        displacement = np.zeros((len(affines), int(n_pts / 3)))
+    for i, affine in enumerate(affines):
+        newpos[i, :] = np.dot(affine, all_pts)[0:3, :].ravel()
         if brain_pts is not None:
-            displacement[i, :] = \
-                np.sqrt(np.sum(np.power(np.reshape(newpos[i, :],
-                                                   (3, all_pts.shape[1])) -
-                                        all_pts[0:3, :],
-                                        2),
-                               axis=0))
+            displacement[i, :] = np.sqrt(np.sum(
+                np.power(np.reshape(newpos[i, :],
+                                    (3, all_pts.shape[1])) - all_pts[0:3, :],
+                         2),
+                axis=0))
     # np.savez('displacement.npz', newpos=newpos, pts=all_pts)
-    normdata = np.zeros(mc.shape[0])
+    normdata = np.zeros(len(affines))
     if use_differences:
         newpos = np.concatenate((np.zeros((1, n_pts)),
                                  np.diff(newpos, n=1, axis=0)), axis=0)

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -148,8 +148,10 @@ def _calc_norm_affine(affines, use_differences, source, brain_pts=None):
                                  np.diff(newpos, n=1, axis=0)), axis=0)
         for i in range(newpos.shape[0]):
             normdata[i] = \
-                np.max(np.sqrt(np.sum(np.reshape(np.power(np.abs(newpos[i, :]), 2),
-                                                 (3, all_pts.shape[1])), axis=0)))
+                np.max(np.sqrt(np.sum(
+                    np.reshape(np.power(np.abs(newpos[i, :]), 2),
+                               (3, all_pts.shape[1])),
+                    axis=0)))
     else:
         newpos = np.abs(signal.detrend(newpos, axis=0, type='constant'))
         normdata = np.sqrt(np.mean(np.power(newpos, 2), axis=1))

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -101,10 +101,10 @@ def _calc_norm(mc, use_differences, source, brain_pts=None):
 
     affines = [_get_affine_matrix(mc[i, :], source)
                for i in range(mc.shape[0])]
-    return _calc_norm_affine(affines, use_differences, source, brain_pts)
+    return _calc_norm_affine(affines, use_differences, brain_pts)
 
 
-def _calc_norm_affine(affines, use_differences, source, brain_pts=None):
+def _calc_norm_affine(affines, use_differences, brain_pts=None):
     """Calculates the maximum overall displacement of the midpoints
     of the faces of a cube due to translation and rotation.
 


### PR DESCRIPTION
`algorithms.rapidart._calc_norm` uses an affine-based algorithm to calculate norms and displacements, translating from a list of motion parameters at each time point. This PR separates the two processes, creating a `_calc_norm_affine` function that performs the core functionality, which `_calc_norm` passes a list of affine matrices translated from the motion parameters.

Changes proposed in this pull request
- New function: `_calc_norm_affine`
- Update: `_calc_norm` translates motion parameters, calls `_calc_norm_affine`
- Removed `_nanmean`, since the minimum numpy (1.9) includes `np.nanmean`
