### PR TITLE
allow float as weight in afni's Allineate

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -353,6 +353,13 @@ class AllineateInputSpec(AFNICommandInputSpec):
         argstr='-nomask',
         desc='Don\'t compute the autoweight/mask; if -weight is not '
              'also used, then every voxel will be counted equally.')
+    weight_file = File(
+        argstr='-weight %s',
+        exists=True,
+        deprecated='1.0.0', new_name='weight',
+        desc='Set the weighting for each voxel in the base dataset; '
+             'larger weights mean that voxel count more in the cost function. '
+             'Must be defined on the same grid as the base dataset')
     weight = traits.Either(
         File(exists=True), traits.Float(),
         argstr='-weight %s',

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -353,12 +353,13 @@ class AllineateInputSpec(AFNICommandInputSpec):
         argstr='-nomask',
         desc='Don\'t compute the autoweight/mask; if -weight is not '
              'also used, then every voxel will be counted equally.')
-    weight_file = File(
+    weight = traits.Either(
+        File(exists=True), traits.Float(),
         argstr='-weight %s',
-        exists=True,
         desc='Set the weighting for each voxel in the base dataset; '
              'larger weights mean that voxel count more in the cost function. '
-             'Must be defined on the same grid as the base dataset')
+             'If an image file is given, the volume must be defined on the '
+             'same grid as the base dataset')
     out_weight_file = traits.File(
         argstr='-wtprefix %s',
         desc='Write the weight volume to disk as a dataset',

--- a/nipype/interfaces/afni/tests/test_auto_Allineate.py
+++ b/nipype/interfaces/afni/tests/test_auto_Allineate.py
@@ -117,7 +117,7 @@ def test_Allineate_inputs():
     ),
     warpfreeze=dict(argstr='-warpfreeze',
     ),
-    weight_file=dict(argstr='-weight %s',
+    weight=dict(argstr='-weight %s',
     ),
     zclip=dict(argstr='-zclip',
     ),

--- a/nipype/interfaces/afni/tests/test_auto_Allineate.py
+++ b/nipype/interfaces/afni/tests/test_auto_Allineate.py
@@ -119,6 +119,10 @@ def test_Allineate_inputs():
     ),
     weight=dict(argstr='-weight %s',
     ),
+    weight_file=dict(argstr='-weight %s',
+    deprecated='1.0.0',
+    new_name='weight',
+    ),
     zclip=dict(argstr='-zclip',
     ),
     )


### PR DESCRIPTION
AFNI's `3dAllineate` accepts either float or dataset as weight