### PR TITLE
ENH: Add LTA in/out to Tkregister2

### DIFF
--- a/nipype/interfaces/freesurfer/tests/test_auto_Tkregister2.py
+++ b/nipype/interfaces/freesurfer/tests/test_auto_Tkregister2.py
@@ -14,13 +14,22 @@ def test_Tkregister2_inputs():
     fsl_out=dict(argstr='--fslregout %s',
     ),
     fstal=dict(argstr='--fstal',
-    xor=['target_image', 'moving_image'],
+    xor=['target_image', 'moving_image', 'reg_file'],
     ),
     fstarg=dict(argstr='--fstarg',
     xor=['target_image'],
     ),
     ignore_exception=dict(nohash=True,
     usedefault=True,
+    ),
+    invert_lta_in=dict(requires=['lta_in'],
+    ),
+    invert_lta_out=dict(argstr='--ltaout-inv',
+    requires=['lta_in'],
+    ),
+    lta_in=dict(argstr='--lta %s',
+    ),
+    lta_out=dict(argstr='--ltaout %s',
     ),
     moving_image=dict(argstr='--mov %s',
     mandatory=True,
@@ -57,6 +66,7 @@ def test_Tkregister2_inputs():
 
 def test_Tkregister2_outputs():
     output_map = dict(fsl_file=dict(),
+    lta_file=dict(),
     reg_file=dict(),
     )
     outputs = Tkregister2.output_spec()


### PR DESCRIPTION
Changes proposed in this pull request
- Add LTA input/output with inversion
- Reorganize input/output transforms to make future work on this interface a little easier
- Add an `xor` to `fstal` that follows this section of the help:

```
  --fstal

  Check and edit the talairach registration that was created during
  the FreeSurfer reconstruction. Sets the movable volume to be 
  $FREESURFER_HOME/average/mni305.cor.mgz and sets the registration file to be
  $SUBJECTS_DIR/subjectid/transforms/talairach.xfm. User must have
  write permission to this file. Do not specify --reg with this
  flag. It is ok to specify --regheader with this flag. The format
  of the anatomical is automatically detected as mgz or COR. By default,
  the target c_ras is temporarily set to 0 to assure that the target
  is properly centered. This is taken into account when computing 
  and writing the output xfm. To turn this off, add --no-zero-cras.
```

This is not a complete fleshing out of `tkregister2`.