### PR TITLE
rearranging nilearn test, so they are independent from each other

### DIFF
--- a/nipype/interfaces/tests/test_nilearn.py
+++ b/nipype/interfaces/tests/test_nilearn.py
@@ -45,6 +45,7 @@ def setup_files(request, tmpdir):
     request.addfinalizer(change_directory)
 
 
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extract_no_shared(setup_files):
     # run
     iface.SignalExtraction(in_file=Filenames['in_file'],
@@ -55,6 +56,7 @@ def test_signal_extract_no_shared(setup_files):
     assert_expected_output(Labels, FakeData.base_wanted)
 
 
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_bad_label_list(setup_files):
     # run
     with pytest.raises(ValueError):
@@ -63,14 +65,20 @@ def test_signal_extr_bad_label_list(setup_files):
                                class_labels=['bad'],
                                incl_shared_variance=False).run()
 
+
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_equiv_4d_no_shared(setup_files):
     _test_4d_label(FakeData.base_wanted, FakeData.fake_equiv_4d_label_data,
                   incl_shared_variance=False)
 
+
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_4d_no_shared(setup_files):
     # set up & run & assert
     _test_4d_label(FakeData.fourd_wanted, FakeData.fake_4d_label_data, incl_shared_variance=False)
 
+
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_global_no_shared(setup_files):
     # set up
     wanted_global = [[-4./6], [-1./6], [3./6], [-1./6], [-7./6]]
@@ -87,6 +95,8 @@ def test_signal_extr_global_no_shared(setup_files):
     # assert
     assert_expected_output(Global_labels, wanted_global)
 
+
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_4d_global_no_shared(setup_files):
     # set up
     wanted_global = [[3./8], [-3./8], [1./8], [-7./8], [-9./8]]
@@ -97,6 +107,8 @@ def test_signal_extr_4d_global_no_shared(setup_files):
     _test_4d_label(wanted_global, FakeData.fake_4d_label_data,
                    include_global=True, incl_shared_variance=False)
 
+
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_shared(setup_files):
     # set up
     wanted = []
@@ -112,6 +124,7 @@ def test_signal_extr_shared(setup_files):
     _test_4d_label(wanted, FakeData.fake_4d_label_data)
 
 
+@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
 def test_signal_extr_traits_valid(setup_files):
     ''' Test a node using the SignalExtraction interface.
     Unlike interface.run(), node.run() checks the traits

--- a/nipype/interfaces/tests/test_nilearn.py
+++ b/nipype/interfaces/tests/test_nilearn.py
@@ -21,142 +21,145 @@ try:
 except ImportError:
     pass
 
-@pytest.mark.skipif(no_nilearn, reason="the nilearn library is not available")
-class TestSignalExtraction():
 
-    filenames = {
-        'in_file': 'fmri.nii',
-        'label_files': 'labels.nii',
-        '4d_label_file': '4dlabels.nii',
-        'out_file': 'signals.tsv'
+Filenames = {
+    'in_file': 'fmri.nii',
+    'label_files': 'labels.nii',
+    '4d_label_file': '4dlabels.nii',
+    'out_file': 'signals.tsv'
     }
-    labels = ['CSF', 'GrayMatter', 'WhiteMatter']
-    global_labels = ['GlobalSignal'] + labels
-
-    def setup_class(self):
-        self.orig_dir = os.getcwd()
-        self.temp_dir = tempfile.mkdtemp()
-        os.chdir(self.temp_dir)
-        utils.save_toy_nii(self.fake_fmri_data, self.filenames['in_file'])
-        utils.save_toy_nii(self.fake_label_data, self.filenames['label_files'])
-
-    def test_signal_extract_no_shared(self):
-        # run
-        iface.SignalExtraction(in_file=self.filenames['in_file'],
-                               label_files=self.filenames['label_files'],
-                               class_labels=self.labels,
-                               incl_shared_variance=False).run()
-        # assert
-        self.assert_expected_output(self.labels, self.base_wanted)
+Labels = ['CSF', 'GrayMatter', 'WhiteMatter']
+Global_labels = ['GlobalSignal'] + Labels
 
 
-    def test_signal_extr_bad_label_list(self):
-        # run
-        with pytest.raises(ValueError):
-            iface.SignalExtraction(in_file=self.filenames['in_file'],
-                                   label_files=self.filenames['label_files'],
-                                   class_labels=['bad'],
-                                   incl_shared_variance=False).run()
+@pytest.fixture()
+def setup_files(request, tmpdir):
+    orig_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    utils.save_toy_nii(FakeData.fake_fmri_data, Filenames['in_file'])
+    utils.save_toy_nii(FakeData.fake_label_data, Filenames['label_files'])
 
-    def test_signal_extr_equiv_4d_no_shared(self):
-        self._test_4d_label(self.base_wanted, self.fake_equiv_4d_label_data,
-                            incl_shared_variance=False)
+    def change_directory():
+        os.chdir(orig_dir)
 
-    def test_signal_extr_4d_no_shared(self):
-        # set up & run & assert
-        self._test_4d_label(self.fourd_wanted, self.fake_4d_label_data, incl_shared_variance=False)
+    request.addfinalizer(change_directory)
 
-    def test_signal_extr_global_no_shared(self):
-        # set up
-        wanted_global = [[-4./6], [-1./6], [3./6], [-1./6], [-7./6]]
-        for i, vals in enumerate(self.base_wanted):
-            wanted_global[i].extend(vals)
 
-        # run
-        iface.SignalExtraction(in_file=self.filenames['in_file'],
-                               label_files=self.filenames['label_files'],
-                               class_labels=self.labels,
-                               include_global=True,
+def test_signal_extract_no_shared(setup_files):
+    # run
+    iface.SignalExtraction(in_file=Filenames['in_file'],
+                           label_files=Filenames['label_files'],
+                           class_labels=Labels,
+                           incl_shared_variance=False).run()
+    # assert
+    assert_expected_output(Labels, FakeData.base_wanted)
+
+
+def test_signal_extr_bad_label_list(setup_files):
+    # run
+    with pytest.raises(ValueError):
+        iface.SignalExtraction(in_file=Filenames['in_file'],
+                               label_files=Filenames['label_files'],
+                               class_labels=['bad'],
                                incl_shared_variance=False).run()
 
-        # assert
-        self.assert_expected_output(self.global_labels, wanted_global)
+def test_signal_extr_equiv_4d_no_shared(setup_files):
+    _test_4d_label(FakeData.base_wanted, FakeData.fake_equiv_4d_label_data,
+                  incl_shared_variance=False)
 
-    def test_signal_extr_4d_global_no_shared(self):
-        # set up
-        wanted_global = [[3./8], [-3./8], [1./8], [-7./8], [-9./8]]
-        for i, vals in enumerate(self.fourd_wanted):
-            wanted_global[i].extend(vals)
+def test_signal_extr_4d_no_shared(setup_files):
+    # set up & run & assert
+    _test_4d_label(FakeData.fourd_wanted, FakeData.fake_4d_label_data, incl_shared_variance=False)
 
-        # run & assert
-        self._test_4d_label(wanted_global, self.fake_4d_label_data,
-                            include_global=True, incl_shared_variance=False)
+def test_signal_extr_global_no_shared(setup_files):
+    # set up
+    wanted_global = [[-4./6], [-1./6], [3./6], [-1./6], [-7./6]]
+    for i, vals in enumerate(FakeData.base_wanted):
+        wanted_global[i].extend(vals)
 
-    def test_signal_extr_shared(self):
-        # set up
-        wanted = []
-        for vol in range(self.fake_fmri_data.shape[3]):
-            volume = self.fake_fmri_data[:, :, :, vol].flatten()
-            wanted_row = []
-            for reg in range(self.fake_4d_label_data.shape[3]):
-                region = self.fake_4d_label_data[:, :, :, reg].flatten()
-                wanted_row.append((volume*region).sum()/(region*region).sum())
+    # run
+    iface.SignalExtraction(in_file=Filenames['in_file'],
+                           label_files=Filenames['label_files'],
+                           class_labels=Labels,
+                           include_global=True,
+                           incl_shared_variance=False).run()
 
-            wanted.append(wanted_row)
-        # run & assert
-        self._test_4d_label(wanted, self.fake_4d_label_data)
+    # assert
+    assert_expected_output(Global_labels, wanted_global)
 
+def test_signal_extr_4d_global_no_shared(setup_files):
+    # set up
+    wanted_global = [[3./8], [-3./8], [1./8], [-7./8], [-9./8]]
+    for i, vals in enumerate(FakeData.fourd_wanted):
+        wanted_global[i].extend(vals)
 
-    def test_signal_extr_traits_valid(self):
-        ''' Test a node using the SignalExtraction interface.
-        Unlike interface.run(), node.run() checks the traits
-        '''
-        # run
-        node = pe.Node(iface.SignalExtraction(in_file=os.path.abspath(self.filenames['in_file']),
-                                              label_files=os.path.abspath(self.filenames['label_files']),
-                                              class_labels=self.labels,
-                                              incl_shared_variance=False),
-                       name='SignalExtraction')
-        node.run()
+    # run & assert
+    _test_4d_label(wanted_global, FakeData.fake_4d_label_data,
+                   include_global=True, incl_shared_variance=False)
 
-        # assert
-        # just checking that it passes trait validations
+def test_signal_extr_shared(setup_files):
+    # set up
+    wanted = []
+    for vol in range(FakeData.fake_fmri_data.shape[3]):
+        volume = FakeData.fake_fmri_data[:, :, :, vol].flatten()
+        wanted_row = []
+        for reg in range(FakeData.fake_4d_label_data.shape[3]):
+            region = FakeData.fake_4d_label_data[:, :, :, reg].flatten()
+            wanted_row.append((volume*region).sum()/(region*region).sum())
 
-    def _test_4d_label(self, wanted, fake_labels, include_global=False, incl_shared_variance=True):
-        # set up
-        utils.save_toy_nii(fake_labels, self.filenames['4d_label_file'])
-
-        # run
-        iface.SignalExtraction(in_file=self.filenames['in_file'],
-                               label_files=self.filenames['4d_label_file'],
-                               class_labels=self.labels,
-                               incl_shared_variance=incl_shared_variance,
-                               include_global=include_global).run()
-
-        wanted_labels = self.global_labels if include_global else self.labels
-
-        # assert
-        self.assert_expected_output(wanted_labels, wanted)
-
-    def assert_expected_output(self, labels, wanted):
-        with open(self.filenames['out_file'], 'r') as output:
-            got = [line.split() for line in output]
-            labels_got = got.pop(0) # remove header
-            assert labels_got == labels
-            assert len(got) == self.fake_fmri_data.shape[3],'num rows and num volumes'
-            # convert from string to float
-            got = [[float(num) for num in row] for row in got]
-            for i, time in enumerate(got):
-                assert len(labels) == len(time)
-                for j, segment in enumerate(time):
-                    npt.assert_almost_equal(segment, wanted[i][j], decimal=1)
+        wanted.append(wanted_row)
+    # run & assert
+    _test_4d_label(wanted, FakeData.fake_4d_label_data)
 
 
-    def teardown_class(self):
-        os.chdir(self.orig_dir)
-        shutil.rmtree(self.temp_dir)
+def test_signal_extr_traits_valid(setup_files):
+    ''' Test a node using the SignalExtraction interface.
+    Unlike interface.run(), node.run() checks the traits
+    '''
+    # run
+    node = pe.Node(iface.SignalExtraction(in_file=os.path.abspath(Filenames['in_file']),
+                                          label_files=os.path.abspath(Filenames['label_files']),
+                                          class_labels=Labels,
+                                          incl_shared_variance=False),
+                   name='SignalExtraction')
+    node.run()
+
+    # assert
+    # just checking that it passes trait validations
+
+def _test_4d_label(wanted, fake_labels, include_global=False, incl_shared_variance=True):
+    # set up
+    utils.save_toy_nii(fake_labels, Filenames['4d_label_file'])
+    
+    # run
+    iface.SignalExtraction(in_file=Filenames['in_file'],
+                           label_files=Filenames['4d_label_file'],
+                           class_labels=Labels,
+                           incl_shared_variance=incl_shared_variance,
+                           include_global=include_global).run()
+
+    wanted_labels = Global_labels if include_global else Labels
+
+    # assert
+    assert_expected_output(wanted_labels, wanted)
+
+def assert_expected_output(labels, wanted):
+    with open(Filenames['out_file'], 'r') as output:
+        got = [line.split() for line in output]
+        labels_got = got.pop(0) # remove header
+        assert labels_got == labels
+        assert len(got) == FakeData.fake_fmri_data.shape[3],'num rows and num volumes'
+        # convert from string to float
+        got = [[float(num) for num in row] for row in got]
+        for i, time in enumerate(got):
+            assert len(labels) == len(time)
+            for j, segment in enumerate(time):
+                npt.assert_almost_equal(segment, wanted[i][j], decimal=1)
 
 
+
+
+class FakeData(object):
     fake_fmri_data = np.array([[[[2, -1, 4, -2, 3],
                                  [4, -2, -5, -1, 0]],
 


### PR DESCRIPTION
I had problem when testing traitlets that tests were not completely independent from each other, so decided to remove the class and rearrange, so they run now in different directories etc.