### PR TITLE
DOC: README is .rst, not .md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,5 +93,5 @@ Please add *[nipype]* to the subject line when posting on the mailing list.
 Contributing to the project
 ---------------------------
 
-If you'd like to contribute to the project please read our [guidelines](https://github.com/nipy/nipype/blob/master/CONTRIBUTING.md). Please also read through our [code of conduct](https://github.com/nipy/nipype/blob/master/CODE_OF_CONDUCT.md).
+If you'd like to contribute to the project please read our `guidelines <https://github.com/nipy/nipype/blob/master/CONTRIBUTING.md>`_. Please also read through our `code of conduct <https://github.com/nipy/nipype/blob/master/CODE_OF_CONDUCT.md>`_.
 


### PR DESCRIPTION
Quick fix.

Thanks for adding a CoC, @chrisfilo. Looks imminently reasonable.