### PR TITLE
[ENH]: add list_fwhm option to create_susan_smooth

### DIFF
--- a/nipype/workflows/fmri/fsl/preprocess.py
+++ b/nipype/workflows/fmri/fsl/preprocess.py
@@ -789,6 +789,7 @@ def create_susan_smooth(name="susan_smooth", separate_masks=True, list_fwhms=Fal
     >>> smooth.run() # doctest: +SKIP
 
     """
+    # replaces the functionality of a "for loop"
     def cartesian_product(fwhms, in_files, mask_files, merge_out, median_out):
         if type(in_files) == str:
             in_files = [in_files]


### PR DESCRIPTION
helps with poldracklab/fmriprep#706

Changes proposed in this pull request
- add `list_fwhms` option to `create_susan_smooth` to allow a list of fwhms to be run, instead of one.
