### PR TITLE
BUG: check for eddy_openmp in the right place

### DIFF
--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -592,7 +592,7 @@ class Eddy(FSLCommand):
         cmd = self._cmd
         if all((FSLDIR != '',
                 cmd == 'eddy_openmp',
-                not os.path.exists(os.path.join(FSLDIR, cmd)))):
+                not os.path.exists(os.path.join(FSLDIR, 'bin', cmd)))):
             self._cmd = 'eddy'
         runtime = super(Eddy, self)._run_interface(runtime)
 


### PR DESCRIPTION
eddy_openmp is placed in the $FSLDIR/bin directory not the $FSLDIR directory

Fixes # 1.

Changes proposed in this pull request
- Single minor bug-fix, which is needed to actually run eddy_openmp (if available) rather than eddy

I'm not sure how to test for this as the result depends on the content of $FSLDIR/bin
