### PR TITLE
changing ANTS input traits, fixes #2245

### DIFF
--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""The ants module provides basic functions for interfacing with ants functions.
+"""The ants module provides basic functions for interfacing with ants
+   functions.
 
    Change directory to provide relative paths for doctests
    >>> import os
@@ -7,7 +8,8 @@
    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
    >>> os.chdir(datadir)
 """
-from __future__ import print_function, division, unicode_literals, absolute_import
+from __future__ import (print_function, division, unicode_literals,
+                        absolute_import)
 from builtins import range, str
 import os
 
@@ -20,17 +22,19 @@ class ANTSInputSpec(ANTSCommandInputSpec):
     dimension = traits.Enum(3, 2, argstr='%d', usedefault=False,
                             position=1, desc='image dimension (2 or 3)')
     fixed_image = InputMultiPath(File(exists=True), mandatory=True,
-                                 desc=('image to which the moving image is warped'))
+                                 desc=('image to which the moving image is '
+                                       'warped'))
     moving_image = InputMultiPath(File(exists=True), argstr='%s',
                                   mandatory=True,
-                                  desc=('image to apply transformation to (generally a coregistered '
+                                  desc=('image to apply transformation to '
+                                        '(generally a coregistered'
                                         'functional)'))
 
 #    Not all metrics are appropriate for all modalities. Also, not all metrics
-#    are efficeint or appropriate at all resolution levels, Some metrics perform
-#    well for gross global registraiton, but do poorly for small changes (i.e.
-#    Mattes), and some metrics do well for small changes but don't work well for
-#    gross level changes (i.e. 'CC').
+#    are efficeint or appropriate at all resolution levels, Some metrics
+#    perform well for gross global registraiton, but do poorly for small
+#    changes (i.e. Mattes), and some metrics do well for small changes but
+#    don't work well for gross level changes (i.e. 'CC').
 #
 #    This is a two stage registration. in the first stage
 #      [ 'Mattes', .................]
@@ -54,11 +58,13 @@ class ANTSInputSpec(ANTSCommandInputSpec):
                                 desc='the metric weight(s) for each stage. '
                                 'The weights must sum to 1 per stage.')
 
-    radius = traits.List(traits.Int(), requires=['metric'],  mandatory=True, 
-                         desc='radius of the region (i.e. number of layers around a voxel point)'
-                              ' that is used for computing cross correlation')
+    radius = traits.List(traits.Int(), requires=['metric'],  mandatory=True,
+                         desc='radius of the region (i.e. number of layers'
+                         ' around a voxel point)'
+                         ' that is used for computing cross correlation')
 
-    output_transform_prefix = Str('out', usedefault=True, argstr='--output-naming %s',
+    output_transform_prefix = Str('out', usedefault=True,
+                                  argstr='--output-naming %s',
                                   mandatory=True, desc='')
     transformation_model = traits.Enum('Diff', 'Elast', 'Exp', 'Greedy Exp',
                                        'SyN', argstr='%s', mandatory=True,

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -49,8 +49,12 @@ class ANTSInputSpec(ANTSCommandInputSpec):
     metric = traits.List(traits.Enum('CC', 'MI', 'SMI', 'PR', 'SSD',
                                      'MSQ', 'PSE'), mandatory=True, desc='')
 
-    metric_weight = traits.List(traits.Float(), requires=['metric'], desc='')
-    radius = traits.List(traits.Int(), requires=['metric'], desc='')
+    metric_weight = traits.List(traits.Float(), value=[1.0], usedefault=True,
+                                requires=['metric'], mandatory=True,
+                                desc='the metric weight(s) for each stage. '
+                                'The weights must sum to 1 per stage.')
+
+    radius = traits.List(traits.Int(), requires=['metric'],  mandatory=True, desc='')
 
     output_transform_prefix = Str('out', usedefault=True, argstr='--output-naming %s',
                                   mandatory=True, desc='')

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -54,7 +54,9 @@ class ANTSInputSpec(ANTSCommandInputSpec):
                                 desc='the metric weight(s) for each stage. '
                                 'The weights must sum to 1 per stage.')
 
-    radius = traits.List(traits.Int(), requires=['metric'],  mandatory=True, desc='')
+    radius = traits.List(traits.Int(), requires=['metric'],  mandatory=True, 
+                         desc='radius of the region (i.e. number of layers around a voxel point)'
+                              ' that is used for computing cross correlation')
 
     output_transform_prefix = Str('out', usedefault=True, argstr='--output-naming %s',
                                   mandatory=True, desc='')

--- a/nipype/interfaces/ants/tests/test_registration.py
+++ b/nipype/interfaces/ants/tests/test_registration.py
@@ -1,19 +1,19 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
-# vi: set ft=python sts=4 ts=4 sw=4 et:                                                                                                                 
-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+from __future__ import unicode_literals
 from nipype.interfaces.ants import registration 
 import os
 import pytest
 
 def test_ants_mand():
-    filepath = os.path.dirname( os.path.realpath( __file__ ) )                                                                              
-    datadir = os.path.realpath(os.path.join(filepath, '../../../testing/data'))                                                                
+    filepath = os.path.dirname( os.path.realpath( __file__ ) )
+    datadir = os.path.realpath(os.path.join(filepath, '../../../testing/data'))
 
     ants = registration.ANTS()
     ants.inputs.transformation_model= "SyN"
     ants.inputs.moving_image = [os.path.join(datadir, 'resting.nii')]
     ants.inputs.fixed_image = [os.path.join(datadir, 'T1.nii')]
-    ants.inputs.metric = [u'MI']
+    ants.inputs.metric = ['MI']
 
     with pytest.raises(ValueError) as er:
         ants.run()

--- a/nipype/interfaces/ants/tests/test_registration.py
+++ b/nipype/interfaces/ants/tests/test_registration.py
@@ -1,0 +1,21 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:                                                                                                                 
+
+from nipype.interfaces.ants import registration 
+import os
+import pytest
+
+def test_ants_mand():
+    filepath = os.path.dirname( os.path.realpath( __file__ ) )                                                                              
+    datadir = os.path.realpath(os.path.join(filepath, '../../../testing/data'))                                                                
+
+    ants = registration.ANTS()
+    ants.inputs.transformation_model= "SyN"
+    ants.inputs.moving_image = [os.path.join(datadir, 'resting.nii')]
+    ants.inputs.fixed_image = [os.path.join(datadir, 'T1.nii')]
+    ants.inputs.metric = [u'MI']
+
+    with pytest.raises(ValueError) as er:
+        ants.run()
+    assert "ANTS requires a value for input 'radius'" in str(er.value)
+

--- a/nipype/interfaces/ants/tests/test_registration.py
+++ b/nipype/interfaces/ants/tests/test_registration.py
@@ -1,16 +1,18 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 from __future__ import unicode_literals
-from nipype.interfaces.ants import registration 
+from nipype.interfaces.ants import registration
 import os
 import pytest
 
-def test_ants_mand():
-    filepath = os.path.dirname( os.path.realpath( __file__ ) )
+
+def test_ants_mand(tmpdir):
+    tmpdir.chdir()
+    filepath = os.path.dirname(os.path.realpath(__file__))
     datadir = os.path.realpath(os.path.join(filepath, '../../../testing/data'))
 
     ants = registration.ANTS()
-    ants.inputs.transformation_model= "SyN"
+    ants.inputs.transformation_model = "SyN"
     ants.inputs.moving_image = [os.path.join(datadir, 'resting.nii')]
     ants.inputs.fixed_image = [os.path.join(datadir, 'T1.nii')]
     ants.inputs.metric = ['MI']
@@ -18,4 +20,3 @@ def test_ants_mand():
     with pytest.raises(ValueError) as er:
         ants.run()
     assert "ANTS requires a value for input 'radius'" in str(er.value)
-


### PR DESCRIPTION
I've changed `metric_weight` (took default from other interfaces) and `radius` (left without default value).

Unfortunately other interfaces from that file have similar problems (do not work after providing all mandatory fields) and it was already reported in #529.
I can keep adding `mandatory` to traits and guessing default values, but it might be better for those interfaces if someone who is using them do it (or help me).
