### PR TITLE
inst: ensure later versions of setuptools are used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ def main():
     with open(ver_file) as infofile:
         exec(infofile.read(), globals(), ldict)
 
-    SETUP_REQUIRES = ['future']
+    SETUP_REQUIRES = ['future', 'setuptools>=36.6.0']
     if sys.version_info <= (3, 4):
         SETUP_REQUIRES.append('configparser')
     setup(


### PR DESCRIPTION
Fixes #2108  .

Changes proposed in this pull request
- require later versions of setuptools for installation

Objections with using `setuptools 36.6.0`?