### PR TITLE
Memoize version check

### DIFF
--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -14,45 +14,26 @@ from ... import logging, LooseVersion
 from ...utils.filemanip import split_filename, fname_presuffix
 
 from ..base import (
-    CommandLine, traits, CommandLineInputSpec, isdefined, File, TraitedSpec)
+    CommandLine, traits, CommandLineInputSpec, isdefined, File, TraitedSpec,
+    PackageInfo)
 from ...external.due import BibTeX
 
 # Use nipype's logging system
 IFLOGGER = logging.getLogger('interface')
 
 
-class Info(object):
+class Info(PackageInfo):
     """Handle afni output type and version information.
     """
     __outputtype = 'AFNI'
     ftypes = {'NIFTI': '.nii',
               'AFNI': '',
               'NIFTI_GZ': '.nii.gz'}
+    version_cmd = 'afni --version'
 
     @staticmethod
-    def version():
-        """Check for afni version on system
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        version : str
-           Version number as string or None if AFNI not found
-
-        """
-        try:
-            clout = CommandLine(command='afni --version',
-                                resource_monitor=False,
-                                terminal_output='allatonce').run()
-        except IOError:
-            # If afni_vcheck is not present, return None
-            IFLOGGER.warn('afni executable not found.')
-            return None
-
-        version_stamp = clout.runtime.stdout.split('\n')[0].split('Version ')[1]
+    def parse_version(raw_info):
+        version_stamp = raw_info.split('\n')[0].split('Version ')[1]
         if version_stamp.startswith('AFNI'):
             version_stamp = version_stamp.split('AFNI_')[1]
         elif version_stamp.startswith('Debian'):

--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -6,11 +6,11 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from builtins import str
 
 import os
-import subprocess
 
 # Local imports
 from ... import logging, LooseVersion
-from ..base import CommandLine, CommandLineInputSpec, traits, isdefined
+from ..base import (CommandLine, CommandLineInputSpec, traits, isdefined,
+                    PackageInfo)
 logger = logging.getLogger('interface')
 
 # -Using -1 gives primary responsibilty to ITKv4 to do the correct
@@ -29,32 +29,21 @@ PREFERED_ITKv4_THREAD_LIMIT_VARIABLE = 'NSLOTS'
 ALT_ITKv4_THREAD_LIMIT_VARIABLE = 'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS'
 
 
-class Info(object):
-    _version = None
+class Info(PackageInfo):
+    version_cmd = os.path.join(os.getenv('ANTSPATH', ''),
+                               'antsRegistration') + ' --version'
 
-    @property
-    def version(self):
-        if self._version is None:
-            try:
-                basedir = os.environ['ANTSPATH']
-            except KeyError:
-                return None
-
-            cmd = os.path.join(basedir, 'antsRegistration')
-            try:
-                res = subprocess.check_output([cmd, '--version']).decode('utf-8')
-            except OSError:
-                return None
-
-            for line in res.splitlines():
-                if line.startswith('ANTs Version: '):
-                    self._version = line.split()[2]
-                    break
-            else:
-                return None
+    @staticmethod
+    def parse_version(raw_info):
+        for line in raw_info.splitlines():
+            if line.startswith('ANTs Version: '):
+                v_string = line.split()[2]
+                break
+        else:
+            return None
 
         # -githash may or may not be appended
-        v_string = self._version.split('-')[0]
+        v_string = v_string.split('-')[0]
 
         # 2.2.0-equivalent version string
         if 'post' in v_string and LooseVersion(v_string) >= LooseVersion('2.1.0.post789'):
@@ -125,4 +114,4 @@ class ANTSCommand(CommandLine):
 
     @property
     def version(self):
-        return Info().version
+        return Info.version()

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1927,15 +1927,27 @@ class SEMLikeCommandLine(CommandLine):
 class PackageInfo(object):
     _version = None
     version_cmd = None
+    version_file = None
 
     @classmethod
     def version(klass):
         if klass._version is None:
-            try:
-                clout = CommandLine(command=klass.version_cmd,
-                                    resource_monitor=False,
-                                    terminal_output='allatonce').run()
-            except OSError:
+            if klass.version_cmd is not None:
+                try:
+                    clout = CommandLine(command=klass.version_cmd,
+                                        resource_monitor=False,
+                                        terminal_output='allatonce').run()
+                except OSError:
+                    return None
+
+                raw_info = clout.runtime.stdout
+            elif klass.version_file is not None:
+                try:
+                    with open(klass.version_file, 'rt') as fobj:
+                        raw_info = fobj.read()
+                except OSError:
+                    return None
+            else:
                 return None
 
         klass._version = klass.parse_version(raw_info)

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1937,7 +1937,7 @@ class PackageInfo(object):
                     clout = CommandLine(command=klass.version_cmd,
                                         resource_monitor=False,
                                         terminal_output='allatonce').run()
-                except OSError:
+                except IOError:
                     return None
 
                 raw_info = clout.runtime.stdout

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1924,6 +1924,28 @@ class SEMLikeCommandLine(CommandLine):
         return super(SEMLikeCommandLine, self)._format_arg(name, spec, value)
 
 
+class PackageInfo(object):
+    _version = None
+    version_cmd = None
+
+    @classmethod
+    def version(klass):
+        if klass._version is None:
+            try:
+                clout = CommandLine(command=klass.version_cmd,
+                                    resource_monitor=False,
+                                    terminal_output='allatonce').run()
+            except OSError:
+                return None
+
+        klass._version = klass.parse_version(raw_info)
+        return klass._version
+
+    @staticmethod
+    def parse_version(raw_info):
+        raise NotImplementedError
+
+
 class MultiPath(traits.List):
     """ Abstract class - shared functionality of input and output MultiPath
     """

--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1950,7 +1950,8 @@ class PackageInfo(object):
             else:
                 return None
 
-        klass._version = klass.parse_version(raw_info)
+            klass._version = klass.parse_version(raw_info)
+
         return klass._version
 
     @staticmethod

--- a/nipype/interfaces/freesurfer/base.py
+++ b/nipype/interfaces/freesurfer/base.py
@@ -23,12 +23,13 @@ from ... import LooseVersion
 from ...utils.filemanip import fname_presuffix
 from ..base import (CommandLine, Directory,
                     CommandLineInputSpec, isdefined,
-                    traits, TraitedSpec, File)
+                    traits, TraitedSpec, File,
+                    PackageInfo)
 
 __docformat__ = 'restructuredtext'
 
 
-class Info(object):
+class Info(PackageInfo):
     """ Freesurfer subject directory and version information.
 
     Examples
@@ -39,32 +40,13 @@ class Info(object):
     >>> Info.subjectsdir()  # doctest: +SKIP
 
     """
+    if os.getenv('FREESURFER_HOME'):
+        version_file = os.path.join(os.getenv('FREESURFER_HOME'),
+                                    'build-stamp.txt')
 
     @staticmethod
-    def version():
-        """Check for freesurfer version on system
-
-        Find which freesurfer is being used....and get version from
-        /path/to/freesurfer/build-stamp.txt
-
-        Returns
-        -------
-
-        version : string
-           version number as string
-           or None if freesurfer version not found
-
-        """
-        fs_home = os.getenv('FREESURFER_HOME')
-        if fs_home is None:
-            return None
-        versionfile = os.path.join(fs_home, 'build-stamp.txt')
-        if not os.path.exists(versionfile):
-            return None
-        fid = open(versionfile, 'rt')
-        version = fid.readline()
-        fid.close()
-        return version
+    def parse_version(raw_info):
+        return raw_info.splitlines()[0]
 
     @classmethod
     def looseversion(cls):


### PR DESCRIPTION
Fixes #2273.

Changes proposed in this pull request
- Create `PackageInfo` template that reads version information from a file or command output, passes to a subclass-defined parser, and stores the result for future calls
- Example subclasses for AFNI, ANTs and FreeSurfer
