### PR TITLE
FIX: use gzip compression -6 instead of -1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
               docker save nipype/nipype:base \
                           nipype/nipype:latest \
                           nipype/nipype:py36 \
-                          nipype/nipype:py27 | gzip -1 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz
+                          nipype/nipype:py27 | gzip -6 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz
               du -h /tmp/docker/nipype-base-latest-py36-py27.tar.gz
             else
               # Workaround for `persist_to_workspace` to succeed when we are


### PR DESCRIPTION
Fixes breaking CircleCI deploy step.

Changes proposed in this pull request
- Use higher compression ratio when saving Docker images to `tar.gz` file.

The lowest amount of compression created a tar.gz file of over 5.0 GB. Persisting this to the CircleCI workspace did not show errors, but the tar.gz file in the next step of the workflow would be empty. This caused `docker load` to fail. More compression leads to a tar.gz file that is about 4.7 GB. This relatively smaller file can be loaded in the next step of the CircleCI workflow.

In a future PR, the Nipype container will be minimized with ReproZip. This will create smaller containers and alleviate the issue that this commit aims to fix.
