### PR TITLE
TST+ENH: update neurodocker version + retry building base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,9 @@ jobs:
               echo "Pulling base image ..."
               docker pull nipype/nipype:base
             elif [ "$GET_BASE" == "BUILD" ]; then
-              echo "Building base image ..."
-              docker build -t nipype/nipype:base - < docker/Dockerfile.base
+              e=1 && for i in {1..5}; do
+                docker build -t nipype/nipype:base - < docker/Dockerfile.base  && e=0 && break || sleep 15
+              done && [ "$e" -eq "0" ]
             else
               echo "Error: method to get base image not understood"
               exit 1

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -53,8 +53,8 @@ do
 done
 
 
-# neurodocker version 0.3.1-19-g8d02eb4
-NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:6b5f92f413b9710b7581e62293a8f74438b14ce7e4ab1ce68db2a09f7c64375a"
+# neurodocker version 0.3.1-22-gb0ee069
+NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:c670ec2e0666a63d4e017a73780f66554283e294f3b12250928ee74b8a48bc59"
 
 # neurodebian:stretch-non-free pulled on November 3, 2017
 BASE_IMAGE="neurodebian@sha256:7590552afd0e7a481a33314724ae27f76ccedd05ffd7ac06ec38638872427b9b"


### PR DESCRIPTION
Fixes issue where download steps in `docker build` fail, causing CircleCI build to fail.

Changes proposed in this pull request
- Use newer version of `neurodocker` to generate Dockerfiles. The newer version includes `--retry 5` in `curl` commands to retry downloads.
- Build the base Docker image in a loop, and try building at most 5 times.