### PR TITLE
TST+FIX: do not save empty tar.gz file + use fastest gzip compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,17 +137,13 @@ jobs:
               docker save nipype/nipype:base \
                           nipype/nipype:latest \
                           nipype/nipype:py36 \
-                          nipype/nipype:py27 | gzip -6 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz
+                          nipype/nipype:py27 | gzip -1 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz
               du -h /tmp/docker/nipype-base-latest-py36-py27.tar.gz
-            else
-              # Workaround for `persist_to_workspace` to succeed when we are
-              # not deploying Docker images.
-              touch /tmp/docker/nipype-base-latest-py36-py27.tar.gz
             fi
       - persist_to_workspace:
           root: /tmp
           paths:
-            - docker/nipype-base-latest-py36-py27.tar.gz
+            - docker/*
 
 
   deploy:


### PR DESCRIPTION
(Actually) Fixes breaking deploy step in CircleCI.

Changes proposed in this pull request
- Do not save an empty `tar.gz` file in container 1-3. The empty files overwrote the `tar.gz` file of Docker images, causing `docker load` to fail.
- Persist `/tmp/docker/*` instead of `/tmp/docker/nipype-base-latest-py36-py27.tar.gz`. This will save the tarball of Docker images in container 0 and will not fail on containers 1-3.
- Use fastest `gzip` compression. Turns out this was not the issue.

Tests of this PR on my fork
- [changes with `gzip -6 ...`](https://circleci.com/gh/kaczmarj/nipype/348)
- [changes with `gzip -1 ...`](https://circleci.com/gh/kaczmarj/nipype/353)

Fastest `gzip` produces a 5.1 GB file in 9:30, and `gzip -6` produces a 4.7 GB file in 16:04. Fastest `gzip` compression results in a net decrease in test/deploy time.