### PR TITLE
FIX Deleting reference to remove 'corrections' field

### DIFF
--- a/examples/fmri_fsl.py
+++ b/examples/fmri_fsl.py
@@ -415,7 +415,6 @@ modelfit.connect([
     (modelgen, conestimate, [('con_file', 'tcon_file')]),
     (modelestimate, conestimate, [('param_estimates', 'param_estimates'),
                                   ('sigmasquareds', 'sigmasquareds'),
-                                  ('corrections', 'corrections'),
                                   ('dof_file', 'dof_file')]),
 ])
 


### PR DESCRIPTION
Fixes broken `examples/fmri_fsl.py` per @satra 

In a post at

    https://neurostars.org/t/error-using-nipype-fsl-example/979

Satra answered nataliavelez's question about the error that
fmri_fsl.py throws when it gets to
```
modelfit.connect([
    (modelspec, level1design, [('session_info', 'session_info')]),
    (level1design, modelgen, [('fsf_files', 'fsf_file'),
                              ('ev_files', 'ev_files')]),
    (modelgen, modelestimate, [('design_file', 'design_file')]),
    (modelgen, conestimate, [('con_file', 'tcon_file')]),
    (modelestimate, conestimate, [('param_estimates', 'param_estimates'),
                                  ('sigmasquareds', 'sigmasquareds'),
                                  ('corrections', 'corrections'),
. . . .
```
by saying that the 'corrections' field has been removed.

Per that post, I submit this revised version with the 'corrections' pair
removed.  It appears to have got past that error now.

There are others, but I will try to track those down separately.