### PR TITLE
ENH: Explicit garbage collection in MultiProc

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -122,13 +122,16 @@ class MultiProcPlugin(DistributedPluginBase):
         non_daemon = self.plugin_args.get('non_daemon', True)
         maxtasks = self.plugin_args.get('maxtasksperchild', 10)
         self.processors = self.plugin_args.get('n_procs', cpu_count())
-        self.memory_gb = self.plugin_args.get('memory_gb',  # Allocate 90% of system memory
-                                              get_system_total_memory_gb() * 0.9)
-        self.raise_insufficient = self.plugin_args.get('raise_insufficient', True)
+        self.memory_gb = self.plugin_args.get(
+            'memory_gb',  # Allocate 90% of system memory
+            get_system_total_memory_gb() * 0.9)
+        self.raise_insufficient = self.plugin_args.get('raise_insufficient',
+                                                       True)
 
         # Instantiate different thread pools for non-daemon processes
-        logger.debug('MultiProcPlugin starting in "%sdaemon" mode (n_procs=%d, mem_gb=%0.2f)',
-                     'non' * int(non_daemon), self.processors, self.memory_gb)
+        logger.debug('MultiProcPlugin starting in "%sdaemon" mode (n_procs=%d,'
+                     'mem_gb=%0.2f)', 'non' * int(non_daemon), self.processors,
+                     self.memory_gb)
 
         NipypePool = NonDaemonPool if non_daemon else Pool
         try:
@@ -205,12 +208,13 @@ class MultiProcPlugin(DistributedPluginBase):
         Sends jobs to workers when system resources are available.
         """
 
-        # Check to see if a job is available (jobs without dependencies not run)
+        # Check to see if a job is available (jobs with all dependencies run)
         # See https://github.com/nipy/nipype/pull/2200#discussion_r141605722
         jobids = np.nonzero(~self.proc_done & (self.depidx.sum(0) == 0))[1]
 
-        # Check available system resources by summing all threads and memory used
-        free_memory_gb, free_processors = self._check_resources(self.pending_tasks)
+        # Check available resources by summing all threads and memory used
+        free_memory_gb, free_processors = self._check_resources(
+            self.pending_tasks)
 
         stats = (len(self.pending_tasks), len(jobids), free_memory_gb,
                  self.memory_gb, free_processors, self.processors)
@@ -229,7 +233,8 @@ class MultiProcPlugin(DistributedPluginBase):
                          'be submitted to the queue. Potential deadlock')
             return
 
-        jobids = self._sort_jobs(jobids, scheduler=self.plugin_args.get('scheduler'))
+        jobids = self._sort_jobs(jobids,
+                                 scheduler=self.plugin_args.get('scheduler'))
 
         # Run garbage collector before potentially submitting jobs
         gc.collect()
@@ -265,9 +270,10 @@ class MultiProcPlugin(DistributedPluginBase):
 
             free_memory_gb -= next_job_gb
             free_processors -= next_job_th
-            logger.debug('Allocating %s ID=%d (%0.2fGB, %d threads). Free: %0.2fGB, %d threads.',
-                         self.procs[jobid].fullname, jobid, next_job_gb, next_job_th,
-                         free_memory_gb, free_processors)
+            logger.debug('Allocating %s ID=%d (%0.2fGB, %d threads). Free: '
+                         '%0.2fGB, %d threads.', self.procs[jobid].fullname,
+                         jobid, next_job_gb, next_job_th, free_memory_gb,
+                         free_processors)
 
             # change job status in appropriate queues
             self.proc_done[jobid] = True

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -12,6 +12,7 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from multiprocessing import Process, Pool, cpu_count, pool
 from traceback import format_exception
 import sys
+import gc
 
 from copy import deepcopy
 import numpy as np
@@ -230,6 +231,9 @@ class MultiProcPlugin(DistributedPluginBase):
 
         jobids = self._sort_jobs(jobids, scheduler=self.plugin_args.get('scheduler'))
 
+        # Run garbage collector before potentially submitting jobs
+        gc.collect()
+
         # Submit jobs
         for jobid in jobids:
             # First expand mapnodes
@@ -292,6 +296,9 @@ class MultiProcPlugin(DistributedPluginBase):
                 free_processors += next_job_th
                 # Display stats next loop
                 self._stats = None
+
+                # Clean up any debris from running node in main process
+                gc.collect()
                 continue
 
             # Task should be submitted to workers


### PR DESCRIPTION
With large numbers of processors, moderate (~1GB) increases in memory consumption can produce large spikes in memory committed by the kernel when a batch of processes is forked. For example, if 16 1-core nodes are executed in one round of the MultiProc scheduler, then 16x the virtual memory footprint of the main process is committed by the kernel - so a 500MB increase in main process size would correspond to an 8GB increase in committed memory. For systems which disallow over-commitment of memory, these brief spikes can produce crashes even if the maximum resident memory never approaches the system limits.

This PR adds garbage collection at two points to reduce the memory footprint before forking and after running nodes in the main process, which has the most potential to accumulate objects that need to be freed.

Changes proposed in this pull request
- Garbage collect before submitting jobs
- Garbage collect after `run_without_submitting` jobs
- PEP8/pyflakes cleanup

Happy to argue/discuss alternatives. We found that unsetting `run_without_submitting` on some nodes that were a little more resource-intensive than we originally thought reduced spikes in main process memory consumption. (Would you say this is an accurate characterization?)