### PR TITLE
[ENH] Logging - indicate whether the node was cached

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -339,7 +339,7 @@ class DistributedPluginBase(PluginBase):
             logger.debug('Skipping cached node %s with ID %s.',
                          self.procs[jobid]._id, jobid)
             try:
-                self._task_finished_cb(jobid)
+                self._task_finished_cb(jobid, cached=True)
                 self._remove_node_dirs()
             except Exception:
                 logger.debug('Error skipping cached node %s (%s).',
@@ -349,13 +349,14 @@ class DistributedPluginBase(PluginBase):
             return True
         return False
 
-    def _task_finished_cb(self, jobid):
+    def _task_finished_cb(self, jobid, cached=False):
         """ Extract outputs and assign to inputs of dependent tasks
 
         This is called when a job is completed.
         """
-        logger.info('[Job finished] jobname: %s jobid: %d' %
-                    (self.procs[jobid]._id, jobid))
+        logger.info('[Job %d] %s (%s).', jobid,
+                    'Cached' if cached else 'Completed',
+                    self.procs[jobid].fullname)
         if self._status_callback:
             self._status_callback(self.procs[jobid], 'end')
         # Update job and worker queues


### PR DESCRIPTION
This PR introduces a minimal modification to the logging trace that happens when a node has been run, in order to provide more detailed information and whether the node was cached or actually run.