### PR TITLE
[ENH] Logging - MultiProc report current tasks

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -216,6 +216,7 @@ class MultiProcPlugin(DistributedPluginBase):
                  self.memory_gb, free_processors, self.processors)
         if self._stats != stats:
             tasks_list_msg = ''
+
             if logger.level <= INFO:
                 running_tasks = ['  * %s' % self.procs[jobid].fullname
                                  for _, jobid in self.pending_tasks]
@@ -225,7 +226,8 @@ class MultiProcPlugin(DistributedPluginBase):
                     tasks_list_msg = indent(tasks_list_msg, ' ' * 21)
             logger.info('[MultiProc] Running %d tasks, and %d jobs ready. Free '
                         'memory (GB): %0.2f/%0.2f, Free processors: %d/%d.%s',
-                        *stats, tasks_list_msg)
+                        len(self.pending_tasks), len(jobids), free_memory_gb, self.memory_gb,
+                        free_processors, self.processors, tasks_list_msg)
             self._stats = stats
 
         if free_memory_gb < 0.01 or free_processors == 0:

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -12,10 +12,11 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from multiprocessing import Process, Pool, cpu_count, pool
 from traceback import format_exception
 import sys
+from textwrap import indent
+from logging import INFO
 
 from copy import deepcopy
 import numpy as np
-
 from ... import logging
 from ...utils.profiler import get_system_total_memory_gb
 from ..engine import MapNode
@@ -126,7 +127,7 @@ class MultiProcPlugin(DistributedPluginBase):
         self.raise_insufficient = self.plugin_args.get('raise_insufficient', True)
 
         # Instantiate different thread pools for non-daemon processes
-        logger.debug('MultiProcPlugin starting in "%sdaemon" mode (n_procs=%d, mem_gb=%0.2f)',
+        logger.debug('[MultiProc] Starting in "%sdaemon" mode (n_procs=%d, mem_gb=%0.2f)',
                      'non' * int(non_daemon), self.processors, self.memory_gb)
 
         NipypePool = NonDaemonPool if non_daemon else Pool
@@ -158,7 +159,7 @@ class MultiProcPlugin(DistributedPluginBase):
             run_node, (node, updatehash, self._taskid),
             callback=self._async_callback)
 
-        logger.debug('MultiProc submitted task %s (taskid=%d).',
+        logger.debug('[MultiProc] Submitted task %s (taskid=%d).',
                      node.fullname, self._taskid)
         return self._taskid
 
@@ -214,9 +215,17 @@ class MultiProcPlugin(DistributedPluginBase):
         stats = (len(self.pending_tasks), len(jobids), free_memory_gb,
                  self.memory_gb, free_processors, self.processors)
         if self._stats != stats:
-            logger.info('Currently running %d tasks, and %d jobs ready. Free '
-                        'memory (GB): %0.2f/%0.2f, Free processors: %d/%d',
-                        *stats)
+            tasks_list_msg = ''
+            if logger.level <= INFO:
+                running_tasks = ['  * %s' % self.procs[jobid].fullname
+                                 for _, jobid in self.pending_tasks]
+                if running_tasks:
+                    tasks_list_msg = '\nCurrently running:\n'
+                    tasks_list_msg += '\n'.join(running_tasks)
+                    tasks_list_msg = indent(tasks_list_msg, ' ' * 21)
+            logger.info('[MultiProc] Running %d tasks, and %d jobs ready. Free '
+                        'memory (GB): %0.2f/%0.2f, Free processors: %d/%d.%s',
+                        *stats, tasks_list_msg)
             self._stats = stats
 
         if free_memory_gb < 0.01 or free_processors == 0:

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -12,7 +12,6 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from multiprocessing import Process, Pool, cpu_count, pool
 from traceback import format_exception
 import sys
-from textwrap import indent
 from logging import INFO
 
 from copy import deepcopy
@@ -21,6 +20,16 @@ from ... import logging
 from ...utils.profiler import get_system_total_memory_gb
 from ..engine import MapNode
 from .base import DistributedPluginBase
+
+try:
+    from textwrap import indent
+except ImportError:
+    def indent(text, prefix):
+        """ A textwrap.indent replacement for Python < 3.3 """
+        if not prefix:
+            return text
+        splittext = text.splitlines(True)
+        return prefix + prefix.join(splittext)
 
 # Init logger
 logger = logging.getLogger('workflow')


### PR DESCRIPTION
When the verbosity of logs is >= INFO, a list of currently running tasks is generated and printed out. Also, a `[MultiProc]` prefix is added to logging traces from this module.