### PR TITLE
FIX: Environment canonicalization bugs

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -1343,11 +1343,11 @@ def _canonicalize_env(env):
         return env
 
     out_env = {}
-    for key, val in env:
+    for key, val in env.items():
         if not isinstance(key, bytes):
             key = key.encode('utf-8')
         if not isinstance(val, bytes):
-            val = key.encode('utf-8')
+            val = val.encode('utf-8')
         out_env[key] = val
     return out_env
 


### PR DESCRIPTION
Fixes #2326.

Changes proposed in this pull request
- Correctly iterate over dict
- Encode val, instead of key

Suspect we got away with this because Windows use is small.