### PR TITLE
fix: logging error if % in node cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .DS_Store
 nipype/testing/data/von-ray_errmap.nii.gz
 nipype/testing/data/von_errmap.nii.gz
+nipype/testing/data/.proc*
 crash*.pklz
 .coverage
 htmlcov/

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -577,25 +577,25 @@ class Node(EngineBase):
             self._originputs = deepcopy(self._interface.inputs)
             self._copyfiles_to_wd(execute=execute)
 
-        message = '[Node] Running "%s" ("%s.%s")'
+        message = '[Node] Running "{}" ("{}.{}")'
         if issubclass(self._interface.__class__, CommandLine):
             try:
                 cmd = self._interface.cmdline
             except Exception as msg:
-                result.runtime.stderr = '%s\n\n%s' % (
+                result.runtime.stderr = '{}\n\n{}'.format(
                     getattr(result.runtime, 'stderr', ''), msg)
                 _save_resultfile(result, outdir, self.name)
                 raise
             cmdfile = op.join(outdir, 'command.txt')
             with open(cmdfile, 'wt') as fd:
                 print(cmd + "\n", file=fd)
-            message += ', a CommandLine Interface with command:\n%s' % cmd
-        logger.info(message, self.name, self._interface.__module__,
-                    self._interface.__class__.__name__)
+            message += ', a CommandLine Interface with command:\n{}'.format(cmd)
+        logger.info(message.format(self.name, self._interface.__module__,
+                    self._interface.__class__.__name__))
         try:
             result = self._interface.run()
         except Exception as msg:
-            result.runtime.stderr = '%s\n\n%s' % (
+            result.runtime.stderr = '%s\n\n%s'.format(
                 getattr(result.runtime, 'stderr', ''), msg)
             _save_resultfile(result, outdir, self.name)
             raise

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -577,7 +577,9 @@ class Node(EngineBase):
             self._originputs = deepcopy(self._interface.inputs)
             self._copyfiles_to_wd(execute=execute)
 
-        message = '[Node] Running "{}" ("{}.{}")'
+        message = '[Node] Running "{}" ("{}.{}")'.format(
+            self.name, self._interface.__module__,
+            self._interface.__class__.__name__)
         if issubclass(self._interface.__class__, CommandLine):
             try:
                 cmd = self._interface.cmdline
@@ -590,8 +592,7 @@ class Node(EngineBase):
             with open(cmdfile, 'wt') as fd:
                 print(cmd + "\n", file=fd)
             message += ', a CommandLine Interface with command:\n{}'.format(cmd)
-        logger.info(message.format(self.name, self._interface.__module__,
-                    self._interface.__class__.__name__))
+        logger.info(message)
         try:
             result = self._interface.run()
         except Exception as msg:


### PR DESCRIPTION
Fixes [#2325 (comment)](https://github.com/nipy/nipype/pull/2325#issuecomment-356485950).

Changes proposed in this pull request
- move some logging to `.format` substitution

Eventually, we should be thorough and replace most `%` substitutions