### PR TITLE
FIX: Collect jobids in a numpy 1.9 compatible manner

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -223,7 +223,9 @@ class MultiProcPlugin(DistributedPluginBase):
 
         # Check to see if a job is available (jobs with all dependencies run)
         # See https://github.com/nipy/nipype/pull/2200#discussion_r141605722
-        jobids = np.nonzero(~self.proc_done & (self.depidx.sum(0) == 0))[1]
+        # See also https://github.com/nipy/nipype/issues/2372
+        jobids = np.flatnonzero(~self.proc_done &
+                                (self.depidx.sum(axis=0) == 0).__array__())
 
         # Check available resources by summing all threads and memory used
         free_memory_gb, free_processors = self._check_resources(


### PR DESCRIPTION
Fixes #2372.

Changes proposed in this pull request
- Return to a more explicit technique for collecting available job IDs, which does not depend on newer numpy

cc @divetea @oesteban @mgxd 