### PR TITLE
ENH: Add _cmd_prefix class variable to CommandLine

### DIFF
--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -294,13 +294,10 @@ class AFNIPythonCommandInputSpec(CommandLineInputSpec):
 class AFNIPythonCommand(AFNICommand):
     @property
     def cmd(self):
-        if spawn.find_executable(super(AFNIPythonCommand,
-                                       self).cmd) is not None:
-            return spawn.find_executable(super(AFNIPythonCommand, self).cmd)
-        else:
-            return super(AFNIPythonCommand, self).cmd
+        orig_cmd = super(AFNIPythonCommand, self).cmd
+        found = spawn.find_executable(orig_cmd)
+        return found if found is not None else orig_cmd
 
     @property
-    def cmdline(self):
-        return "{} {}".format(self.inputs.py27_path,
-                              super(AFNIPythonCommand, self).cmdline)
+    def _cmd_prefix(self):
+        return "{} ".format(self.inputs.py27_path)

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -988,13 +988,25 @@ class CommandLine(BaseInterface):
 
         # which $cmd
         executable_name = self.cmd.split()[0]
-        cmd_path = which(executable_name, env=runtime.environ)
+
+        prefix_parts = self._cmd_prefix.split()
+        r_pre = prefix_parts.pop() if prefix_parts else ''
+
+        cmd_path = which(r_pre + executable_name, env=runtime.environ)
 
         if cmd_path is None:
             raise IOError(
                 'No command "%s" found on host %s. Please check that the '
                 'corresponding package is installed.' % (executable_name,
                                                          runtime.hostname))
+
+        if prefix_parts:
+            helper_command = which(prefix_parts[0], env=runtime.environ)
+            if helper_command is None:
+                raise IOError(
+                    'No command "%s" found on host %s. Please check that the '
+                    'corresponding package is installed.' % (helper_command,
+                                                             runtime.hostname))
 
         runtime.command_path = cmd_path
         runtime.dependencies = (get_dependencies(executable_name,

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -26,6 +26,7 @@ import re
 import platform
 import select
 import subprocess as sp
+import shlex
 import sys
 from textwrap import wrap
 import simplejson as json
@@ -987,26 +988,14 @@ class CommandLine(BaseInterface):
         runtime.environ.update(out_environ)
 
         # which $cmd
-        executable_name = self.cmd.split()[0]
-
-        prefix_parts = self._cmd_prefix.split()
-        r_pre = prefix_parts.pop() if prefix_parts else ''
-
-        cmd_path = which(r_pre + executable_name, env=runtime.environ)
+        executable_name = shlex.split(self._cmd_prefix + self.cmd)[0]
+        cmd_path = which(executable_name, env=runtime.environ)
 
         if cmd_path is None:
             raise IOError(
                 'No command "%s" found on host %s. Please check that the '
                 'corresponding package is installed.' % (executable_name,
                                                          runtime.hostname))
-
-        if prefix_parts:
-            helper_command = which(prefix_parts[0], env=runtime.environ)
-            if helper_command is None:
-                raise IOError(
-                    'No command "%s" found on host %s. Please check that the '
-                    'corresponding package is installed.' % (helper_command,
-                                                             runtime.hostname))
 
         runtime.command_path = cmd_path
         runtime.dependencies = (get_dependencies(executable_name,

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -857,6 +857,7 @@ class CommandLine(BaseInterface):
 
     """
     input_spec = CommandLineInputSpec
+    _cmd_prefix = ''
     _cmd = None
     _version = None
     _terminal_output = 'stream'
@@ -915,7 +916,7 @@ class CommandLine(BaseInterface):
         """ `command` plus any arguments (args)
         validates arguments and generates command line"""
         self._check_mandatory_inputs()
-        allargs = [self.cmd] + self._parse_inputs()
+        allargs = [self._cmd_prefix + self.cmd] + self._parse_inputs()
         return ' '.join(allargs)
 
     @property

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -480,3 +480,38 @@ def test_global_CommandLine_output(tmpdir):
     # Check default affects derived interfaces
     ci = BET()
     assert ci.terminal_output == 'file'
+
+
+def test_CommandLine_prefix(tmpdir):
+    tmpdir.chdir()
+    oop = 'out/of/path'
+    os.makedirs(oop)
+
+    script_name = 'test_script.sh'
+    script_path = os.path.join(oop, script_name)
+    with open(script_path, 'w') as script_f:
+        script_f.write('#!/usr/bin/env bash\necho Success!')
+    os.chmod(script_path, 0o755)
+
+    ci = nib.CommandLine(command=script_name)
+    with pytest.raises(OSError):
+        ci.run()
+
+    class OOPCLI(nib.CommandLine):
+        _cmd_prefix = oop + '/'
+
+    ci = OOPCLI(command=script_name)
+    ci.run()
+
+    class OOPShell(nib.CommandLine):
+        _cmd_prefix = 'bash {}/'.format(oop)
+
+    ci = OOPShell(command=script_name)
+    ci.run()
+
+    class OOPBadShell(nib.CommandLine):
+        _cmd_prefix = 'shell_dne {}/'.format(oop)
+
+    ci = OOPBadShell(command=script_name)
+    with pytest.raises(OSError):
+        ci.run()

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -494,7 +494,7 @@ def test_CommandLine_prefix(tmpdir):
     os.chmod(script_path, 0o755)
 
     ci = nib.CommandLine(command=script_name)
-    with pytest.raises(OSError):
+    with pytest.raises(IOError):
         ci.run()
 
     class OOPCLI(nib.CommandLine):
@@ -513,5 +513,5 @@ def test_CommandLine_prefix(tmpdir):
         _cmd_prefix = 'shell_dne {}/'.format(oop)
 
     ci = OOPBadShell(command=script_name)
-    with pytest.raises(OSError):
+    with pytest.raises(IOError):
         ci.run()

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -655,8 +655,9 @@ class DICOMConvert(FSCommand):
         files = self._get_filelist(outdir)
         for infile, outfile in files:
             if not os.path.exists(outfile):
-                single_cmd = '%s %s %s' % (self.cmd, infile,
-                                           os.path.join(outdir, outfile))
+                single_cmd = '%s%s %s %s' % (self._cmd_prefix, self.cmd,
+                                             infile, os.path.join(outdir,
+                                                                  outfile))
                 cmd.extend([single_cmd])
         return '; '.join(cmd)
 

--- a/nipype/interfaces/minc/minc.py
+++ b/nipype/interfaces/minc/minc.py
@@ -1742,15 +1742,15 @@ class Blur(StdOutCommandLine):
     @property
     def cmdline(self):
         output_file_base = self.inputs.output_file_base
+        orig_cmdline = super(Blur, self).cmdline
 
         if isdefined(output_file_base):
-            return super(Blur, self).cmdline
+            return orig_cmdline
         else:
             # FIXME this seems like a bit of a hack. Can we force output_file
             # to show up in cmdline by default, even if it isn't specified in
             # the instantiation of Pik?
-            return '%s %s' % (super(Blur, self).cmdline,
-                              self._gen_output_base())
+            return '%s %s' % (orig_cmdline, self._gen_output_base())
 
 
 class MathInputSpec(CommandLineInputSpec):

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -781,7 +781,7 @@ def which(cmd, env=None, pathext=None):
         extcmd = cmd + ext
         fpath, fname = os.path.split(extcmd)
         if fpath:
-            if isexec(fpath):
+            if isexec(extcmd):
                 return extcmd
         else:
             for directory in path.split(os.pathsep):

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -774,12 +774,20 @@ def which(cmd, env=None, pathext=None):
                 return filename
         return None
 
+    def isexec(path):
+        return os.path.isfile(path) and os.access(path, os.X_OK)
+
     for ext in pathext:
         extcmd = cmd + ext
-        for directory in path.split(os.pathsep):
-            filename = op.join(directory, extcmd)
-            if op.exists(filename):
-                return filename
+        fpath, fname = os.path.split(extcmd)
+        if fpath:
+            if isexec(fpath):
+                return extcmd
+        else:
+            for directory in path.split(os.pathsep):
+                filename = op.join(directory, extcmd)
+                if isexec(filename):
+                    return filename
     return None
 
 


### PR DESCRIPTION
This PR adds a `_cmd_prefix` which is a string that is prepended (with no space) to the command. This will permit users to add installation-specific prefixes, whether they be installation directories that are not in the path or idiosyncratic names that have been chosen by a package manager.

The idea is that users could do something like:

```Python
import nipype
nipype.interfaces.ants.AntsCommand._cmd_prefix = '/opt/ants/'
```

or

```Python
import nipype
nipype.interfaces.fsl.FSLCommand._cmd_prefix = 'fsl_'
```

Fixes #1415.

cc @satra @TheChymera 
