### PR TITLE
No longer concatenating extensions

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1314,18 +1314,19 @@ def export_graph(graph_in,
 def format_dot(dotfilename, format='png'):
     """Dump a directed graph (Linux only; install via `brew` on OSX)"""
     if format != 'dot':
-        cmd = 'dot -T%s -O \'%s\'' % (format, dotfilename)
+        dot_base =  os.path.splitext(dotfilename)[0]
+        formatted_dot = '{}.{}'.format(dot_base, format)
+        cmd = 'dot -T{} -o"{}" "{}"'.format(format, formatted_dot, dotfilename)
         try:
             CommandLine(cmd, resource_monitor=False).run()
         except IOError as ioe:
             if "could not be found" in str(ioe):
-                raise IOError(
-                    "Cannot draw directed graph; executable 'dot' is unavailable"
-                )
+                raise IOError("Cannot draw directed graph; executable 'dot' is unavailable")
             else:
                 raise ioe
-        dotfilename += '.%s' % format
-    return dotfilename
+    else:
+        formatted_dot = dotfilename
+    return formatted_dot
 
 
 def get_all_files(infile):

--- a/tools/interfacedocgen.py
+++ b/tools/interfacedocgen.py
@@ -227,7 +227,8 @@ class InterfaceHelpWriter(object):
 
         fhandle.close()
         os.remove(fname)
-        os.remove(fname + ".png")
+        bitmap_fname = '{}.png'.format(os.path.splitext(fname)[0])
+        os.remove(bitmap_fname)
         return ad
 
     def generate_api_doc(self, uri):


### PR DESCRIPTION
graph.png and graph.dot side by side is a lot better than graph.dot.png and graph.dot - for both tab completion, and software which has trouble intelligently parsing extensions (e.g. LaTeX's \includegraphics).

reiteration of #2268