### PR TITLE
RF: Use consistent dot file renaming scheme

### DIFF
--- a/examples/nipype_tutorial.ipynb
+++ b/examples/nipype_tutorial.ipynb
@@ -1065,7 +1065,7 @@
      "collapsed": false,
      "input": [
       "from IPython.core.display import Image\n",
-      "Image('realign_with_spm/graph.dot.png')"
+      "Image('realign_with_spm/graph.png')"
      ],
      "language": "python",
      "metadata": {},
@@ -1076,7 +1076,7 @@
      "collapsed": false,
      "input": [
       "realignflow.write_graph(graph2use='orig')\n",
-      "Image('realign_with_spm/graph_detailed.dot.png')"
+      "Image('realign_with_spm/graph_detailed.png')"
      ],
      "language": "python",
      "metadata": {
@@ -1298,7 +1298,7 @@
      "collapsed": false,
      "input": [
       "connectedworkflow.write_graph()\n",
-      "Image('working_dir/connectedtogether/graph.dot.png')"
+      "Image('working_dir/connectedtogether/graph.png')"
      ],
      "language": "python",
      "metadata": {

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1279,53 +1279,56 @@ def export_graph(graph_in,
         base_dir = os.getcwd()
 
     makedirs(base_dir, exist_ok=True)
-    outfname = fname_presuffix(
+    out_dot = fname_presuffix(
         dotfilename, suffix='_detailed.dot', use_ext=False, newpath=base_dir)
-    _write_detailed_dot(graph, outfname)
-    if format != 'dot':
-        cmd = 'dot -T%s -O %s' % (format, outfname)
-        res = CommandLine(
-            cmd, terminal_output='allatonce', resource_monitor=False).run()
-        if res.runtime.returncode:
-            logger.warning('dot2png: %s', res.runtime.stderr)
+    _write_detailed_dot(graph, out_dot)
+
+    # Convert .dot if format != 'dot'
+    outfname, res = _run_dot(out_dot, format_ext=format)
+    if res is not None and res.runtime.returncode:
+        logger.warning('dot2png: %s', res.runtime.stderr)
+
     pklgraph = _create_dot_graph(graph, show_connectinfo, simple_form)
-    simplefname = fname_presuffix(
+    simple_dot = fname_presuffix(
         dotfilename, suffix='.dot', use_ext=False, newpath=base_dir)
-    nx.drawing.nx_pydot.write_dot(pklgraph, simplefname)
-    if format != 'dot':
-        cmd = 'dot -T%s -O %s' % (format, simplefname)
-        res = CommandLine(
-            cmd, terminal_output='allatonce', resource_monitor=False).run()
-        if res.runtime.returncode:
-            logger.warning('dot2png: %s', res.runtime.stderr)
+    nx.drawing.nx_pydot.write_dot(pklgraph, simple_dot)
+
+    # Convert .dot if format != 'dot'
+    simplefname, res = _run_dot(simple_dot, format_ext=format)
+    if res is not None and res.runtime.returncode:
+        logger.warning('dot2png: %s', res.runtime.stderr)
+
     if show:
         pos = nx.graphviz_layout(pklgraph, prog='dot')
         nx.draw(pklgraph, pos)
         if show_connectinfo:
             nx.draw_networkx_edge_labels(pklgraph, pos)
 
-    if format != 'dot':
-        outfname += '.%s' % format
-        simplefname += '.%s' % format
     return simplefname if simple_form else outfname
 
 
 def format_dot(dotfilename, format='png'):
     """Dump a directed graph (Linux only; install via `brew` on OSX)"""
-    if format != 'dot':
-        dot_base =  os.path.splitext(dotfilename)[0]
-        formatted_dot = '{}.{}'.format(dot_base, format)
-        cmd = 'dot -T{} -o"{}" "{}"'.format(format, formatted_dot, dotfilename)
-        try:
-            CommandLine(cmd, resource_monitor=False).run()
-        except IOError as ioe:
-            if "could not be found" in str(ioe):
-                raise IOError("Cannot draw directed graph; executable 'dot' is unavailable")
-            else:
-                raise ioe
-    else:
-        formatted_dot = dotfilename
+    try:
+        formatted_dot, _ = _run_dot(dotfilename, format_ext=format)
+    except IOError as ioe:
+        if "could not be found" in str(ioe):
+            raise IOError("Cannot draw directed graph; executable 'dot' is unavailable")
+        else:
+            raise ioe
     return formatted_dot
+
+
+def _run_dot(dotfilename, format_ext):
+    if format_ext == 'dot':
+        return dotfilename, None
+
+    dot_base =  os.path.splitext(dotfilename)[0]
+    formatted_dot = '{}.{}'.format(dot_base, format_ext)
+    cmd = 'dot -T{} -o"{}" "{}"'.format(format_ext, formatted_dot, dotfilename)
+    res = CommandLine(cmd, terminal_output='allatonce',
+                      resource_monitor=False).run()
+    return formatted_dot, res
 
 
 def get_all_files(infile):


### PR DESCRIPTION
Only colored and hierarchical graphs are currently renamed to drop the `.dot` from the filename when converted to PNG or SVG.

The relevant branch is here: https://github.com/nipy/nipype/blob/a2d054aa8feb9c278c2b0503cc2fd4a9d3d4583c/nipype/pipeline/engine/workflows.py#L429-L450

Changes proposed in this pull request
- Factors out the renaming logic and updated command line from #2381 and calls from both `export_graph` and `format_dot`.

Follow-up to #2381.

Would appreciate review from @TheChymera and @djarecka.