### PR TITLE
FIX: PipeFunc __repr__ format string

### DIFF
--- a/nipype/caching/memory.py
+++ b/nipype/caching/memory.py
@@ -94,7 +94,7 @@ class PipeFunc(object):
         return out
 
     def __repr__(self):
-        return '{}({}.{}}, base_dir={})'.format(
+        return '{}({}.{}), base_dir={})'.format(
             self.__class__.__name__, self.interface.__module__,
             self.interface.__name__, self.base_dir)
 


### PR DESCRIPTION
Fixes the lesser part of #2406.

Bug introduced in 6c6cd787e71ca730fceae0764a2f55dacdd5baf4.

Changes proposed in this pull request
- Replace curly brace with close paren to create a valid format string