### PR TITLE
ENH: Re-enable spm.Realign to take lists of lists of files

### DIFF
--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -322,15 +322,11 @@ class MultiPath(traits.List):
 
         newvalue = value
 
+        inner_trait = self.inner_traits()[0]
         if not isinstance(value, list) \
-            or (self.inner_traits() and
-                isinstance(self.inner_traits()[0].trait_type,
-                           traits.List) and not
-                isinstance(self.inner_traits()[0].trait_type,
-                           InputMultiPath) and
-                isinstance(value, list) and
-                value and not
-                isinstance(value[0], list)):
+            or (isinstance(inner_trait.trait_type, traits.List) and
+                not isinstance(inner_trait.trait_type, InputMultiPath) and
+                not isinstance(value[0], list)):
             newvalue = [value]
         value = super(MultiPath, self).validate(object, name, newvalue)
 

--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -214,25 +214,18 @@ class ImageFile(File):
         """
         self.types = types
         self.allow_compressed = allow_compressed
-        self._exts = None
         super(ImageFile, self).__init__(value, filter, auto_set, entries,
                                         exists, **metadata)
 
     def info(self):
-        existing='n existing' if self.exists else ''
+        existing = 'n existing' if self.exists else ''
         comma = ',' if self.exists and not self.allow_compressed else ''
-        uncompressed=' uncompressed' if not self.allow_compressed else ''
-        with_ext = ' (valid extensions: [{}])'.format(', '.join(self.exts)) \
-            if self.types else ''
+        uncompressed = ' uncompressed' if not self.allow_compressed else ''
+        with_ext = ' (valid extensions: [{}])'.format(
+            ', '.join(self.grab_exts())) if self.types else ''
         return 'a{existing}{comma}{uncompressed} file{with_ext}'.format(
             existing=existing, comma=comma, uncompressed=uncompressed,
             with_ext=with_ext)
-
-    @property
-    def exts(self):
-        if self.types and self._exts is None:
-            self._exts = self.grab_exts()
-        return self._exts
 
     def grab_exts(self):
         # TODO: file type validation
@@ -260,10 +253,11 @@ class ImageFile(File):
         """
         validated_value = super(ImageFile, self).validate(object, name, value)
         if validated_value and self.types:
-            if not any(validated_value.endswith(x) for x in self.exts):
+            _exts = self.grab_exts()
+            if not any(validated_value.endswith(x) for x in _exts):
                 raise TraitError(
                     args="{} is not included in allowed types: {}".format(
-                        validated_value, ', '.join(self.exts)))
+                        validated_value, ', '.join(_exts)))
         return validated_value
 
 

--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -214,8 +214,25 @@ class ImageFile(File):
         """
         self.types = types
         self.allow_compressed = allow_compressed
+        self._exts = None
         super(ImageFile, self).__init__(value, filter, auto_set, entries,
                                         exists, **metadata)
+
+    def info(self):
+        existing='n existing' if self.exists else ''
+        comma = ',' if self.exists and not self.allow_compressed else ''
+        uncompressed=' uncompressed' if not self.allow_compressed else ''
+        with_ext = ' (valid extensions: [{}])'.format(', '.join(self.exts)) \
+            if self.types else ''
+        return 'a{existing}{comma}{uncompressed} file{with_ext}'.format(
+            existing=existing, comma=comma, uncompressed=uncompressed,
+            with_ext=with_ext)
+
+    @property
+    def exts(self):
+        if self.types and self._exts is None:
+            self._exts = self.grab_exts()
+        return self._exts
 
     def grab_exts(self):
         # TODO: file type validation
@@ -243,11 +260,10 @@ class ImageFile(File):
         """
         validated_value = super(ImageFile, self).validate(object, name, value)
         if validated_value and self.types:
-            self._exts = self.grab_exts()
-            if not any(validated_value.endswith(x) for x in self._exts):
+            if not any(validated_value.endswith(x) for x in self.exts):
                 raise TraitError(
                     args="{} is not included in allowed types: {}".format(
-                        validated_value, ', '.join(self._exts)))
+                        validated_value, ', '.join(self.exts)))
         return validated_value
 
 

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -125,7 +125,7 @@ class SliceTiming(SPMCommand):
 
 class RealignInputSpec(SPMCommandInputSpec):
     in_files = InputMultiPath(
-        ImageFileSPM(exists=True),
+        InputMultiPath(ImageFileSPM(exists=True)),
         field='data',
         mandatory=True,
         copyfile=True,

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -125,8 +125,8 @@ class SliceTiming(SPMCommand):
 
 class RealignInputSpec(SPMCommandInputSpec):
     in_files = InputMultiPath(
-        traits.Either(traits.List(ImageFileSPM(exists=True)),
-                      ImageFileSPM(exists=True)),
+        traits.Either(ImageFileSPM(exists=True),
+                      traits.List(ImageFileSPM(exists=True))),
         field='data',
         mandatory=True,
         copyfile=True,

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -125,7 +125,8 @@ class SliceTiming(SPMCommand):
 
 class RealignInputSpec(SPMCommandInputSpec):
     in_files = InputMultiPath(
-        ImageFileSPM(exists=True),
+        traits.Either(traits.List(ImageFileSPM(exists=True)),
+                      ImageFileSPM(exists=True)),
         field='data',
         mandatory=True,
         copyfile=True,

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -125,7 +125,7 @@ class SliceTiming(SPMCommand):
 
 class RealignInputSpec(SPMCommandInputSpec):
     in_files = InputMultiPath(
-        InputMultiPath(ImageFileSPM(exists=True)),
+        ImageFileSPM(exists=True),
         field='data',
         mandatory=True,
         copyfile=True,


### PR DESCRIPTION
Fixes #2406. Essentially reverts #2375, but using `InputMultiPath` instead of `Either`.

Changes proposed in this pull request
- Re-enables spm.Realign to take lists of lists, using nested `InputMultiPath`s.