### PR TITLE
FIX: fix ortvec argstr for Deconvolve

### DIFF
--- a/nipype/interfaces/afni/model.py
+++ b/nipype/interfaces/afni/model.py
@@ -142,7 +142,7 @@ class DeconvolveInputSpec(AFNICommandInputSpec):
         desc='this option lets you input a rectangular array of 1 or more '
         'baseline vectors from a file. This method is a fast way to '
         'include a lot of baseline regressors in one step. ',
-        argstr='ortvec %s')
+        argstr='-ortvec %s %s')
     x1D = File(desc='specify name for saved X matrix', argstr='-x1D %s')
     x1D_stop = traits.Bool(
         desc='stop running after writing .xmat.1D file', argstr='-x1D_stop')

--- a/nipype/interfaces/afni/tests/test_auto_Deconvolve.py
+++ b/nipype/interfaces/afni/tests/test_auto_Deconvolve.py
@@ -73,7 +73,7 @@ def test_Deconvolve_inputs():
             nohash=True,
             usedefault=True,
         ),
-        ortvec=dict(argstr='ortvec %s', ),
+        ortvec=dict(argstr='-ortvec %s %s', ),
         out_file=dict(argstr='-bucket %s', ),
         outputtype=dict(),
         polort=dict(argstr='-polort %d', ),


### PR DESCRIPTION
I thought I already added this fix in https://github.com/nipy/nipype/pull/2334, but it somehow reverted back when pep8ified. 

Changes proposed in this pull request
- Fix ortvec argstr
