### PR TITLE
fix: remove deprecated output from _list_outputs

### DIFF
--- a/nipype/algorithms/icc.py
+++ b/nipype/algorithms/icc.py
@@ -80,7 +80,6 @@ class ICC(BaseInterface):
     def _list_outputs(self):
         outputs = self._outputs().get()
         outputs['icc_map'] = os.path.abspath('icc_map.nii')
-        outputs['sessions_F_map'] = os.path.abspath('sessions_F_map.nii')
         outputs['session_var_map'] = os.path.abspath('session_var_map.nii')
         outputs['subject_var_map'] = os.path.abspath('subject_var_map.nii')
         return outputs


### PR DESCRIPTION
Fixes #2421 .

Changes proposed in this pull request
- `sessions_F_map` was removed in d1ad1f9dd542d1489489e813ad8ddd5d22df5f7d, removing the last instance of it from `ICC._list_outputs`
