### PR TITLE
fix little out_file  bugs in  afni.Zcat and afni.Merge

### DIFF
--- a/nipype/interfaces/afni/tests/test_auto_Merge.py
+++ b/nipype/interfaces/afni/tests/test_auto_Merge.py
@@ -32,7 +32,7 @@ def test_Merge_inputs():
         ),
         out_file=dict(
             argstr='-prefix %s',
-            name_source='in_file',
+            name_source='in_files',
             name_template='%s_merge',
         ),
         outputtype=dict(),

--- a/nipype/interfaces/afni/tests/test_auto_Zcat.py
+++ b/nipype/interfaces/afni/tests/test_auto_Zcat.py
@@ -36,7 +36,8 @@ def test_Zcat_inputs():
         ),
         out_file=dict(
             argstr='-prefix %s',
-            name_template='zcat',
+            name_source='in_files',
+            name_template='%s_zcat',
         ),
         outputtype=dict(),
         terminal_output=dict(

--- a/nipype/interfaces/afni/utils.py
+++ b/nipype/interfaces/afni/utils.py
@@ -1434,7 +1434,7 @@ class MergeInputSpec(AFNICommandInputSpec):
         name_template='%s_merge',
         desc='output image file name',
         argstr='-prefix %s',
-        name_source='in_file')
+        name_source='in_files')
     doall = traits.Bool(
         desc='apply options to all sub-bricks in dataset', argstr='-doall')
     blurfwhm = traits.Int(
@@ -2635,9 +2635,10 @@ class ZcatInputSpec(AFNICommandInputSpec):
         mandatory=True,
         copyfile=False)
     out_file = File(
-        name_template='zcat',
+        name_template='%s_zcat',
         desc='output dataset prefix name (default \'zcat\')',
-        argstr='-prefix %s')
+        argstr='-prefix %s',
+        name_source='in_files')
     datum = traits.Enum(
         'byte',
         'short',


### PR DESCRIPTION
little bugs make `afni.Zcat` and `afni.Merge` crash when the out_file is kept as default.