### PR TITLE
[WIP] COV: Ignore tests in calculating coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -26,3 +26,4 @@ coverage:
     - "nipype/external/*"
     - "tools/*"
     - "doc/*"
+    - "**/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,8 @@ coverage:
         flags:
           - "smoketests"
   ignore:          # files and folders that will be removed during processing
-    - "nipype/external/*"
-    - "tools/*"
-    - "doc/*"
+    - "nipype/external"
+    - "tools"
+    - "doc"
     - "**/tests"
+    - "examples"


### PR DESCRIPTION
This is an attempt to get more accurate coverage reports. Follow-up to #2386, which re-enabled codecov uploads. Will update the following list to reflect steps taken.

1. Removing tests directories, to reduce noise in report