### PR TITLE
CI/DOCKER: Hard code miniconda 4.3.31

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,28 @@ jobs:
       - run: *_run_codecov_coverage
       - store_artifacts: *store_artifacts_kwds
       - store_test_results: *store_artifacts_kwds
+      - run:
+          name: Build docs (py36)
+          no_output_timeout: 30m
+          environment: *test_environment
+          command: bash -ux /home/circleci/nipype/.circleci/test_py3_docs.sh
+      - store_artifacts:
+          path: /home/circleci/work/docs
+      - run:
+          name: Save Docker images to workspace if on master
+          no_output_timeout: 60m
+          command: |
+            if [ "$CIRCLE_BRANCH" = "master" -a -z "$CIRCLE_PULL_REQUEST" ]; then
+              docker save nipype/nipype:base \
+                          nipype/nipype:latest \
+                          nipype/nipype:py27 \
+                          nipype/nipype:py36 | gzip -1 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz \
+              && du -h /tmp/docker/nipype-base-latest-py36-py27.tar.gz
+            fi
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - docker
 
   test_py3_fmri_fsl_spm:
     machine: *machine_kwds
@@ -200,11 +222,6 @@ jobs:
       - run: *_get_codecov
       - run: *_download_test_data
       - run: *prepare_working_directory
-      - run:
-          name: Run FSL FEEDS pipeline (py36)
-          no_output_timeout: 40m
-          environment: *test_environment
-          command: bash -ux /home/circleci/nipype/.circleci/test_py3_fmri_fsl_feeds_linear_l1.sh
       - run:
           name: Run FSL reuse pipeline (py36)
           no_output_timeout: 40m
@@ -252,7 +269,7 @@ jobs:
       - run: *_run_codecov_smoke
       - store_artifacts: *store_artifacts_kwds
 
-  test_fmri_spm_nested_multiproc:
+  test_fmri_spm_nested_fsl_feeds:
     machine: *machine_kwds
     working_directory: /home/circleci/nipype
     steps:
@@ -279,30 +296,13 @@ jobs:
           no_output_timeout: 30m
           environment: *test_environment
           command: bash -ux /home/circleci/nipype/.circleci/test_py2_fmri_spm_nested_multiproc_l2.sh
+      - run:
+          name: Run FSL FEEDS pipeline (py36)
+          no_output_timeout: 40m
+          environment: *test_environment
+          command: bash -ux /home/circleci/nipype/.circleci/test_py3_fmri_fsl_feeds_linear_l1.sh
       - run: *_run_codecov_smoke
       - store_artifacts: *store_artifacts_kwds
-      - run:
-          name: Build docs (py36)
-          no_output_timeout: 30m
-          environment: *test_environment
-          command: bash -ux /home/circleci/nipype/.circleci/test_py3_docs.sh
-      - store_artifacts:
-          path: /home/circleci/work/docs
-      - run:
-          name: Save Docker images to workspace if on master
-          no_output_timeout: 60m
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" -a -z "$CIRCLE_PULL_REQUEST" ]; then
-              docker save nipype/nipype:base \
-                          nipype/nipype:latest \
-                          nipype/nipype:py27 \
-                          nipype/nipype:py36 | gzip -1 > /tmp/docker/nipype-base-latest-py36-py27.tar.gz \
-              && du -h /tmp/docker/nipype-base-latest-py36-py27.tar.gz
-            fi
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - docker
 
   deploy:
     docker:
@@ -350,7 +350,7 @@ workflows:
       - test_py3_fmri_spm_dartel_multiproc:
           requires:
             - compare_base_dockerfiles
-      - test_fmri_spm_nested_multiproc:
+      - test_fmri_spm_nested_fsl_feeds:
           requires:
             - compare_base_dockerfiles
       - deploy:
@@ -359,6 +359,6 @@ workflows:
               only: master
           requires:
             - test_pytest
-            - test_fmri_spm_nested_multiproc
+            - test_fmri_spm_nested_fsl_feeds
             - test_py3_fmri_fsl_spm
             - test_py3_fmri_spm_dartel_multiproc

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
 - conda config --set always_yes yes --set changeps1 no
 - travis_retry conda update -q conda
 - conda config --add channels conda-forge
-- travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu
+- travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu asn1crypto=0.23
 - travis_retry pip install -r requirements.txt
 - travis_retry git clone https://github.com/INCF/pybids.git ${HOME}/pybids &&
   pip install -e ${HOME}/pybids

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   fi;
 
 # handle python operations separately to reduce timeouts
-- wget https://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh
+- wget https://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-4.3.31-Linux-x86_64.sh
     -O /home/travis/.cache/conda.sh
 - bash ${HOME}/.cache/conda.sh -b -p ${HOME}/conda
 - export PATH=${HOME}/conda/bin:$PATH
@@ -48,7 +48,7 @@ before_install:
 - conda config --set always_yes yes --set changeps1 no
 - travis_retry conda update -q conda
 - conda config --add channels conda-forge
-- travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu asn1crypto=0.23
+- travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu
 - travis_retry pip install -r requirements.txt
 - travis_retry git clone https://github.com/INCF/pybids.git ${HOME}/pybids &&
   pip install -e ${HOME}/pybids

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -88,6 +88,7 @@ function generate_main_dockerfile() {
   --user neuro \
   --miniconda env_name=neuro \
               activate=true \
+              miniconda_version=4.3.31 \
   --copy docker/files/run_builddocs.sh docker/files/run_examples.sh \
          docker/files/run_pytests.sh nipype/external/fsl_imglob.py /usr/bin/ \
   --copy . /src/nipype \


### PR DESCRIPTION
Travis builds on master are failing, apparently because of today's miniconda release, which bundled asn1crypto 0.24. Possibly rolling back to 0.23 will fix the issue.