### PR TITLE
CI: Update Travis builds, Docker to use latest miniconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   fi;
 
 # handle python operations separately to reduce timeouts
-- wget https://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-4.3.31-Linux-x86_64.sh
+- wget https://repo.continuum.io/miniconda/Miniconda${TRAVIS_PYTHON_VERSION:0:1}-latest-Linux-x86_64.sh
     -O /home/travis/.cache/conda.sh
 - bash ${HOME}/.cache/conda.sh -b -p ${HOME}/conda
 - export PATH=${HOME}/conda/bin:$PATH

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -54,7 +54,7 @@ done
 
 
 # neurodocker version 0.3.1-22-gb0ee069
-NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:c670ec2e0666a63d4e017a73780f66554283e294f3b12250928ee74b8a48bc59"
+NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:f15ca90803f4b89acfca55cd1c7269bf2ec2dfd95b3de1118b08afa34b87d9d1"
 
 # neurodebian:stretch-non-free pulled on November 3, 2017
 BASE_IMAGE="neurodebian@sha256:7590552afd0e7a481a33314724ae27f76ccedd05ffd7ac06ec38638872427b9b"

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -88,7 +88,6 @@ function generate_main_dockerfile() {
   --user neuro \
   --miniconda env_name=neuro \
               activate=true \
-              miniconda_version=4.3.31 \
   --copy docker/files/run_builddocs.sh docker/files/run_examples.sh \
          docker/files/run_pytests.sh nipype/external/fsl_imglob.py /usr/bin/ \
   --copy . /src/nipype \


### PR DESCRIPTION
Tracks fixes to miniconda. Tests should be periodically rerun, to see if Continuum is fixing things on their end.

Follow-up to #2454.