### PR TITLE
Fix: Extract unit information from image header in CompCor

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -605,6 +605,10 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "affiliation": "Vrije Universiteit Amsterdam",
+      "name": "Ort, Eduard"
     }
   ],
   "keywords": [

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -532,7 +532,7 @@ class CompCor(BaseInterface):
                 # Derive TR from NIfTI header, if possible
                 try:
                     TR = imgseries.header.get_zooms()[3]
-                    if imgseries.get_xyzt_units()[1] == 'msec':
+                    if imgseries.header.get_xyzt_units()[1] == 'msec':
                         TR /= 1000
                 except (AttributeError, IndexError):
                     TR = 0


### PR DESCRIPTION
Fixes [#2456](https://github.com/nipy/nipype/issues/2456) .

Changes proposed in this pull request
- extract unit information from image header, rather than from image directly
