### PR TITLE
[FIX] #2435 Error creating gradients in DTIRecon

### DIFF
--- a/nipype/interfaces/diffusion_toolkit/dti.py
+++ b/nipype/interfaces/diffusion_toolkit/dti.py
@@ -103,18 +103,9 @@ class DTIRecon(CommandLine):
         with open(bvals_file) as fbvals:
             bvals = [val for val in re.split('\s+', fbvals.readline().strip())]
         with open(bvecs_file) as fbvecs:
-            bvecs_x = [
-                val for val in re.split('\s+',
-                                        fbvecs.readline().strip())
-            ]
-            bvecs_y = [
-                val for val in re.split('\s+',
-                                        fbvecs.readline().strip())
-            ]
-            bvecs_z = [
-                val for val in re.split('\s+',
-                                        fbvecs.readline().strip())
-            ]
+          bvecs_x = fbvecs.readline().split()
+          bvecs_y = fbvecs.readline().split()
+          bvecs_z = fbvecs.readline().split()
 
         with open(_gradient_matrix_file, 'w') as gradient_matrix_f:
             for i in range(len(bvals)):

--- a/nipype/interfaces/diffusion_toolkit/dti.py
+++ b/nipype/interfaces/diffusion_toolkit/dti.py
@@ -103,15 +103,15 @@ class DTIRecon(CommandLine):
         with open(bvals_file) as fbvals:
             bvals = [val for val in re.split('\s+', fbvals.readline().strip())]
         with open(bvecs_file) as fbvecs:
+            bvecs_x = [
+                val for val in re.split('\s+',
+                                        fbvecs.readline().strip())
+            ]
             bvecs_y = [
                 val for val in re.split('\s+',
                                         fbvecs.readline().strip())
             ]
             bvecs_z = [
-                val for val in re.split('\s+',
-                                        fbvecs.readline().strip())
-            ]
-            bvecs_x = [
                 val for val in re.split('\s+',
                                         fbvecs.readline().strip())
             ]


### PR DESCRIPTION
The bvecs file was read assuming that directions followed YZX order, which created a gradients_matrix.txt with swapped directions. The new order is XYZ.

Closes #2435.