### PR TITLE
TEST: Parallelize pytest

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -25,19 +25,19 @@ logging = Logging(config)
 
 
 class NipypeTester(object):
-    def __call__(self, doctests=True):
+    def __call__(self, doctests=True, parallel=True):
         try:
             import pytest
         except:
             raise RuntimeError(
                 'py.test not installed, run: pip install pytest')
-        params = {'args': []}
-        if doctests:
-            params['args'].append('--doctest-modules')
-        nipype_path = os.path.dirname(__file__)
-        params['args'].extend(
-            ['-x', '--ignore={}/external'.format(nipype_path), nipype_path])
-        pytest.main(**params)
+        args = []
+        if not doctests:
+            args.extend(['-p', 'no:doctest'])
+        if not parallel:
+            args.append('-n0')
+        args.append(os.path.dirname(__file__))
+        pytest.main(args=args)
 
 
 test = NipypeTester()

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -3,13 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 '''
 Algorithms to compute confounds in :abbr:`fMRI (functional MRI)`
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 '''
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -3,14 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 Miscellaneous algorithms for 2D contours and 3D triangularized meshes handling
-
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath( __file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -4,13 +4,6 @@
 '''
 Image assessment algorithms. Typical overlap and error computation
 measures to evaluate results from other processing units.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 '''
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -3,13 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 '''
 Miscellaneous algorithms
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 '''
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -10,13 +10,6 @@ experiments.
 These functions include:
 
   * SpecifyModel: allows specification of sparse and non-sparse models
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -11,12 +11,6 @@ These functions include:
 
   * StimulusCorrelation: determines correlation between stimuli
     schedule and movement/intensity parameters
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/caching/memory.py
+++ b/nipype/caching/memory.py
@@ -2,12 +2,6 @@
 """
 Using nipype with persistence and lazy recomputation but without explicit
 name-steps pipeline: getting back scope in command-line based programming.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/conftest.py
+++ b/nipype/conftest.py
@@ -11,3 +11,13 @@ def add_np(doctest_namespace):
     filepath = os.path.dirname(os.path.realpath(__file__))
     datadir = os.path.realpath(os.path.join(filepath, 'testing/data'))
     doctest_namespace["datadir"] = datadir
+
+
+@pytest.fixture(scope='session', autouse=True)
+def in_testing():
+    datadir = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), 'testing/data'))
+    origdir = os.getcwd()
+    os.chdir(datadir)
+    yield
+    os.chdir(origdir)

--- a/nipype/conftest.py
+++ b/nipype/conftest.py
@@ -2,22 +2,20 @@ import pytest
 import numpy
 import os
 
+DATADIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), 'testing/data'))
+
 
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
     doctest_namespace['os'] = os
 
-    filepath = os.path.dirname(os.path.realpath(__file__))
-    datadir = os.path.realpath(os.path.join(filepath, 'testing/data'))
-    doctest_namespace["datadir"] = datadir
+    doctest_namespace["datadir"] = DATADIR
 
 
-@pytest.fixture(scope='session', autouse=True)
-def in_testing():
-    datadir = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), 'testing/data'))
-    origdir = os.getcwd()
-    os.chdir(datadir)
-    yield
-    os.chdir(origdir)
+@pytest.fixture(autouse=True)
+def in_testing(request):
+    # This seems to be a reliable way to distinguish tests from doctests
+    if request.function is None:
+        os.chdir(DATADIR)

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -153,7 +153,7 @@ REQUIRES = [
 if sys.version_info <= (3, 4):
     REQUIRES.append('configparser')
 
-TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-xdist']
+TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-xdist', 'pytest-env']
 
 EXTRA_REQUIRES = {
     'doc': ['Sphinx>=1.4', 'numpydoc', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -153,7 +153,7 @@ REQUIRES = [
 if sys.version_info <= (3, 4):
     REQUIRES.append('configparser')
 
-TESTS_REQUIRES = ['pytest-cov', 'codecov']
+TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-xdist']
 
 EXTRA_REQUIRES = {
     'doc': ['Sphinx>=1.4', 'numpydoc', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],

--- a/nipype/interfaces/afni/model.py
+++ b/nipype/interfaces/afni/model.py
@@ -6,11 +6,6 @@
 Examples
 --------
 See the docstrings of the individual classes for examples.
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2,12 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """AFNI preprocessing interfaces
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/afni/svm.py
+++ b/nipype/interfaces/afni/svm.py
@@ -2,12 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft = python sts = 4 ts = 4 sw = 4 et:
 """Afni svm interfaces
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/afni/utils.py
+++ b/nipype/interfaces/afni/utils.py
@@ -6,11 +6,6 @@
 Examples
 --------
 See the docstrings of the individual classes for examples.
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/ants/legacy.py
+++ b/nipype/interfaces/ants/legacy.py
@@ -4,12 +4,6 @@
 #        of the antsApplyTransform program.  This implementation is here
 #        for backwards compatibility.
 """ANTS Apply Transforms interface
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 
 from builtins import range

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
 """The ants module provides basic functions for interfacing with ants
    functions.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/ants/resampling.py
+++ b/nipype/interfaces/ants/resampling.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 """ANTS Apply Transforms interface
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -1,12 +1,5 @@
 # -*- coding: utf-8 -*-
 """The ants module provides basic functions for interfacing with ants functions.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 """ANTS Apply Transforms interface
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/ants/visualization.py
+++ b/nipype/interfaces/ants/visualization.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 """The ants visualisation module provides basic functions based on ITK.
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/bru2nii.py
+++ b/nipype/interfaces/bru2nii.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 """The bru2nii module provides basic functions for dicom conversion
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/c3.py
+++ b/nipype/interfaces/c3.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
 """The ants module provides basic functions for interfacing with ants
    functions.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/camino/calib.py
+++ b/nipype/interfaces/camino/calib.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/camino/connectivity.py
+++ b/nipype/interfaces/camino/connectivity.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 import os

--- a/nipype/interfaces/camino/convert.py
+++ b/nipype/interfaces/camino/convert.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/camino/dti.py
+++ b/nipype/interfaces/camino/dti.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/camino/odf.py
+++ b/nipype/interfaces/camino/odf.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/camino/utils.py
+++ b/nipype/interfaces/camino/utils.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 import os

--- a/nipype/interfaces/camino2trackvis/convert.py
+++ b/nipype/interfaces/camino2trackvis/convert.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 """
 Provides interfaces to various commands provided by Camino-Trackvis
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from builtins import range, open

--- a/nipype/interfaces/cmtk/convert.py
+++ b/nipype/interfaces/cmtk/convert.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from builtins import str, open, range

--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from builtins import range

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 """The dcm2nii module provides basic functions for dicom conversion
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/dcmstack.py
+++ b/nipype/interfaces/dcmstack.py
@@ -1,12 +1,5 @@
 # -*- coding: utf-8 -*-
 """Provides interfaces to various commands provided by dcmstack
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/diffusion_toolkit/dti.py
+++ b/nipype/interfaces/diffusion_toolkit/dti.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various commands provided by diffusion toolkit
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/diffusion_toolkit/odf.py
+++ b/nipype/interfaces/diffusion_toolkit/odf.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various commands provided by diffusion toolkit
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/diffusion_toolkit/postproc.py
+++ b/nipype/interfaces/diffusion_toolkit/postproc.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various commands provided by diffusion toolkit
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/dipy/anisotropic_power.py
+++ b/nipype/interfaces/dipy/anisotropic_power.py
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-"""Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-"""
-
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -1,12 +1,4 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -1,10 +1,4 @@
 # -*- coding: utf-8 -*-
-"""Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from multiprocessing import (Pool, cpu_count)

--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -1,10 +1,4 @@
 # -*- coding: utf-8 -*-
-"""Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various longitudinal commands provided by freesurfer
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/freesurfer/model.py
+++ b/nipype/interfaces/freesurfer/model.py
@@ -3,13 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """The freesurfer module provides basic functions for interfacing with
    freesurfer tools.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various commands provided by FreeSurfer
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/freesurfer/registration.py
+++ b/nipype/interfaces/freesurfer/registration.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Provides interfaces to various longitudinal commands provided by freesurfer
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces to assorted Freesurfer utility programs.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/fsl/aroma.py
+++ b/nipype/interfaces/fsl/aroma.py
@@ -3,12 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """This commandline module provides classes for interfacing with the
 `ICA-AROMA.py<https://github.com/rhr-pruim/ICA-AROMA>`_ command line tool.
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 
 from __future__ import (print_function, division, unicode_literals,

--- a/nipype/interfaces/fsl/dti.py
+++ b/nipype/interfaces/fsl/dti.py
@@ -4,13 +4,6 @@
 """The fsl module provides classes for interfacing with the `FSL
 <http://www.fmrib.ox.ac.uk/fsl/index.html>`_ command line tools.  This
 was written to work with FSL version 4.1.4.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -4,13 +4,6 @@
 """The fsl module provides classes for interfacing with the `FSL
 <http://www.fmrib.ox.ac.uk/fsl/index.html>`_ command line tools.  This
 was written to work with FSL version 5.0.4.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import print_function, division, unicode_literals, \
     absolute_import

--- a/nipype/interfaces/fsl/maths.py
+++ b/nipype/interfaces/fsl/maths.py
@@ -2,14 +2,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """
-    The maths module provides higher-level interfaces to some of the operations
-    that can be performed with the fslmaths command-line program.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
+The maths module provides higher-level interfaces to some of the operations
+that can be performed with the fslmaths command-line program.
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -4,12 +4,6 @@
 """The fsl module provides classes for interfacing with the `FSL
 <http://www.fmrib.ox.ac.uk/fsl/index.html>`_ command line tools.  This
 was written to work with FSL version 4.1.4.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/fsl/possum.py
+++ b/nipype/interfaces/fsl/possum.py
@@ -8,14 +8,6 @@ The possum module provides classes for interfacing with `POSSUM
 Please, check out the link for pertinent citations using POSSUM.
 
   .. Note:: This was written to work with FSL version 5.0.6.
-
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    import os
-    filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    os.chdir(datadir)
-
 """
 
 from .base import FSLCommand, FSLCommandInputSpec

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -4,12 +4,6 @@
 """The fsl module provides classes for interfacing with the `FSL
 <http://www.fmrib.ox.ac.uk/fsl/index.html>`_ command line tools.  This
 was written to work with FSL version 4.1.4.
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -8,13 +8,6 @@ was written to work with FSL version 4.1.4.
 Examples
 --------
 See the docstrings of the individual classes for examples.
-
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    import os
-    filepath = os.path.dirname(os.path.realpath( __file__ ))
-    datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -10,13 +10,6 @@
 
     To come :
     XNATSink
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -2,13 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """ Fixes meshes:
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/minc/minc.py
+++ b/nipype/interfaces/minc/minc.py
@@ -7,14 +7,6 @@ module was written to work with MINC version 2.2.00.
 
 Author: Carlo Hamalainen <carlo@carlo-hamalainen.net>
         http://carlo-hamalainen.net
-
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from io import open

--- a/nipype/interfaces/mrtrix/preprocess.py
+++ b/nipype/interfaces/mrtrix/preprocess.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix/tensors.py
+++ b/nipype/interfaces/mrtrix/tensors.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix/tracking.py
+++ b/nipype/interfaces/mrtrix/tracking.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/connectivity.py
+++ b/nipype/interfaces/mrtrix3/connectivity.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/tracking.py
+++ b/nipype/interfaces/mrtrix3/tracking.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -1,15 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/niftyfit/asl.py
+++ b/nipype/interfaces/niftyfit/asl.py
@@ -2,13 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 The ASL module of niftyfit, which wraps the fitting methods in NiftyFit.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from ..base import TraitedSpec, traits, CommandLineInputSpec

--- a/nipype/interfaces/niftyfit/dwi.py
+++ b/nipype/interfaces/niftyfit/dwi.py
@@ -2,13 +2,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """
 The dwi module of niftyfit, which wraps the fitting methods in NiftyFit.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from ..base import TraitedSpec, traits, isdefined, CommandLineInputSpec

--- a/nipype/interfaces/niftyfit/qt1.py
+++ b/nipype/interfaces/niftyfit/qt1.py
@@ -3,13 +3,6 @@
 """
 The QT1 module of niftyfit, which wraps the Multi-Echo T1 fitting methods
 in NiftyFit.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from ..base import TraitedSpec, File, traits, CommandLineInputSpec

--- a/nipype/interfaces/niftyreg/reg.py
+++ b/nipype/interfaces/niftyreg/reg.py
@@ -6,13 +6,6 @@ The reg module provides classes for interfacing with the `niftyreg
 <http://niftyreg.sourceforge.net>`_ registration command line tools.
 
 The interfaces were written to work with niftyreg version 1.5.10
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from __future__ import (print_function, division, unicode_literals,

--- a/nipype/interfaces/niftyreg/regutils.py
+++ b/nipype/interfaces/niftyreg/regutils.py
@@ -5,13 +5,6 @@
 <http://niftyreg.sourceforge.net>`_ utility command line tools.
 
 The interfaces were written to work with niftyreg version 1.5.10
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from __future__ import (print_function, division, unicode_literals,

--- a/nipype/interfaces/niftyseg/em.py
+++ b/nipype/interfaces/niftyseg/em.py
@@ -9,13 +9,6 @@ that can be performed with the seg_em command-line program.
 Examples
 --------
 See the docstrings of the individual classes for examples.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from ..base import (TraitedSpec, File, traits, CommandLineInputSpec,

--- a/nipype/interfaces/niftyseg/label_fusion.py
+++ b/nipype/interfaces/niftyseg/label_fusion.py
@@ -3,13 +3,6 @@
 """
 The fusion module provides higher-level interfaces to some of the operations
 that can be performed with the seg_LabFusion command-line program.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 from builtins import str

--- a/nipype/interfaces/niftyseg/lesions.py
+++ b/nipype/interfaces/niftyseg/lesions.py
@@ -9,13 +9,6 @@ that can be performed with the seg_FillLesions command-line program.
 Examples
 --------
 See the docstrings of the individual classes for examples.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 import warnings

--- a/nipype/interfaces/niftyseg/maths.py
+++ b/nipype/interfaces/niftyseg/maths.py
@@ -9,13 +9,6 @@ that can be performed with the niftysegmaths (seg_maths) command-line program.
 Examples
 --------
 See the docstrings of the individual classes for examples.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 import os

--- a/nipype/interfaces/niftyseg/patchmatch.py
+++ b/nipype/interfaces/niftyseg/patchmatch.py
@@ -3,13 +3,6 @@
 """
 The fusion module provides higher-level interfaces to some of the operations
 that can be performed with the seg_DetectLesions command-line program.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 
 import warnings

--- a/nipype/interfaces/niftyseg/stats.py
+++ b/nipype/interfaces/niftyseg/stats.py
@@ -3,13 +3,6 @@
 """
 The stats module provides higher-level interfaces to some of the operations
 that can be performed with the niftyseg stats (seg_stats) command-line program.
-
-Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/\
-data'))
-    >>> os.chdir(datadir)
 """
 from __future__ import print_function
 import numpy as np

--- a/nipype/interfaces/nilearn.py
+++ b/nipype/interfaces/nilearn.py
@@ -3,13 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 '''
 Algorithms to compute statistics on :abbr:`fMRI (functional MRI)`
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 '''
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 from builtins import open

--- a/nipype/interfaces/nipy/utils.py
+++ b/nipype/interfaces/nipy/utils.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/petpvc.py
+++ b/nipype/interfaces/petpvc.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/interfaces/quickshear.py
+++ b/nipype/interfaces/quickshear.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
 """ Quickshear is a simple geometric defacing algorithm
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import unicode_literals
 

--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -3,13 +3,6 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """The spm module provides basic functions for interfacing with matlab
 and spm to access spm tools.
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -2,12 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """SPM wrappers for preprocessing data
-
-   Change directory to provide relative paths for doctests
-   >>> import os
-   >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-   >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-   >>> os.chdir(datadir)
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/utility/csv.py
+++ b/nipype/interfaces/utility/csv.py
@@ -2,14 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """CSV Handling utilities
-
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath(__file__))
-    >>> datadir = os.path.realpath(os.path.join(filepath,
-    ...                            '../../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/interfaces/vista/vista.py
+++ b/nipype/interfaces/vista/vista.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-"""
-    Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname( os.path.realpath( __file__ ) )
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-    >>> os.chdir(datadir)
-
-"""
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 

--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -5,14 +5,6 @@
 """Defines functionality for pipelined execution of interfaces
 
 The `EngineBase` class implements the more general view of a task.
-
-  .. testsetup::
-     # Change directory to provide relative paths for doctests
-     import os
-     filepath = os.path.dirname(os.path.realpath( __file__ ))
-     datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-     os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -4,14 +4,6 @@
 """Defines functionality for pipelined execution of interfaces
 
 The `Node` class provides core functionality for batch processing.
-
-  .. testsetup::
-     # Change directory to provide relative paths for doctests
-     import os
-     filepath = os.path.dirname(os.path.realpath( __file__ ))
-     datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-     os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -5,14 +5,6 @@
 """Defines functionality for pipelined execution of interfaces
 
 The `Workflow` class provides core functionality for batch processing.
-
-  .. testsetup::
-     # Change directory to provide relative paths for doctests
-     import os
-     filepath = os.path.dirname(os.path.realpath( __file__ ))
-     datadir = os.path.realpath(os.path.join(filepath, '../../testing/data'))
-     os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/nipype/pytest.ini
+++ b/nipype/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 norecursedirs = .git build dist doc nipype/external tools examples src
-addopts = --doctest-modules
+addopts = --doctest-modules -n auto
 doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE

--- a/nipype/pytest.ini
+++ b/nipype/pytest.ini
@@ -2,3 +2,5 @@
 norecursedirs = .git build dist doc nipype/external tools examples src
 addopts = --doctest-modules -n auto
 doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE
+env =
+    PYTHONHASHSEED=0

--- a/nipype/testing/fixtures.py
+++ b/nipype/testing/fixtures.py
@@ -103,7 +103,7 @@ def set_output_type(fsl_output_type):
     return prev_output_type
 
 
-@pytest.fixture(params=[None] + list(Info.ftypes))
+@pytest.fixture(params=[None] + sorted(Info.ftypes))
 def create_files_in_directory_plus_output_type(request, tmpdir):
     func_prev_type = set_output_type(request.param)
     origdir = tmpdir.chdir()

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -2,14 +2,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Miscellaneous file manipulation functions
-
-  .. testsetup::
-    # Change directory to provide relative paths for doctests
-    >>> import os
-    >>> filepath = os.path.dirname(os.path.realpath( __file__ ))
-    >>> datadir = os.path.realpath(os.path.join(filepath, '../testing/data'))
-    >>> os.chdir(datadir)
-
 """
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ click>=6.6.0
 funcsigs
 configparser
 pytest>=3.0
+pytest-xdist
 mock
 pydotplus
 pydot>=1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ funcsigs
 configparser
 pytest>=3.0
 pytest-xdist
+pytest-env
 mock
 pydotplus
 pydot>=1.2.3


### PR DESCRIPTION
Was curious how much parallelizing could squeeze down pytest runtime, acknowledging that it's already not super long (~10 minutes out of a 40 minute build and test cycle).

This led down a doctest-shaped rabbit hole, because some workers were running the module-level doctests that changed directories and others were running the function-level doctests, and the context wasn't being shared so there were a couple stochastic crashes each build. So I figured out how to set a fixture that would `chdir` into the `testing/data` directory on doctests and only doctests. This seems cleaner than the old way of doing it anyway.

Changes proposed in this pull request
- Add `pytest-xdist` to testing dependencies
- Add `-n auto` to pytest config
- Add `in_testing` fixture to `chdir` for doctests
- Remove old header `chdir` boilerplate
