### PR TITLE
ENH: Add interpolation order parameter to NiftyReg's RegTools

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -558,7 +558,7 @@
       "name": "Flandin, Guillaume"
     },
     {
-      "affiliation": "Stereotaxy Core, Brain & Spine Institute",
+      "affiliation": "University College London",
       "name": "P\u00e9rez-Garc\u00eda, Fernando",
       "orcid": "0000-0001-9090-3024"
     },

--- a/nipype/interfaces/niftyreg/regutils.py
+++ b/nipype/interfaces/niftyreg/regutils.py
@@ -122,7 +122,7 @@ warpfield.nii -res im2_res.nii.gz'
     # Need this overload to properly constraint the interpolation type input
     def _format_arg(self, name, spec, value):
         if name == 'inter_val':
-            inter_val = {'NN': 0, 'LIN': 1, 'CUB': 3, 'SINC': 5}
+            inter_val = {'NN': 0, 'LIN': 1, 'CUB': 3, 'SINC': 4}
             return spec.argstr % inter_val[value]
         else:
             return super(RegResample, self)._format_arg(name, spec, value)
@@ -338,7 +338,7 @@ class RegTools(NiftyRegCommand):
     # Need this overload to properly constraint the interpolation type input
     def _format_arg(self, name, spec, value):
         if name == 'inter_val':
-            inter_val = {'NN': 0, 'LIN': 1, 'CUB': 3, 'SINC': 5}
+            inter_val = {'NN': 0, 'LIN': 1, 'CUB': 3, 'SINC': 4}
             return spec.argstr % inter_val[value]
         else:
             return super(RegTools, self)._format_arg(name, spec, value)

--- a/nipype/interfaces/niftyreg/regutils.py
+++ b/nipype/interfaces/niftyreg/regutils.py
@@ -295,6 +295,15 @@ class RegToolsInputSpec(NiftyRegCommandInputSpec):
         desc=desc,
         argstr='-smoG %f %f %f')
 
+    # Interpolation type
+    inter_val = traits.Enum(
+        'NN',
+        'LIN',
+        'CUB',
+        'SINC',
+        desc='Interpolation order to use to warp the floating image',
+        argstr='-interp %d')
+
 
 class RegToolsOutputSpec(TraitedSpec):
     """ Output Spec for RegTools. """

--- a/nipype/interfaces/niftyreg/regutils.py
+++ b/nipype/interfaces/niftyreg/regutils.py
@@ -335,6 +335,14 @@ class RegTools(NiftyRegCommand):
     output_spec = RegToolsOutputSpec
     _suffix = '_tools'
 
+    # Need this overload to properly constraint the interpolation type input
+    def _format_arg(self, name, spec, value):
+        if name == 'inter_val':
+            inter_val = {'NN': 0, 'LIN': 1, 'CUB': 3, 'SINC': 5}
+            return spec.argstr % inter_val[value]
+        else:
+            return super(RegTools, self)._format_arg(name, spec, value)
+
 
 class RegAverageInputSpec(NiftyRegCommandInputSpec):
     """ Input Spec for RegAverage. """

--- a/nipype/interfaces/niftyreg/tests/test_auto_RegTools.py
+++ b/nipype/interfaces/niftyreg/tests/test_auto_RegTools.py
@@ -24,6 +24,7 @@ def test_RegTools_inputs():
             argstr='-in %s',
             mandatory=True,
         ),
+        inter_val=dict(argstr='-interp %d', ),
         iso_flag=dict(argstr='-iso', ),
         mask_file=dict(argstr='-nan %s', ),
         mul_val=dict(argstr='-mul %s', ),


### PR DESCRIPTION
Fixes #2470

Note: I ran `make check-before-commit` and got the following:
```
(nipype)  nipype   add-interp-to-niftyreg-regtools  make check-before-commit                                                                                           ◂◂◂◂◂◃◃◃◃◃
Checking specs and autogenerating spec tests
env PYTHONPATH=".:" python tools/checkspecs.py
Traceback (most recent call last):
  File "tools/checkspecs.py", line 15, in <module>
    from yapf.yapflib.yapf_api import FormatCode
ModuleNotFoundError: No module named 'yapf'
make: *** [specs] Error 1
```
I fixed it with `pip install yapf`.