### PR TITLE
FIX: Check and report mount table parsing failures

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -185,7 +185,8 @@ def fname_presuffix(fname, prefix='', suffix='', newpath=None, use_ext=True):
     '/tmp/prefoopost.nii.gz'
 
     >>> from nipype.interfaces.base import Undefined
-    >>> fname_presuffix(fname, 'pre', 'post', Undefined) == fname_presuffix(fname, 'pre', 'post')
+    >>> fname_presuffix(fname, 'pre', 'post', Undefined) == \
+            fname_presuffix(fname, 'pre', 'post')
     True
 
     """

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -451,7 +451,16 @@ tmpfs on /proc/timer_list type tmpfs (rw,nosuid,size=65536k,mode=755)
 tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,size=65536k,mode=755)
 tmpfs on /proc/scsi type tmpfs (ro,relatime)
 tmpfs on /sys/firmware type tmpfs (ro,relatime)
-''', 0, [('/data', 'cifs')])
+''', 0, [('/data', 'cifs')]),
+# From @yarikoptic - added blank lines to test for resilience
+(r'''/proc on /proc type proc (rw,relatime)
+sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+tmpfs on /dev/shm type tmpfs (rw,relatime)
+devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+
+devpts on /dev/ptmx type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+
+''', 0, []),
 )
 
 


### PR DESCRIPTION
Fixes #2473.

Follow-up to #2444 and #1941.

Changes proposed in this pull request
- Log a debug message on parse failure.
- Separate matching from retrieving, to enable error checking.
- Ignore blank lines. These shouldn't happen, but we shouldn't be sensitive to them.
- Simplify regular expression by enumerating stop conditions in fstype group.

@yarikoptic Can you verify this resolves your issue?