### PR TITLE
FIX: mark .niml.dset as special extension in utils.filemanip

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -74,7 +74,7 @@ def split_filename(fname):
 
     """
 
-    special_extensions = [".nii.gz", ".tar.gz"]
+    special_extensions = [".nii.gz", ".tar.gz", ".niml.dset"]
 
     pth = op.dirname(fname)
     fname = op.basename(fname)

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -24,6 +24,7 @@ def _ignore_atime(stat):
 @pytest.mark.parametrize(
     "filename, split",
     [('foo.nii', ('', 'foo', '.nii')), ('foo.nii.gz', ('', 'foo', '.nii.gz')),
+     ('foo.niml.dset', ('', 'foo', '.niml.dset')),
      ('/usr/local/foo.nii.gz',
       ('/usr/local', 'foo', '.nii.gz')), ('../usr/local/foo.nii',
                                           ('../usr/local', 'foo', '.nii')),


### PR DESCRIPTION
All AFNI commands work also on files with extension `.niml.dset` (for surfaces).

Changes proposed in this pull request
- consider `*.niml.dset` as special extension to correctly split filenames
