### PR TITLE
FIX: Some install_requires are actually only setup_requires

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -143,11 +143,14 @@ REQUIRES = [
     'prov==%s' % PROV_VERSION,
     'click>=%s' % CLICK_MIN_VERSION,
     'funcsigs',
-    'pytest>=%s' % PYTEST_MIN_VERSION,
-    'mock',
     'pydotplus',
     'pydot>=%s' % PYDOT_MIN_VERSION,
     'packaging',
+]
+SETUP_REQUIRES = [
+    'future',
+    'mock',
+    'pytest>=%s' % PYTEST_MIN_VERSION,
 ]
 
 if sys.version_info <= (3, 4):

--- a/setup.py
+++ b/setup.py
@@ -125,9 +125,8 @@ def main():
     with open(ver_file) as infofile:
         exec(infofile.read(), globals(), ldict)
 
-    SETUP_REQUIRES = ['future']
     if sys.version_info <= (3, 4):
-        SETUP_REQUIRES.append('configparser')
+        ldict['SETUP_REQUIRES'].append('configparser')
     setup(
         name=ldict['NAME'],
         maintainer=ldict['MAINTAINER'],
@@ -143,7 +142,7 @@ def main():
         platforms=ldict['PLATFORMS'],
         version=ldict['VERSION'],
         install_requires=ldict['REQUIRES'],
-        setup_requires=SETUP_REQUIRES,
+        setup_requires=ldict['SETUP_REQUIRES'],
         provides=ldict['PROVIDES'],
         packages=find_packages(),
         package_data={'nipype': testdatafiles},


### PR DESCRIPTION
`pytest` and `mock` were previously listed under `install_requires`. This meant that if creating a packages that depends on `nipype`, you need to have these dependencies installed, but really they are only used during building, testing and installing (I believe, a quick grep looks like it).