### PR TITLE
FIX: Build cmdline from working directory

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -27,7 +27,7 @@ from ...utils.misc import flatten, unflatten, str2bool, dict_diff
 from ...utils.filemanip import (md5, FileNotFoundError, filename_to_list,
                                 list_to_filename, copyfiles, fnames_presuffix,
                                 loadpkl, split_filename, load_json, makedirs,
-                                emptydirs, savepkl, to_str)
+                                emptydirs, savepkl, to_str, indirectory)
 
 from ...interfaces.base import (traits, InputMultiPath, CommandLine, Undefined,
                                 DynamicTraitedSpec, Bunch, InterfaceResult,
@@ -627,7 +627,8 @@ class Node(EngineBase):
             self._interface.__class__.__name__)
         if issubclass(self._interface.__class__, CommandLine):
             try:
-                cmd = self._interface.cmdline
+                with indirectory(outdir):
+                    cmd = self._interface.cmdline
             except Exception as msg:
                 result.runtime.stderr = '{}\n\n{}'.format(
                     getattr(result.runtime, 'stderr', ''), msg)

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -18,6 +18,7 @@ import os
 import os.path as op
 import re
 import shutil
+import contextlib
 import posixpath
 import simplejson as json
 import numpy as np
@@ -916,3 +917,11 @@ def relpath(path, start=None):
     if not rel_list:
         return os.curdir
     return op.join(*rel_list)
+
+
+@contextlib.contextmanager
+def indirectory(path):
+    cwd = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(cwd)

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -923,5 +923,7 @@ def relpath(path, start=None):
 def indirectory(path):
     cwd = os.getcwd()
     os.chdir(path)
-    yield
-    os.chdir(cwd)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -515,3 +515,9 @@ def test_indirectory(tmpdir):
             assert os.getcwd() == sd2
         assert os.getcwd() == sd1
     assert os.getcwd() == tmpdir.strpath
+    try:
+        with indirectory('subdir1'):
+            raise ValueError("Erroring out of context")
+    except ValueError:
+        pass
+    assert os.getcwd() == tmpdir.strpath

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -14,7 +14,7 @@ from ...utils.filemanip import (
     save_json, load_json, fname_presuffix, fnames_presuffix, hash_rename,
     check_forhash, _parse_mount_table, _cifs_table, on_cifs, copyfile,
     copyfiles, filename_to_list, list_to_filename, check_depends,
-    split_filename, get_related_files)
+    split_filename, get_related_files, indirectory)
 
 
 def _ignore_atime(stat):
@@ -490,3 +490,28 @@ def test_cifs_check():
 
     _cifs_table[:] = []
     _cifs_table.extend(orig_table)
+
+
+def test_indirectory(tmpdir):
+    tmpdir.chdir()
+
+    os.makedirs('subdir1/subdir2')
+    sd1 = os.path.abspath('subdir1')
+    sd2 = os.path.abspath('subdir1/subdir2')
+
+    assert os.getcwd() == tmpdir.strpath
+    with indirectory('/'):
+        assert os.getcwd() == '/'
+    assert os.getcwd() == tmpdir.strpath
+    with indirectory('subdir1'):
+        assert os.getcwd() == sd1
+        with indirectory('subdir2'):
+            assert os.getcwd() == sd2
+            with indirectory('..'):
+                assert os.getcwd() == sd1
+                with indirectory('/'):
+                    assert os.getcwd() == '/'
+                assert os.getcwd() == sd1
+            assert os.getcwd() == sd2
+        assert os.getcwd() == sd1
+    assert os.getcwd() == tmpdir.strpath


### PR DESCRIPTION
This fix supports an earlier ridiculous hack (#1857) that was broken by properly managing working directories (#2368).

Fixes #2518.

Changes proposed in this pull request
- Construct `cmdline` within the working directory, for the probably one case in which the `cmdline` depends on the working directory.
- Adds and tests an `indirectory` context manager, because I hate the `os.getcwd(); os.chdir(); CONTENT; os.chdir()` pattern.

There may be a more elegant way to get input traits into a file, but it's not clear to me what that is at this point, so I went for the cheap solution.
