### PR TITLE
[WIP] enh: a version of Function

### DIFF
--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -146,17 +146,6 @@ class Function(IOBase):
                 self.inputs.remove_trait(name)
             self._input_names = input_names
             add_traits(self.inputs, input_names)
-        else:
-            print(2, name, self._banned_names, obj, old)
-            if name not in self._banned_names and (self._kwargs_allowed or
-                                                   (self._input_names and
-                                                    name in self._input_names)):
-                self.inputs.trait_set(
-                    trait_change_notify=False, **{
-                        '%s' % name: new
-                    })
-            else:
-                raise ValueError('{} not an allowed argument'.format(name))
 
     def _add_output_traits(self, base):
         undefined_traits = {}

--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -134,6 +134,10 @@ class Function(IOBase):
 
     def _cannot_modify(self, obj, name, old, new):
         if name in self._banned_names:
+            self.inputs.trait_set(
+                trait_change_notify=False, **{
+                    '%s' % name: old
+                })
             raise traits.TraitError('The function does not allow modifying ' 
                                     'input: {}'.format(name))
 

--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -58,6 +58,7 @@ def parse_function(function, input_names=None, imports=None):
             raise ValueError('Unknown arguments: {} '
                              'for function'.format(unknown))
     banned_names = list(set(argspec.kwonlydefaults.keys()) - set(input_names))
+    banned_names = {k: argspec.kwonlydefaults[k] for k in banned_names}
     return function_str, filename_to_list(input_names), \
            banned_names, argspec.varkw is not None
 
@@ -119,8 +120,12 @@ class Function(IOBase):
         self.inputs.on_trait_change(self._set_function_string, 'function_str')
         self._output_names = filename_to_list(output_names)
         add_traits(self.inputs, [name for name in self._input_names])
-        for name in self._banned_names:
+        for name, value in self._banned_names.items():
             self.inputs.add_trait(name, traits.Any)
+            self.inputs.trait_set(
+                trait_change_notify=False, **{
+                    '%s' % name: value
+                })
             self.inputs.on_trait_change(self._cannot_modify, name)
         self.imports = imports
         self._out = {}


### PR DESCRIPTION
mostly in reference to #2520 

```python
In [1]: from nipype import Function

In [2]: def func(a, b, *, c, d=None, **kwargs):
   ...:     return 1
   ...: 

In [3]: foo = Function(func, input_names='a', output_names='out')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-f8f4cb531730> in <module>()
----> 1 foo = Function(func, input_names='a', output_names='out')

/software/nipy-repo/nipype/nipype/interfaces/utility/wrappers.py in __init__(self, function, input_names, output_names, imports, **inputs)
    114             self._input_names,\
    115             self._banned_names,\
--> 116             self._kwargs_allowed = parse_function(function, input_names, imports)
    117         if self._kwargs_allowed:
    118             self.inputs = FunctionInputSpec2()

/software/nipy-repo/nipype/nipype/interfaces/utility/wrappers.py in parse_function(function, input_names, imports)
     53         if missed_args:
     54             raise ValueError('These positional args must be in '
---> 55                              'input_names: {}'.format(missed_args))
     56         unknown = set(input_names) - set(all_args)
     57         if unknown:

ValueError: These positional args must be in input_names: {'c', 'b'}

In [4]: foo = Function(func, input_names=['a', 'b', 'c'], output_names='out')

In [5]: foo.inputs.d = 1
Exception occurred in traits notification handler.
...
/software/nipy-repo/nipype/nipype/interfaces/utility/wrappers.py in _cannot_modify(self, obj, name, old, new)
    131         if name in self._banned_names:
    132             raise traits.TraitError('The function does not allow modifying ' 
--> 133                                     'input: {}'.format(name))
    134 
    135     def _set_function_string(self, obj, name, old, new):

TraitError: The function does not allow modifying input: d

In [6]: foo.inputs.e = 1

In [7]: def func(a, b, *, c, d=None):
   ...:     return 1
   ...: 

In [8]: foo = Function(func, input_names=['a', 'b', 'c'], output_names='out')

In [9]: foo.inputs.e = 1
---------------------------------------------------------------------------
TraitError                                Traceback (most recent call last)
<ipython-input-9-3047e0808bfc> in <module>()
----> 1 foo.inputs.e = 1

TraitError: Cannot set the undefined 'e' attribute of a 'FunctionInputSpec' object.
```
