### PR TITLE
FIX: Replace deprecated ``HasTraits.get`` with ``trait_get``

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -1133,7 +1133,7 @@ class CommandLine(BaseInterface):
         metadata = dict(name_source=lambda t: t is not None)
         traits = self.inputs.traits(**metadata)
         if traits:
-            outputs = self.output_spec().get()
+            outputs = self.output_spec().trait_get()
             for name, trait_spec in list(traits.items()):
                 out_name = name
                 if trait_spec.output_name is not None:
@@ -1237,7 +1237,7 @@ class SEMLikeCommandLine(CommandLine):
     """
 
     def _list_outputs(self):
-        outputs = self.output_spec().get()
+        outputs = self.output_spec().trait_get()
         return self._outputs_from_inputs(outputs)
 
     def _outputs_from_inputs(self, outputs):

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -150,18 +150,17 @@ class BaseTraitedSpec(traits.HasTraits):
                             '%s' % trait_spec.new_name: new
                         })
 
-    def get(self, **kwargs):
+    def trait_get(self, **kwargs):
         """ Returns traited class as a dict
 
         Augments the trait get function to return a dictionary without
         notification handles
         """
-        try:
-            out = super(BaseTraitedSpec, self).trait_get(**kwargs)
-        except AttributeError:  # deprecated old get
-            out = super(BaseTraitedSpec, self).get(**kwargs)
+        out = super(BaseTraitedSpec, self).trait_get(**kwargs)
         out = self._clean_container(out, Undefined)
         return out
+
+    get = trait_get
 
     def get_traitsfree(self, **kwargs):
         """ Returns traited class as a dict
@@ -170,7 +169,7 @@ class BaseTraitedSpec(traits.HasTraits):
         any traits. The dictionary does not contain any attributes that
         were Undefined
         """
-        out = super(BaseTraitedSpec, self).get(**kwargs)
+        out = super(BaseTraitedSpec, self).trait_get(**kwargs)
         out = self._clean_container(out, skipundefined=True)
         return out
 
@@ -238,7 +237,7 @@ class BaseTraitedSpec(traits.HasTraits):
 
         list_withhash = []
         list_nofilename = []
-        for name, val in sorted(self.get().items()):
+        for name, val in sorted(self.trait_get().items()):
             if not isdefined(val) or self.has_metadata(name, "nohash", True):
                 # skip undefined traits and traits with nohash=True
                 continue
@@ -343,7 +342,7 @@ class DynamicTraitedSpec(BaseTraitedSpec):
         id_self = id(self)
         if id_self in memo:
             return memo[id_self]
-        dup_dict = deepcopy(self.get(), memo)
+        dup_dict = deepcopy(self.trait_get(), memo)
         # access all keys
         for key in self.copyable_trait_names():
             if key in self.__dict__.keys():

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -18,7 +18,6 @@ from warnings import warn
 from builtins import str, bytes
 from packaging.version import Version
 
-from ...utils.misc import is_container
 from ...utils.filemanip import md5, hash_infile, hash_timestamp, to_str
 from .traits_extension import (
     traits,
@@ -157,7 +156,10 @@ class BaseTraitedSpec(traits.HasTraits):
         Augments the trait get function to return a dictionary without
         notification handles
         """
-        out = super(BaseTraitedSpec, self).get(**kwargs)
+        try:
+            out = super(BaseTraitedSpec, self).trait_get(**kwargs)
+        except AttributeError:  # deprecated old get
+            out = super(BaseTraitedSpec, self).get(**kwargs)
         out = self._clean_container(out, Undefined)
         return out
 
@@ -183,8 +185,8 @@ class BaseTraitedSpec(traits.HasTraits):
                 else:
                     if not skipundefined:
                         out[key] = undefinedval
-        elif (isinstance(objekt, TraitListObject) or isinstance(objekt, list)
-              or isinstance(objekt, tuple)):
+        elif (isinstance(objekt, TraitListObject) or isinstance(objekt, list) or
+              isinstance(objekt, tuple)):
             out = []
             for val in objekt:
                 if isdefined(val):
@@ -241,8 +243,8 @@ class BaseTraitedSpec(traits.HasTraits):
                 # skip undefined traits and traits with nohash=True
                 continue
 
-            hash_files = (not self.has_metadata(name, "hash_files", False)
-                          and not self.has_metadata(name, "name_source"))
+            hash_files = (not self.has_metadata(name, "hash_files", False) and
+                          not self.has_metadata(name, "name_source"))
             list_nofilename.append((name,
                                     self._get_sorteddict(
                                         val,
@@ -286,8 +288,8 @@ class BaseTraitedSpec(traits.HasTraits):
         else:
             out = None
             if isdefined(objekt):
-                if (hash_files and isinstance(objekt, (str, bytes))
-                        and os.path.isfile(objekt)):
+                if (hash_files and isinstance(objekt, (str, bytes)) and
+                        os.path.isfile(objekt)):
                     if hash_method is None:
                         hash_method = config.get('execution', 'hash_method')
 

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -531,8 +531,8 @@ class Node(EngineBase):
             else:
                 output_name = info[1]
                 try:
-                    output_value = results.outputs.get()[output_name]
-                except TypeError:
+                    output_value = results.outputs.trait_get()[output_name]
+                except AttributeError:
                     output_value = results.outputs.dictcopy()[output_name]
             logger.debug('output: %s', output_name)
             try:
@@ -678,7 +678,7 @@ class Node(EngineBase):
             makedirs(outdir, exist_ok=True)
 
         for info in self._interface._get_filecopy_info():
-            files = self.inputs.get().get(info['key'])
+            files = self.inputs.trait_get().get(info['key'])
             if not isdefined(files) or not files:
                 continue
 
@@ -1084,7 +1084,7 @@ class MapNode(Node):
     @property
     def outputs(self):
         if self._interface._outputs():
-            return Bunch(self._interface._outputs().get())
+            return Bunch(self._interface._outputs().trait_get())
 
     def _make_nodes(self, cwd=None):
         if cwd is None:
@@ -1109,7 +1109,7 @@ class MapNode(Node):
                 name=nodename)
             node.plugin_args = self.plugin_args
             node.interface.inputs.trait_set(
-                **deepcopy(self._interface.inputs.get()))
+                **deepcopy(self._interface.inputs.trait_get()))
             node.interface.resource_monitor = self._interface.resource_monitor
             for field in self.iterfield:
                 if self.nested:
@@ -1153,7 +1153,7 @@ class MapNode(Node):
                     if not isdefined(values):
                         values = []
                     if nresult and nresult.outputs:
-                        values.insert(i, nresult.outputs.get()[key])
+                        values.insert(i, nresult.outputs.trait_get()[key])
                     else:
                         values.insert(i, None)
                     defined_vals = [isdefined(val) for val in values]
@@ -1201,7 +1201,7 @@ class MapNode(Node):
         return len(filename_to_list(getattr(self.inputs, self.iterfield[0])))
 
     def _get_inputs(self):
-        old_inputs = self._inputs.get()
+        old_inputs = self._inputs.trait_get()
         self._inputs = self._create_dynamic_traits(
             self._interface.inputs, fields=self.iterfield)
         self._inputs.trait_set(**old_inputs)

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -142,7 +142,7 @@ def write_report(node, report_type=None, is_mapnode=False):
                 ['Hierarchy : %s' % node.fullname,
                  'Exec ID : %s' % node._id]),
             write_rst_header('Original Inputs', level=1),
-            write_rst_dict(node.inputs.get()),
+            write_rst_dict(node.inputs.trait_get()),
         ]
         with open(report_file, 'wt') as fp:
             fp.write('\n'.join(lines))
@@ -150,7 +150,7 @@ def write_report(node, report_type=None, is_mapnode=False):
 
     lines = [
         write_rst_header('Execution Inputs', level=1),
-        write_rst_dict(node.inputs.get()),
+        write_rst_dict(node.inputs.trait_get()),
     ]
 
     result = node.result  # Locally cache result
@@ -166,7 +166,7 @@ def write_report(node, report_type=None, is_mapnode=False):
     if isinstance(outputs, Bunch):
         lines.append(write_rst_dict(outputs.dictcopy()))
     elif outputs:
-        lines.append(write_rst_dict(outputs.get()))
+        lines.append(write_rst_dict(outputs.trait_get()))
 
     if is_mapnode:
         lines.append(write_rst_header('Subnode reports', level=1))
@@ -238,8 +238,8 @@ def save_resultfile(result, cwd, name):
     resultsfile = os.path.join(cwd, 'result_%s.pklz' % name)
     if result.outputs:
         try:
-            outputs = result.outputs.get()
-        except TypeError:
+            outputs = result.outputs.trait_get()
+        except AttributeError:
             outputs = result.outputs.dictcopy()  # outputs was a bunch
         result.outputs.set(**modify_paths(outputs, relative=True, basedir=cwd))
 
@@ -293,8 +293,8 @@ def load_resultfile(path, name):
         else:
             if result.outputs:
                 try:
-                    outputs = result.outputs.get()
-                except TypeError:
+                    outputs = result.outputs.trait_get()
+                except AttributeError:
                     outputs = result.outputs.dictcopy()  # outputs == Bunch
                 try:
                     result.outputs.set(
@@ -1391,19 +1391,19 @@ def clean_working_directory(outputs,
     """
     if not outputs:
         return
-    outputs_to_keep = list(outputs.get().keys())
+    outputs_to_keep = list(outputs.trait_get().keys())
     if needed_outputs and \
        str2bool(config['execution']['remove_unnecessary_outputs']):
         outputs_to_keep = needed_outputs
     # build a list of needed files
     output_files = []
-    outputdict = outputs.get()
+    outputdict = outputs.trait_get()
     for output in outputs_to_keep:
         output_files.extend(walk_outputs(outputdict[output]))
     needed_files = [path for path, type in output_files if type == 'f']
     if str2bool(config['execution']['keep_inputs']):
         input_files = []
-        inputdict = inputs.get()
+        inputdict = inputs.trait_get()
         input_files.extend(walk_outputs(inputdict))
         needed_files += [path for path, type in input_files if type == 'f']
     for extra in [
@@ -1435,7 +1435,7 @@ def clean_working_directory(outputs,
     else:
         if not str2bool(config['execution']['keep_inputs']):
             input_files = []
-            inputdict = inputs.get()
+            inputdict = inputs.trait_get()
             input_files.extend(walk_outputs(inputdict))
             input_files = [path for path, type in input_files if type == 'f']
             for f in walk_files(cwd):


### PR DESCRIPTION
Deprecation mark: https://github.com/enthought/traits/blob/a99b3f64d50c5f7f28ffc01bf69419b061f9e976/traits/has_traits.py#L1481

Fixes the following deprecation warning:

```
nipype/nipype/interfaces/base/specs.py:160: DeprecationWarning: use "HasTraits.trait_get" instead
  out = super(BaseTraitedSpec, self).get(**kwargs)
```

This warning has started to appear recently, traits must have gotten a major update.
