### PR TITLE
[FIX] return non-enhanced volumes from dwi_flirt

### DIFF
--- a/nipype/workflows/dmri/fsl/utils.py
+++ b/nipype/workflows/dmri/fsl/utils.py
@@ -125,34 +125,42 @@ def dwi_flirt(name='DWICoregistration', excl_nodiff=False, flirt_param={}):
         fsl.FLIRT(**flirt_param),
         name='CoRegistration',
         iterfield=['in_file', 'in_matrix_file'])
-    thres = pe.MapNode(
-        fsl.Threshold(thresh=0.0),
-        iterfield=['in_file'],
-        name='RemoveNegative')
+    apply_xfms = pe.MapNode(
+        fsl.ApplyXFM(
+            apply_xfm=True,
+            interp='spline',
+            bgvalue=0),
+        name='ApplyXFMs',
+        iterfield=['in_file', 'in_matrix_file']
+    )
     merge = pe.Node(fsl.Merge(dimension='t'), name='MergeDWIs')
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['out_file', 'out_xfms']),
         name='outputnode')
     wf = pe.Workflow(name=name)
-    wf.connect(
-        [(inputnode, split, [('in_file', 'in_file')]),
-         (inputnode, dilate, [('ref_mask', 'in_file')]),
-         (inputnode, enhb0, [('ref_mask', 'in_mask')]), (inputnode, initmat, [
-             ('in_xfms', 'in_xfms'), ('in_bval', 'in_bval')
-         ]), (inputnode, n4,
-              [('reference', 'input_image'),
-               ('ref_mask', 'mask_image')]), (dilate, flirt, [
-                   ('out_file', 'ref_weight'), ('out_file', 'in_weight')
-               ]), (n4, enhb0, [('output_image', 'in_file')]), (split, enhdw, [
-                   ('out_files', 'in_file')
-               ]), (dilate, enhdw, [('out_file', 'in_mask')]), (enhb0, flirt, [
-                   ('out_file', 'reference')
-               ]), (enhdw, flirt, [('out_file', 'in_file')]),
-         (initmat, flirt, [('init_xfms', 'in_matrix_file')]), (flirt, thres, [
-             ('out_file', 'in_file')
-         ]), (thres, merge, [('out_file', 'in_files')]), (merge, outputnode, [
-             ('merged_file', 'out_file')
-         ]), (flirt, outputnode, [('out_matrix_file', 'out_xfms')])])
+    wf.connect([
+        (inputnode, split, [('in_file', 'in_file')]),
+        (inputnode, dilate, [('ref_mask', 'in_file')]),
+        (inputnode, enhb0, [('ref_mask', 'in_mask')]),
+        (inputnode, initmat, [('in_xfms', 'in_xfms'),
+                              ('in_bval', 'in_bval')]),
+        (inputnode, n4, [('reference', 'input_image'),
+                         ('ref_mask', 'mask_image')]),
+        (dilate, flirt, [('out_file', 'ref_weight'),
+                         ('out_file', 'in_weight')]),
+        (n4, enhb0, [('output_image', 'in_file')]),
+        (split, enhdw, [('out_files', 'in_file')]),
+        (split, apply_xfms, [('out_files', 'in_file')]),
+        (dilate, enhdw, [('out_file', 'in_mask')]),
+        (enhb0, flirt, [('out_file', 'reference')]),
+        (enhb0, apply_xfms, [('out_file', 'reference')]),
+        (enhdw, flirt, [('out_file', 'in_file')]),
+        (initmat, flirt, [('init_xfms', 'in_matrix_file')]),
+        (flirt, apply_xfms, [('out_matrix_file', 'in_matrix_file')]),
+        (apply_xfms, merge, [('out_file', 'in_files')]),
+        (merge, outputnode, [('merged_file', 'out_file')]),
+        (flirt, outputnode, [('out_matrix_file', 'out_xfms')])
+    ])
     return wf
 
 

--- a/nipype/workflows/dmri/fsl/utils.py
+++ b/nipype/workflows/dmri/fsl/utils.py
@@ -133,6 +133,10 @@ def dwi_flirt(name='DWICoregistration', excl_nodiff=False, flirt_param={}):
         name='ApplyXFMs',
         iterfield=['in_file', 'in_matrix_file']
     )
+    thres = pe.MapNode(
+        fsl.Threshold(thresh=0.0),
+        iterfield=['in_file'],
+        name='RemoveNegative')
     merge = pe.Node(fsl.Merge(dimension='t'), name='MergeDWIs')
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['out_file', 'out_xfms']),
@@ -157,7 +161,8 @@ def dwi_flirt(name='DWICoregistration', excl_nodiff=False, flirt_param={}):
         (enhdw, flirt, [('out_file', 'in_file')]),
         (initmat, flirt, [('init_xfms', 'in_matrix_file')]),
         (flirt, apply_xfms, [('out_matrix_file', 'in_matrix_file')]),
-        (apply_xfms, merge, [('out_file', 'in_files')]),
+        (apply_xfms, thres, [('out_file', 'in_file')]),
+        (thres, merge, [('out_file', 'in_files')]),
         (merge, outputnode, [('merged_file', 'out_file')]),
         (flirt, outputnode, [('out_matrix_file', 'out_xfms')])
     ])


### PR DESCRIPTION
Fixes #1787

Changes proposed in this pull request
- applies the matrix transforms from the adjusted/enhanced non-B0 volumes to the original non-B0 volumes, so that the image intensities remain the same. Ideally flirt should just estimate/apply linear transforms, not change the image intensities. As @salma1601 mentioned, `exposure.equalize_adapthist` appears to be the culprit.

[example dwi data for testing](https://osf.io/hde8t/download)

[related code that _can_ be used for testing (with modification)](https://github.com/uiowa-mri-course-2018/Labs/blob/master/11-Lab/DWI.ipynb)
