### PR TITLE
fix: propagate explicit workflow config to nodes in a workflow and allow nodes to overwrite

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -183,6 +183,7 @@ class Node(EngineBase):
         self._hashed_inputs = None
         self._needed_outputs = []
         self.needed_outputs = needed_outputs
+        self.config = None
 
     @property
     def interface(self):


### PR DESCRIPTION
Fixes # 2557.

Changes proposed in this pull request
- Simply set the node config to None on initialization
- This picks up the default when run is called.

@eort - please see if this branch solves your problem
