### PR TITLE
ENH: ReportCapableInterface mix-in/base interface

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -517,7 +517,9 @@ class BaseInterface(Interface):
         outputs = None
 
         try:
+            runtime = self._pre_run_hook(runtime)
             runtime = self._run_interface(runtime)
+            runtime = self._post_run_hook(runtime)
             outputs = self.aggregate_outputs(runtime)
         except Exception as e:
             import traceback
@@ -652,6 +654,28 @@ class BaseInterface(Interface):
         iflogger.debug('saving inputs {}', inputs)
         with open(json_file, 'w' if PY3 else 'wb') as fhandle:
             json.dump(inputs, fhandle, indent=4, ensure_ascii=False)
+
+    def _pre_run_hook(self, runtime):
+        """
+        Perform any pre-_run_interface() processing
+
+        Subclasses may override this function to modify ``runtime`` object or
+        interface state
+
+        MUST return runtime object
+        """
+        return runtime
+
+    def _post_run_hook(self, runtime):
+        """
+        Perform any post-_run_interface() processing
+
+        Subclasses may override this function to modify ``runtime`` object or
+        interface state
+
+        MUST return runtime object
+        """
+        return runtime
 
 
 class SimpleInterface(BaseInterface):

--- a/nipype/interfaces/mixins/__init__.py
+++ b/nipype/interfaces/mixins/__init__.py
@@ -1,0 +1,2 @@
+from reporting import (
+    ReportCapableInterface, ReportCapableInputSpec, ReportCapableOutputSpec)

--- a/nipype/interfaces/mixins/__init__.py
+++ b/nipype/interfaces/mixins/__init__.py
@@ -1,2 +1,2 @@
-from reporting import (
+from .reporting import (
     ReportCapableInterface, ReportCapableInputSpec, ReportCapableOutputSpec)

--- a/nipype/interfaces/mixins/reporting.py
+++ b/nipype/interfaces/mixins/reporting.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+""" class mixin and utilities for enabling reports for nipype interfaces """
+from __future__ import (print_function, division, unicode_literals,
+                        absolute_import)
+
+import os
+from abc import abstractmethod
+
+from ... import logging
+from ..base import (
+    File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
+
+iflogger = logging.getLogger('interface')
+
+
+class ReportCapableInputSpec(BaseInterfaceInputSpec):
+    generate_report = traits.Bool(False, usedefault=True,
+                                  desc="Enable report generation")
+    out_report = File('report', usedefault=True, hash_files=False,
+                      desc='filename for the visual report')
+
+
+class ReportCapableOutputSpec(TraitedSpec):
+    out_report = File(desc='filename for the visual report')
+
+
+class ReportCapableInterface(BaseInterface):
+    """Mixin to enable reporting for Nipype interfaces"""
+    _out_report = None
+
+    def _post_run_hook(self, runtime):
+        runtime = super(ReportCapableInterface, self)._post_run_hook(runtime)
+
+        # leave early if there's nothing to do
+        if not self.inputs.generate_report:
+            return runtime
+
+        self._out_report = os.path.abspath(self.inputs.out_report)
+        self._generate_report()
+
+        return runtime
+
+    def _list_outputs(self):
+        try:
+            outputs = super(ReportCapableInterface, self)._list_outputs()
+        except NotImplementedError:
+            outputs = {}
+        if self._out_report is not None:
+            outputs['out_report'] = self._out_report
+        return outputs
+
+    @abstractmethod
+    def _generate_report(self):
+        """
+        Saves report to file identified by _out_report instance variable
+        """
+        raise NotImplementedError

--- a/nipype/interfaces/mixins/reporting.py
+++ b/nipype/interfaces/mixins/reporting.py
@@ -16,8 +16,6 @@ iflogger = logging.getLogger('interface')
 
 
 class ReportCapableInputSpec(BaseInterfaceInputSpec):
-    generate_report = traits.Bool(False, usedefault=True,
-                                  desc="Enable report generation")
     out_report = File('report', usedefault=True, hash_files=False,
                       desc='filename for the visual report')
 
@@ -30,11 +28,15 @@ class ReportCapableInterface(BaseInterface):
     """Mixin to enable reporting for Nipype interfaces"""
     _out_report = None
 
+    def __init__(self, generate_report=False, **kwargs):
+        super(ReportCapableInterface, self).__init__(self, **kwargs)
+        self.generate_report = generate_report
+
     def _post_run_hook(self, runtime):
         runtime = super(ReportCapableInterface, self)._post_run_hook(runtime)
 
         # leave early if there's nothing to do
-        if not self.inputs.generate_report:
+        if not self.generate_report:
             return runtime
 
         self._out_report = os.path.abspath(self.inputs.out_report)

--- a/nipype/interfaces/mixins/reporting.py
+++ b/nipype/interfaces/mixins/reporting.py
@@ -29,7 +29,7 @@ class ReportCapableInterface(BaseInterface):
     _out_report = None
 
     def __init__(self, generate_report=False, **kwargs):
-        super(ReportCapableInterface, self).__init__(self, **kwargs)
+        super(ReportCapableInterface, self).__init__(**kwargs)
         self.generate_report = generate_report
 
     def _post_run_hook(self, runtime):

--- a/nipype/interfaces/mixins/reporting.py
+++ b/nipype/interfaces/mixins/reporting.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 
 from ... import logging
 from ..base import (
-    File, traits, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
+    File, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
 
 iflogger = logging.getLogger('interface')
 
@@ -39,7 +39,11 @@ class ReportCapableInterface(BaseInterface):
         if not self.generate_report:
             return runtime
 
-        self._out_report = os.path.abspath(self.inputs.out_report)
+        self._out_report = self.inputs.out_report
+        if not os.path.isabs(self._out_report):
+            self._out_report = os.path.abspath(os.path.join(runtime.cwd,
+                                                            self._out_report))
+
         self._generate_report()
 
         return runtime


### PR DESCRIPTION
Related (closes?): #2553

Changes proposed in this pull request
- Adds pre- and post-run hooks to BaseInterface, which is intended to allow mix-ins to be more flexible about where exactly they fall within the method resolution stack.
- Creates `ReportCapableInterface` as a mix-in that is also written to work as a base class as well.

This factors out what seemed to be the essential parts of the niworkflows [`ReportCapableInterface`](https://github.com/poldracklab/niworkflows/blob/9d4163e30dae3caf7560313ef353d4177a38004f/niworkflows/interfaces/report_base.py#L23-L108).

Differences:

* Compression is removed as an option - without the actual figure generation and compression machinery, this would be under-supported. If these are worth adding, we can do so, but in point of fact we're considering undoing some of our compression steps as they make our reports Chrome-only.
* `_post_run_hook` is now the driver of this functionality, and classes using this mix-in should tail-call `return super(..., self)._post_run_hook(runtime)`.
* `_generate_error_report` was removed. I don't think this can actually be hit in niworkflows, as `CommandLine` interfaces that had bad return values raised exceptions.