### PR TITLE
FIX/TEST: Gunzip cleanup and test

### DIFF
--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -266,21 +266,32 @@ class GunzipOutputSpec(TraitedSpec):
 
 class Gunzip(BaseInterface):
     """Gunzip wrapper
+
+    >>> from nipype.algorithms.misc import Gunzip
+    >>> gunzip = Gunzip(in_file='tpms_msk.nii.gz')
+    >>> res = gunzip.run()
+    >>> res.outputs.out_file  # doctest: +ELLIPSIS
+    '.../tpms_msk.nii'
+
+    .. testcleanup::
+
+    >>> os.unlink('tpms_msk.nii')
     """
     input_spec = GunzipInputSpec
     output_spec = GunzipOutputSpec
 
     def _gen_output_file_name(self):
         _, base, ext = split_filename(self.inputs.in_file)
-        if ext[-2:].lower() == ".gz":
+        if ext[-3:].lower() == ".gz":
             ext = ext[:-3]
-        return os.path.abspath(base + ext[:-3])
+        return os.path.abspath(base + ext)
 
     def _run_interface(self, runtime):
         import gzip
+        import shutil
         with gzip.open(self.inputs.in_file, 'rb') as in_file:
             with open(self._gen_output_file_name(), 'wb') as out_file:
-                out_file.write(in_file.read())
+                shutil.copyfileobj(in_file, out_file)
         return runtime
 
     def _list_outputs(self):


### PR DESCRIPTION
Following [Neurostars #1623](https://neurostars.org/t/attention-with-anonymization-and-gzipped-files-you-might-be-publishing-subject-information/1623), I checked on the nipype `Gzip` implementation. Apparently I misremembered, because I found `Gunzip` instead. Anyway, here are some cleanups and a doctest.

Changes proposed in this pull request
- FIX: `_gen_output_file_name` had a bad test for `.gz` extension
- ENH: Use `shutil.copyfileobj` to ensure more memory-friendly buffering
- TEST: Add doctest to demonstrate usage and verify filename change