### PR TITLE
CI: Test against minimum versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ python:
 - 3.6
 
 env:
-- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler" CI_SKIP_TEST=1
-- INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler" CI_SKIP_TEST=1
-- INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler" MIN_DEP=1 CI_SKIP_TEST=1
-- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler,duecredit,ssh" CI_SKIP_TEST=1
-- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler" PIP_FLAGS="--pre" CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,profiler" CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,profiler" CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,profiler" MIN_DEP=1 CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,profiler,duecredit,ssh" CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,profiler" PIP_FLAGS="--pre" CI_SKIP_TEST=1
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,6 @@ before_install:
 - travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu
 - if [ "$MIN_DEP" = "1" ]; then
     sed -e 's/>=/==/' < requirements.txt > requirements_min.txt;
-    if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then
-        sed -i -e "s/scipy==.*/scipy==0.16.0/" requirements_min.txt;
-    elif [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
-        sed -i -e "s/scipy==.*/scipy==0.18.1/" requirements_min.txt;
-    fi;
     travis_retry pip install -r requirements_min.txt;
   else
     travis_retry pip install -r requirements.txt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,11 @@ before_install:
 - travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu
 - if [ "$MIN_DEP" = "1" ]; then
     sed -e 's/>=/==/' < requirements.txt > requirements_min.txt;
+    if [ "$TRAVIS_PYTHON_VERSION" = "3.5" ]; then
+        sed -i -e "s/scipy==.*/scipy==0.16.0/" requirements_min.txt;
+    elif [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
+        sed -i -e "s/scipy==.*/scipy==0.18.1/" requirements_min.txt;
+    fi;
     travis_retry pip install -r requirements_min.txt;
   else
     travis_retry pip install -r requirements.txt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 env:
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler" CI_SKIP_TEST=1
 - INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler" CI_SKIP_TEST=1
+- INSTALL_DEB_DEPENDECIES=false NIPYPE_EXTRAS="doc,tests,fmri,profiler" MIN_DEP=1 CI_SKIP_TEST=1
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler,duecredit,ssh" CI_SKIP_TEST=1
 - INSTALL_DEB_DEPENDECIES=true NIPYPE_EXTRAS="doc,tests,fmri,profiler" PIP_FLAGS="--pre" CI_SKIP_TEST=1
 
@@ -49,7 +50,12 @@ before_install:
 - travis_retry conda update -q conda
 - conda config --add channels conda-forge
 - travis_retry conda install -y python=${TRAVIS_PYTHON_VERSION} icu
-- travis_retry pip install -r requirements.txt
+- if [ "$MIN_DEP" = "1" ]; then
+    sed -e 's/>=/==/' < requirements.txt > requirements_min.txt;
+    travis_retry pip install -r requirements_min.txt;
+  else
+    travis_retry pip install -r requirements.txt;
+  fi;
 - travis_retry git clone https://github.com/INCF/pybids.git ${HOME}/pybids &&
   pip install -e ${HOME}/pybids
 - travis_retry pip install codecov

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -224,7 +224,11 @@ class DistributedPluginBase(PluginBase):
             self._status_callback(self.procs[jobid], 'exception')
 
         if str2bool(self._config['execution']['stop_on_first_crash']):
-            raise RuntimeError("".join(result['traceback']))
+            if result is None:
+                tb = '\n'.join(format_exception(*sys.exc_info()))
+            else:
+                tb = result['traceback']
+            raise RuntimeError("".join(tb))
         crashfile = self._report_crash(self.procs[jobid], result=result)
         if jobid in self.mapnodesubids:
             # remove current jobid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.9.0
-scipy>=0.14
+numpy>=1.9.3
+scipy>=0.19.1
 networkx>=1.9
 traits>=4.6
 python-dateutil>=2.2


### PR DESCRIPTION
We're currently testing against the most recent versions of our dependencies, which makes it harder to identify when we accidentally depend on newer features. See, e.g., #2181.