### PR TITLE
CI: Move PyPI deployment to Circle 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
           command: |
             pip install twine future
             python setup.py sdist bdist_wheel
-            twine upload dist/*
+            # twine upload dist/*
 
 workflows:
   version: 2
@@ -368,11 +368,11 @@ workflows:
             - test_py3_fmri_fsl_spm
             - test_py3_fmri_spm_dartel_multiproc
       - deploy_pypi:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
+          # filters:
+          #   branches:
+          #     ignore: /.*/
+          #   tags:
+          #     only: /.*/
           requires:
             - test_pytest
             - test_fmri_spm_nested_fsl_feeds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
       - run: *_run_codecov_smoke
       - store_artifacts: *store_artifacts_kwds
 
-  deploy:
+  deploy_dockerhub:
     docker:
       - image: docker:17.10.0-ce-git
     steps:
@@ -330,6 +330,16 @@ jobs:
             - /tmp/docker/cache/Dockerfile.base-pruned
           key: dockerfile-cache-v1-{{ .Branch }}-{{ checksum "/tmp/docker/cache/Dockerfile.base-pruned" }}
 
+  deploy_pypi:
+    machine: *machine_kwds
+    working_directory: /home/circleci/nipype
+    steps:
+      - run:
+          name: Deploy to PyPI
+          command: |
+            pip install twine future
+            python setup.py sdist bdist_wheel
+            twine upload dist/*
 
 workflows:
   version: 2
@@ -348,10 +358,21 @@ workflows:
       - test_fmri_spm_nested_fsl_feeds:
           requires:
             - compare_base_dockerfiles
-      - deploy:
+      - deploy_dockerhub:
           filters:
             branches:
               only: master
+          requires:
+            - test_pytest
+            - test_fmri_spm_nested_fsl_feeds
+            - test_py3_fmri_fsl_spm
+            - test_py3_fmri_spm_dartel_multiproc
+      - deploy_pypi:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
           requires:
             - test_pytest
             - test_fmri_spm_nested_fsl_feeds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ _build_main_image_py36: &build_main_image_py36
         --tag nipype/nipype:py36 \
         --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
-        --build-arg VERSION="${CIRCLE_TAG}" /home/circleci/nipype \
+        --build-arg VERSION="${CIRCLE_TAG}" /home/circleci/nipype
 
 _build_main_image_py27: &build_main_image_py27
   name: Build main image (py27)
@@ -68,7 +68,7 @@ _build_main_image_py27: &build_main_image_py27
         --build-arg PYTHON_VERSION_MINOR=7 \
         --build-arg BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
-        --build-arg VERSION="${CIRCLE_TAG}-py27" /home/circleci/nipype \
+        --build-arg VERSION="${CIRCLE_TAG}-py27" /home/circleci/nipype
 
 _download_test_data: &_download_test_data
   name: Download test data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
           command: |
             pip install twine future wheel
             python setup.py sdist bdist_wheel
-            # twine upload dist/*
+            twine upload dist/*
 
 workflows:
   version: 2
@@ -370,11 +370,11 @@ workflows:
             - test_py3_fmri_fsl_spm
             - test_py3_fmri_spm_dartel_multiproc
       - deploy_pypi:
-          # filters:
-          #   branches:
-          #     ignore: /.*/
-          #   tags:
-          #     only: /.*/
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
           requires:
             - test_pytest
             - test_fmri_spm_nested_fsl_feeds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
       - run:
           name: Deploy to PyPI
           command: |
-            pip install twine future
+            pip install twine future wheel
             python setup.py sdist bdist_wheel
             # twine upload dist/*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,8 @@ jobs:
     machine: *machine_kwds
     working_directory: /home/circleci/nipype
     steps:
+      - checkout:
+          path: /home/circleci/nipype
       - run:
           name: Deploy to PyPI
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,16 +60,5 @@ install:
 script:
 - py.test -v --cov nipype --cov-config .coveragerc --cov-report xml:cov.xml -c nipype/pytest.ini --doctest-modules nipype
 
-deploy:
-  provider: pypi
-  user: satra
-  password:
-    secure: OCO0FXb4f+pH4Uw7zWCIRp3qOJ1t7rhky4K8MjNU8tyVCJgd6O/Bv8GJgceS0LktPodlAAjB8SxAhTORPAQZ1D/44PJYy3NQIisvej1zjLpaA9TEGfl6W7MqhDpRyMHW+cnSi/n84SAmdr+Z4vOxScDHdwr13EPmGyOIlHMAGnE=
-  on:
-    tags: true
-    repo: nipy/nipype
-    branch: master
-  distributions: "sdist bdist_wheel"
-
 after_script:
 - codecov --file cov.xml --flags unittests -e TRAVIS_JOB_NUMBER


### PR DESCRIPTION
Closes #2313.

Changes proposed in this pull request
- Moves PyPI deployment to CircleCI

The Travis builds are a little weird in that, on tagging, the first to successfully complete will upload to PyPI, while the rest will fail. This seems unnecessary, and we might as well use the dependencies allowed by Circle 2.0 workflows.

This will need @satra's PyPI credentials stored properly in Circle before it makes sense to merge.

Testing everything but the `twine` upload.