### PR TITLE
FIX: Set default result in DistributedPluginBase._clean_queue

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -154,9 +154,7 @@ class DistributedPluginBase(PluginBase):
                     result = self._get_result(taskid)
                 except Exception:
                     notrun.append(
-                        self._clean_queue(
-                            jobid,
-                            graph))
+                        self._clean_queue(jobid, graph))
                 else:
                     if result:
                         if result['traceback']:
@@ -218,9 +216,9 @@ class DistributedPluginBase(PluginBase):
 
         if self._status_callback:
             self._status_callback(self.procs[jobid], 'exception')
-		if result is None:
-			result={'result': None,
-					'traceback': '\n'.join(format_exception(*sys.exc_info()))}
+        if result is None:
+            result = {'result': None,
+                      'traceback': '\n'.join(format_exception(*sys.exc_info()))}
 
         if str2bool(self._config['execution']['stop_on_first_crash']):
             raise RuntimeError("".join(result['traceback']))

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -156,11 +156,7 @@ class DistributedPluginBase(PluginBase):
                     notrun.append(
                         self._clean_queue(
                             jobid,
-                            graph,
-                            result={
-                                'result': None,
-                                'traceback': '\n'.join(format_exception(*sys.exc_info()))
-                            }))
+                            graph))
                 else:
                     if result:
                         if result['traceback']:
@@ -222,6 +218,9 @@ class DistributedPluginBase(PluginBase):
 
         if self._status_callback:
             self._status_callback(self.procs[jobid], 'exception')
+		if result is None:
+			result={'result': None,
+					'traceback': '\n'.join(format_exception(*sys.exc_info()))}
 
         if str2bool(self._config['execution']['stop_on_first_crash']):
             raise RuntimeError("".join(result['traceback']))


### PR DESCRIPTION
Fixing this: https://github.com/nipy/nipype/issues/2570

Changes proposed in this pull request
- calls to _clean_queue in plugins/base.py now always have the information about exceptions when it's available
