### PR TITLE
FIX: Correctly connect JoinNodes in nested iterables

### DIFF
--- a/nipype/pipeline/engine/tests/test_join.py
+++ b/nipype/pipeline/engine/tests/test_join.py
@@ -627,3 +627,35 @@ def test_name_prefix_join(tmpdir):
                               joinfield=['in1'])
     wf.connect(square, 'out', square_join, "in1")
     wf.run()
+
+
+def test_join_nestediters(tmpdir):
+    tmpdir.chdir()
+
+    def exponent(x, p):
+        return x ** p
+
+    wf = pe.Workflow('wf', base_dir=tmpdir.strpath)
+
+    xs = pe.Node(IdentityInterface(['x']),
+                 iterables=[('x', [1, 2])],
+                 name='xs')
+    ps = pe.Node(IdentityInterface(['p']),
+                 iterables=[('p', [3, 4])],
+                 name='ps')
+    exp = pe.Node(Function(function=exponent), name='exp')
+    exp_joinx = pe.JoinNode(Merge(1, ravel_inputs=True),
+                            name='exp_joinx',
+                            joinsource='xs',
+                            joinfield=['in1'])
+    exp_joinp = pe.JoinNode(Merge(1, ravel_inputs=True),
+                            name='exp_joinp',
+                            joinsource='ps',
+                            joinfield=['in1'])
+    wf.connect([
+        (xs, exp, [('x', 'x')]),
+        (ps, exp, [('p', 'p')]),
+        (exp, exp_joinx, [('out', 'in1')]),
+        (exp_joinx, exp_joinp, [('out', 'in1')])])
+
+    wf.run()

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1066,6 +1066,9 @@ def generate_expanded_graph(graph_in):
                     if re.match(src_id + r'((\.[a-z](I\.[a-z])?|J)\d+)?$',
                                 node.itername):
                         expansions[src_id].append(node)
+                    else:
+                        logger.debug("Unmatched pattern: %s; src_id: %s",
+                                     node.itername, src_id)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"
                              " to %d nodes.", jnode, in_id, len(in_nodes))

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1055,6 +1055,8 @@ def generate_expanded_graph(graph_in):
                     # Drop the original JoinNodes; only concerned with
                     # generated Nodes
                     if hasattr(node, 'joinfield'):
+                        logger.warning("Dropping JoinNode: %s; src_id: %s",
+                                       node.itername, src_id)
                         continue
                     # Patterns:
                     #   - src_id : Non-iterable node

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1054,21 +1054,18 @@ def generate_expanded_graph(graph_in):
                 for src_id in list(old_edge_dict.keys()):
                     # Drop the original JoinNodes; only concerned with
                     # generated Nodes
-                    if hasattr(node, 'joinfield'):
-                        logger.warning("Dropping JoinNode: %s; src_id: %s",
-                                       node.itername, src_id)
+                    if hasattr(node, 'joinfield') and node.itername == src_id:
                         continue
                     # Patterns:
                     #   - src_id : Non-iterable node
-                    #   - src_id.[a-z]\d+ : IdentityInterface w/ iterables
-                    #   - src_id.[a-z]I.[a-z]\d+ : Non-IdentityInterface w/ iterables
+                    #   - src_id.[a-z]\d+ :
+                    #       IdentityInterface w/ iterables or nested JoinNode
+                    #   - src_id.[a-z]I.[a-z]\d+ :
+                    #       Non-IdentityInterface w/ iterables
                     #   - src_idJ\d+ : JoinNode(IdentityInterface)
                     if re.match(src_id + r'((\.[a-z](I\.[a-z])?|J)\d+)?$',
                                 node.itername):
                         expansions[src_id].append(node)
-                    else:
-                        logger.debug("Unmatched pattern: %s; src_id: %s",
-                                     node.itername, src_id)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug("The join node %s input %s was expanded"
                              " to %d nodes.", jnode, in_id, len(in_nodes))


### PR DESCRIPTION
Fixes #2578
Follow-up to #2479

Changes proposed in this pull request
- Narrow node name check to ensure `JoinNode`s aren't excluded incorrectly
- Add test
