### PR TITLE
MAINT: fix interaction with external logging

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -24,7 +24,7 @@ from ..interfaces.base import (traits, TraitedSpec, BaseInterface,
 from ..utils import NUMPY_MMAP
 from ..utils.misc import normalize_mc_params
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class ComputeDVARSInputSpec(BaseInterfaceInputSpec):

--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -17,7 +17,7 @@ from ..interfaces.base import (BaseInterface, traits, TraitedSpec, File,
                                BaseInterfaceInputSpec)
 from ..interfaces.vtkbase import tvtk
 from ..interfaces import vtkbase as VTKInfo
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class TVTKBaseInterface(BaseInterface):

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -26,7 +26,7 @@ from ..interfaces.base import (
     isdefined)
 from ..interfaces.nipy.base import NipyBaseInterface
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class DistanceInputSpec(BaseInterfaceInputSpec):

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -31,7 +31,7 @@ from ..utils import NUMPY_MMAP
 
 from . import confounds
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class PickAtlasInputSpec(BaseInterfaceInputSpec):

--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -29,7 +29,7 @@ from ..interfaces.base import (BaseInterface, TraitedSpec, InputMultiPath,
 from ..utils.filemanip import ensure_list
 from ..utils.misc import normalize_mc_params
 from .. import config, logging
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def gcd(a, b):

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -31,7 +31,7 @@ from ..interfaces.base import (BaseInterface, traits, InputMultiPath,
 from ..utils.filemanip import ensure_list, save_json, split_filename
 from ..utils.misc import find_indices, normalize_mc_params
 from .. import logging, config
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def _get_affine_matrix(params, source):

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -19,7 +19,7 @@ from ..base import (CommandLine, traits, CommandLineInputSpec, isdefined, File,
 from ...external.due import BibTeX
 
 # Use nipype's logging system
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class Info(PackageInfo):

--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -12,7 +12,7 @@ import os
 from ... import logging, LooseVersion
 from ..base import (CommandLine, CommandLineInputSpec, traits, isdefined,
                     PackageInfo)
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 # -Using -1 gives primary responsibilty to ITKv4 to do the correct
 #  thread limitings.

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -49,7 +49,7 @@ from .support import (Bunch, Stream, InterfaceResult, NipypeInterfaceError)
 from future import standard_library
 standard_library.install_aliases()
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 PY35 = sys.version_info >= (3, 5)
 PY3 = sys.version_info[0] > 2

--- a/nipype/interfaces/base/support.py
+++ b/nipype/interfaces/base/support.py
@@ -20,7 +20,7 @@ import locale
 from ... import logging
 from ...utils.misc import is_container
 from ...utils.filemanip import md5, to_str, hash_infile
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class NipypeInterfaceError(Exception):

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -19,7 +19,7 @@ from ...utils import NUMPY_MMAP
 
 from ..base import (BaseInterface, BaseInterfaceInputSpec, traits, File,
                     TraitedSpec, Directory, OutputMultiPath, isdefined)
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def length(xyz, along=False):

--- a/nipype/interfaces/cmtk/nbs.py
+++ b/nipype/interfaces/cmtk/nbs.py
@@ -13,7 +13,7 @@ from ... import logging
 from ..base import (LibraryBaseInterface, BaseInterfaceInputSpec, traits, File,
                     TraitedSpec, InputMultiPath, OutputMultiPath, isdefined)
 from .base import have_cv
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def ntwks_to_matrices(in_files, edge_key):

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -18,7 +18,7 @@ from ..base import (BaseInterface, BaseInterfaceInputSpec, traits, File,
                     TraitedSpec, InputMultiPath, OutputMultiPath, isdefined)
 from .base import have_cmp
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def read_unknown_ntwk(ntwk):

--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -18,7 +18,7 @@ from ..base import (BaseInterface, LibraryBaseInterface,
                     BaseInterfaceInputSpec, traits, File,
                     TraitedSpec, Directory, isdefined)
 from .base import have_cmp
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def create_annot_label(subject_id, subjects_dir, fs_dir, parcellation_name):

--- a/nipype/interfaces/dipy/anisotropic_power.py
+++ b/nipype/interfaces/dipy/anisotropic_power.py
@@ -8,7 +8,7 @@ from ... import logging
 from ..base import TraitedSpec, File, isdefined
 from .base import DipyDiffusionInterface, DipyBaseInterfaceInputSpec
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class APMQballInputSpec(DipyBaseInterfaceInputSpec):

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -12,7 +12,7 @@ from ... import logging
 from ..base import (traits, TraitedSpec, File, isdefined)
 from .base import DipyBaseInterface
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class ResampleInputSpec(TraitedSpec):

--- a/nipype/interfaces/dipy/reconstruction.py
+++ b/nipype/interfaces/dipy/reconstruction.py
@@ -18,7 +18,7 @@ from ... import logging
 from ..base import TraitedSpec, File, traits, isdefined
 from .base import DipyDiffusionInterface, DipyBaseInterfaceInputSpec
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class RESTOREInputSpec(DipyBaseInterfaceInputSpec):

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -13,7 +13,7 @@ from ...utils import NUMPY_MMAP
 from ..base import (traits, TraitedSpec, BaseInterfaceInputSpec, File,
                     InputMultiPath, isdefined)
 from .base import DipyBaseInterface
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class SimulateMultiTensorInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -8,7 +8,7 @@ from ... import logging
 from ..base import TraitedSpec, File, isdefined
 from .base import DipyDiffusionInterface, DipyBaseInterfaceInputSpec
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class DTIInputSpec(DipyBaseInterfaceInputSpec):

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -11,7 +11,7 @@ from ... import logging
 from ..base import (TraitedSpec, BaseInterfaceInputSpec, File, isdefined,
                     traits)
 from .base import DipyBaseInterface
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class TrackDensityMapInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/dtitk/base.py
+++ b/nipype/interfaces/dtitk/base.py
@@ -36,7 +36,7 @@ from ..base import CommandLine
 from nipype.interfaces.fsl.base import Info
 import warnings
 
-LOGGER = logging.getLogger('interface')
+LOGGER = logging.getLogger('nipype.interface')
 
 
 class DTITKRenameMixin(object):

--- a/nipype/interfaces/elastix/base.py
+++ b/nipype/interfaces/elastix/base.py
@@ -14,7 +14,7 @@ from __future__ import (print_function, division, unicode_literals,
 
 from ... import logging
 from ..base import CommandLineInputSpec, Directory, traits
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class ElastixBaseInputSpec(CommandLineInputSpec):

--- a/nipype/interfaces/elastix/registration.py
+++ b/nipype/interfaces/elastix/registration.py
@@ -18,7 +18,7 @@ from ... import logging
 from .base import ElastixBaseInputSpec
 from ..base import CommandLine, TraitedSpec, File, traits, InputMultiPath
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class RegistrationInputSpec(ElastixBaseInputSpec):

--- a/nipype/interfaces/elastix/utils.py
+++ b/nipype/interfaces/elastix/utils.py
@@ -16,7 +16,7 @@ import os.path as op
 from ... import logging
 from ..base import (BaseInterface, BaseInterfaceInputSpec, isdefined,
                     TraitedSpec, File, traits)
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class EditTransformInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/freesurfer/longitudinal.py
+++ b/nipype/interfaces/freesurfer/longitudinal.py
@@ -15,7 +15,7 @@ from .base import (FSCommand, FSTraitedSpec, FSCommandOpenMP,
                    FSTraitedSpecOpenMP)
 
 __docformat__ = 'restructuredtext'
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class RobustTemplateInputSpec(FSTraitedSpecOpenMP):

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -26,7 +26,7 @@ from .base import (FSCommand, FSTraitedSpec, FSTraitedSpecOpenMP,
 from .utils import copy2subjdir
 
 __docformat__ = 'restructuredtext'
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 # Keeping this to avoid breaking external programs that depend on it, but
 # this should not be used internally

--- a/nipype/interfaces/freesurfer/registration.py
+++ b/nipype/interfaces/freesurfer/registration.py
@@ -17,7 +17,7 @@ from .base import (FSCommand, FSTraitedSpec, FSScriptCommand,
 from ..base import (isdefined, TraitedSpec, File, traits, Directory)
 
 __docformat__ = 'restructuredtext'
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class MPRtoMNI305InputSpec(FSTraitedSpec):

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -43,7 +43,7 @@ filetypes = [
 ]
 implicit_filetypes = ['gii']
 
-logger = logging.getLogger('interface')
+logger = logging.getLogger('nipype.interface')
 
 
 def copy2subjdir(cls, in_file, folder=None, basename=None, subject_id=None):

--- a/nipype/interfaces/fsl/base.py
+++ b/nipype/interfaces/fsl/base.py
@@ -37,7 +37,7 @@ from ..base import (traits, isdefined, CommandLine, CommandLineInputSpec,
                     PackageInfo)
 from ...external.due import BibTeX
 
-IFLOGGER = logging.getLogger('interface')
+IFLOGGER = logging.getLogger('nipype.interface')
 
 
 class Info(PackageInfo):

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -62,7 +62,7 @@ try:
 except:
     pass
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def copytree(src, dst, use_hardlink=False):
@@ -513,7 +513,7 @@ class DataSink(IOBase):
 
         # Init variables
         creds_path = self.inputs.creds_path
-        iflogger = logging.getLogger('interface')
+        iflogger = logging.getLogger('nipype.interface')
 
         # Get AWS credentials
         try:
@@ -587,7 +587,7 @@ class DataSink(IOBase):
         from botocore.exceptions import ClientError
 
         # Init variables
-        iflogger = logging.getLogger('interface')
+        iflogger = logging.getLogger('nipype.interface')
         s3_str = 's3://'
         s3_prefix = s3_str + bucket.name
 
@@ -655,7 +655,7 @@ class DataSink(IOBase):
         """
 
         # Init variables
-        iflogger = logging.getLogger('interface')
+        iflogger = logging.getLogger('nipype.interface')
         outputs = self.output_spec().get()
         out_files = []
         # Use hardlink

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -513,7 +513,6 @@ class DataSink(IOBase):
 
         # Init variables
         creds_path = self.inputs.creds_path
-        iflogger = logging.getLogger('nipype.interface')
 
         # Get AWS credentials
         try:
@@ -587,7 +586,6 @@ class DataSink(IOBase):
         from botocore.exceptions import ClientError
 
         # Init variables
-        iflogger = logging.getLogger('nipype.interface')
         s3_str = 's3://'
         s3_prefix = s3_str + bucket.name
 
@@ -655,7 +653,6 @@ class DataSink(IOBase):
         """
 
         # Init variables
-        iflogger = logging.getLogger('nipype.interface')
         outputs = self.output_spec().get()
         out_files = []
         # Use hardlink

--- a/nipype/interfaces/mixins/reporting.py
+++ b/nipype/interfaces/mixins/reporting.py
@@ -12,7 +12,7 @@ from ... import logging
 from ..base import (
     File, BaseInterface, BaseInterfaceInputSpec, TraitedSpec)
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class ReportCapableInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/mne/base.py
+++ b/nipype/interfaces/mne/base.py
@@ -11,7 +11,7 @@ from ...utils.filemanip import simplify_list
 from ..base import (traits, File, Directory, TraitedSpec, OutputMultiPath)
 from ..freesurfer.base import FSCommand, FSTraitedSpec
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class WatershedBEMInputSpec(FSTraitedSpec):

--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -19,7 +19,7 @@ from ...workflows.misc.utils import get_data_dims, get_vox_dims
 from ..base import TraitedSpec, File, isdefined
 from ..dipy.base import DipyBaseInterface, HAVE_DIPY as have_dipy
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def transform_to_affine(streams, header, affine):

--- a/nipype/interfaces/mrtrix/tensors.py
+++ b/nipype/interfaces/mrtrix/tensors.py
@@ -11,7 +11,7 @@ from ... import logging
 from ...utils.filemanip import split_filename
 from ..base import (CommandLineInputSpec, CommandLine, BaseInterface, traits,
                     File, TraitedSpec, isdefined)
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class DWI2SphericalHarmonicsImageInputSpec(CommandLineInputSpec):

--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -6,7 +6,7 @@ from __future__ import (print_function, division, unicode_literals,
 
 from ... import logging
 from ..base import (CommandLineInputSpec, CommandLine, traits, File, isdefined)
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class MRTrix3BaseInputSpec(CommandLineInputSpec):

--- a/nipype/interfaces/niftyreg/base.py
+++ b/nipype/interfaces/niftyreg/base.py
@@ -26,7 +26,7 @@ from ... import logging
 from ..base import CommandLine, CommandLineInputSpec, traits, Undefined
 from ...utils.filemanip import split_filename
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 def get_custom_path(command, env_dir='NIFTYREGDIR'):

--- a/nipype/interfaces/spm/base.py
+++ b/nipype/interfaces/spm/base.py
@@ -37,7 +37,7 @@ from ..matlab import MatlabCommand
 from ...external.due import due, Doi, BibTeX
 
 __docformat__ = 'restructuredtext'
-logger = logging.getLogger('interface')
+logger = logging.getLogger('nipype.interface')
 
 
 def func_is_3d(in_file):

--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -26,7 +26,7 @@ from .base import (SPMCommand, SPMCommandInputSpec, scans_for_fnames,
                    ImageFileSPM)
 
 __docformat__ = 'restructuredtext'
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class Level1DesignInputSpec(SPMCommandInputSpec):

--- a/nipype/interfaces/utility/wrappers.py
+++ b/nipype/interfaces/utility/wrappers.py
@@ -22,7 +22,7 @@ from ..io import IOBase, add_traits
 from ...utils.filemanip import ensure_list
 from ...utils.functions import getsource, create_function_from_source
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class FunctionInputSpec(DynamicTraitedSpec, BaseInterfaceInputSpec):

--- a/nipype/interfaces/vtkbase.py
+++ b/nipype/interfaces/vtkbase.py
@@ -12,7 +12,7 @@ from __future__ import (print_function, division, unicode_literals,
 import os
 from .. import logging
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 # Check that VTK can be imported and get version
 _vtk_version = None

--- a/nipype/interfaces/workbench/base.py
+++ b/nipype/interfaces/workbench/base.py
@@ -19,7 +19,7 @@ from ... import logging
 from ...utils.filemanip import split_filename
 from ..base import CommandLine, PackageInfo
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class Info(PackageInfo):

--- a/nipype/interfaces/workbench/metric.py
+++ b/nipype/interfaces/workbench/metric.py
@@ -10,7 +10,7 @@ from ..base import (TraitedSpec, File, traits, CommandLineInputSpec)
 from .base import WBCommand
 from ... import logging
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class MetricResampleInputSpec(CommandLineInputSpec):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -41,7 +41,7 @@ from .base import EngineBase
 
 standard_library.install_aliases()
 
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 class Node(EngineBase):

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -52,7 +52,7 @@ except ImportError:
     from funcsigs import signature
 
 standard_library.install_aliases()
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 PY3 = sys.version_info[0] > 2
 
 try:

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -39,7 +39,7 @@ from .nodes import MapNode
 from future import standard_library
 standard_library.install_aliases()
 
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 class Workflow(EngineBase):

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -25,7 +25,7 @@ from ..engine.utils import (nx, dfs_preorder, topological_sort)
 from ..engine import MapNode
 from .tools import report_crash, report_nodes_not_run, create_pyscript
 
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 class PluginBase(object):

--- a/nipype/pipeline/plugins/condor.py
+++ b/nipype/pipeline/plugins/condor.py
@@ -10,7 +10,7 @@ from time import sleep
 from ...interfaces.base import CommandLine
 from ... import logging
 from .base import SGELikeBatchManagerBase, logger
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class CondorPlugin(SGELikeBatchManagerBase):

--- a/nipype/pipeline/plugins/lsf.py
+++ b/nipype/pipeline/plugins/lsf.py
@@ -11,7 +11,7 @@ from time import sleep
 from ... import logging
 from ...interfaces.base import CommandLine
 from .base import SGELikeBatchManagerBase, logger
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class LSFPlugin(SGELikeBatchManagerBase):

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -37,7 +37,7 @@ except ImportError:
 
 
 # Init logger
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 # Run node

--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -14,7 +14,7 @@ import simplejson as json
 from ... import logging
 from ...interfaces.base import CommandLine
 from .base import SGELikeBatchManagerBase, logger
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class OARPlugin(SGELikeBatchManagerBase):

--- a/nipype/pipeline/plugins/pbs.py
+++ b/nipype/pipeline/plugins/pbs.py
@@ -12,7 +12,7 @@ from ... import logging
 from ...interfaces.base import CommandLine
 from .base import SGELikeBatchManagerBase, logger
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class PBSPlugin(SGELikeBatchManagerBase):

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -19,7 +19,7 @@ import random
 from ... import logging
 from ...interfaces.base import CommandLine
 from .base import SGELikeBatchManagerBase, logger
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 DEBUGGING_PREFIX = str(int(random.uniform(100, 999)))
 
 

--- a/nipype/pipeline/plugins/slurm.py
+++ b/nipype/pipeline/plugins/slurm.py
@@ -17,7 +17,7 @@ from ... import logging
 from ...interfaces.base import CommandLine
 from .base import SGELikeBatchManagerBase, logger
 
-iflogger = logging.getLogger('interface')
+iflogger = logging.getLogger('nipype.interface')
 
 
 class SLURMPlugin(SGELikeBatchManagerBase):

--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -18,7 +18,7 @@ from traceback import format_exception
 from ... import logging
 from ...utils.filemanip import savepkl, crash2txt, makedirs
 
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 def report_crash(node, traceback=None, hostname=None):

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -353,7 +353,7 @@ class NipypeConfig(object):
         if self._display is not None:
             from .. import logging
             self._display.stop()
-            logging.getLogger('interface').debug(
+            logging.getLogger('nipype.interface').debug(
                 'Closing display (if virtual)')
 
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -30,7 +30,7 @@ from .misc import is_container
 from future import standard_library
 standard_library.install_aliases()
 
-fmlogger = logging.getLogger('utils')
+fmlogger = logging.getLogger('nipype.utils')
 
 related_filetype_sets = [
     ('.hdr', '.img', '.mat'),

--- a/nipype/utils/logger.py
+++ b/nipype/utils/logger.py
@@ -30,9 +30,15 @@ class Logging(object):
 
     def __init__(self, config):
         self._config = config
-        logging.basicConfig(
-            format=self.fmt, datefmt=self.datefmt, stream=sys.stdout)
-        # logging.basicConfig(stream=sys.stdout)
+        # scope our logger to not interfere with user
+        _nipype_logger = logging.getLogger('nipype')
+        _nipype_hdlr = logging.StreamHandler(stream=sys.stdout)
+        _nipype_hdlr.setFormatter(logging.Formatter(fmt=self.fmt,
+                                                    datefmt=self.datefmt))
+        # if StreamHandler was added, do not stack
+        if not len(_nipype_logger.handlers):
+            _nipype_logger.addHandler(_nipype_hdlr)
+
         self._logger = logging.getLogger('workflow')
         self._utlogger = logging.getLogger('utils')
         self._fmlogger = logging.getLogger('filemanip')

--- a/nipype/utils/logger.py
+++ b/nipype/utils/logger.py
@@ -39,16 +39,16 @@ class Logging(object):
         if not len(_nipype_logger.handlers):
             _nipype_logger.addHandler(_nipype_hdlr)
 
-        self._logger = logging.getLogger('workflow')
-        self._utlogger = logging.getLogger('utils')
-        self._fmlogger = logging.getLogger('filemanip')
-        self._iflogger = logging.getLogger('interface')
+        self._logger = logging.getLogger('nipype.workflow')
+        self._utlogger = logging.getLogger('nipype.utils')
+        self._fmlogger = logging.getLogger('nipype.filemanip')
+        self._iflogger = logging.getLogger('nipype.interface')
 
         self.loggers = {
-            'workflow': self._logger,
-            'utils': self._utlogger,
-            'filemanip': self._fmlogger,
-            'interface': self._iflogger
+            'nipype.workflow': self._logger,
+            'nipype.utils': self._utlogger,
+            'nipype.filemanip': self._fmlogger,
+            'nipype.interface': self._iflogger
         }
         self._hdlr = None
         self.update_logging(self._config)

--- a/nipype/utils/profiler.py
+++ b/nipype/utils/profiler.py
@@ -17,7 +17,7 @@ except ImportError as exc:
 from builtins import open, range
 from .. import config, logging
 
-proflogger = logging.getLogger('utils')
+proflogger = logging.getLogger('nipype.utils')
 resource_monitor = config.resource_monitor
 
 # Init variables
@@ -351,7 +351,7 @@ def _use_resources(n_procs, mem_gb):
     from nipype import logging
     from nipype.utils.profiler import _use_cpu
 
-    iflogger = logging.getLogger('interface')
+    iflogger = logging.getLogger('nipype.interface')
 
     # Getsize of one character string
     BSIZE = sys.getsizeof('  ') - sys.getsizeof(' ')

--- a/nipype/utils/provenance.py
+++ b/nipype/utils/provenance.py
@@ -22,7 +22,7 @@ import prov.model as pm
 from .. import get_info, logging, __version__
 from .filemanip import (md5, hashlib, hash_infile)
 
-logger = logging.getLogger('utils')
+logger = logging.getLogger('nipype.utils')
 foaf = pm.Namespace("foaf", "http://xmlns.com/foaf/0.1/")
 dcterms = pm.Namespace("dcterms", "http://purl.org/dc/terms/")
 nipype_ns = pm.Namespace("nipype", "http://nipy.org/nipype/terms/")

--- a/nipype/utils/tests/test_config.py
+++ b/nipype/utils/tests/test_config.py
@@ -253,9 +253,9 @@ def test_debug_mode():
     if_config = config.get('logging', 'interface_level')
     ut_config = config.get('logging', 'utils_level')
 
-    wf_level = logging.getLogger('workflow').level
-    if_level = logging.getLogger('interface').level
-    ut_level = logging.getLogger('utils').level
+    wf_level = logging.getLogger('nipype.workflow').level
+    if_level = logging.getLogger('nipype.interface').level
+    ut_level = logging.getLogger('nipype.utils').level
 
     config.enable_debug_mode()
 
@@ -267,9 +267,9 @@ def test_debug_mode():
     assert config.get('logging', 'interface_level') == 'DEBUG'
     assert config.get('logging', 'utils_level') == 'DEBUG'
 
-    assert logging.getLogger('workflow').level == 10
-    assert logging.getLogger('interface').level == 10
-    assert logging.getLogger('utils').level == 10
+    assert logging.getLogger('nipype.workflow').level == 10
+    assert logging.getLogger('nipype.interface').level == 10
+    assert logging.getLogger('nipype.utils').level == 10
 
     # Restore config and levels
     config.set('execution', 'stop_on_first_crash', sofc_config)
@@ -287,6 +287,6 @@ def test_debug_mode():
     assert config.get('logging', 'interface_level') == if_config
     assert config.get('logging', 'utils_level') == ut_config
 
-    assert logging.getLogger('workflow').level == wf_level
-    assert logging.getLogger('interface').level == if_level
-    assert logging.getLogger('utils').level == ut_level
+    assert logging.getLogger('nipype.workflow').level == wf_level
+    assert logging.getLogger('nipype.interface').level == if_level
+    assert logging.getLogger('nipype.utils').level == ut_level

--- a/nipype/workflows/fmri/spm/preprocess.py
+++ b/nipype/workflows/fmri/spm/preprocess.py
@@ -11,7 +11,7 @@ from ....pipeline import engine as pe
 from ...smri.freesurfer.utils import create_getmask_flow
 
 from .... import logging
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 def create_spm_preproc(name='preproc'):

--- a/nipype/workflows/smri/freesurfer/recon.py
+++ b/nipype/workflows/smri/freesurfer/recon.py
@@ -12,7 +12,7 @@ from ....interfaces.io import DataSink
 from .utils import getdefaultconfig
 from .... import logging
 
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 def create_skullstripped_recon_flow(name="skullstripped_recon_all"):


### PR DESCRIPTION
Fixes #2569  .

Changes proposed in this pull request
- remove call to `logging.basicConfig`
- scope sub-loggers (interface, workflow, etc) within `nipype` ancestor
