### PR TITLE
ENH: Add versioning metadata to crash files

### DIFF
--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -58,7 +58,8 @@ def report_crash(node, traceback=None, hostname=None):
     if crashfile.endswith('.txt'):
         crash2txt(crashfile, dict(node=node, traceback=traceback))
     else:
-        savepkl(crashfile, dict(node=node, traceback=traceback))
+        savepkl(crashfile, dict(node=node, traceback=traceback),
+                versioning=True)
     return crashfile
 
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -665,7 +665,7 @@ def loadpkl(infile, versioning=False):
     # Unpickling problems    
     except Exception as e:
         if not versioning:
-            return None
+            raise e
 
         from nipype import __version__ as version
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -723,12 +723,10 @@ def savepkl(filename, record, versioning=False):
 
     if versioning:
         from nipype import __version__ as version
-        metadata = json.dumps({'version': version},
-                              ensure_ascii=True,
-                              encoding='ascii')
+        metadata = json.dumps({'version': version})
 
-        pkl_file.write(metadata.encode('ascii'))
-        pkl_file.write('\n'.encode('ascii'))
+        pkl_file.write(metadata.encode('utf-8'))
+        pkl_file.write('\n'.encode('utf-8'))
 
     pickle.dump(record, pkl_file)
     pkl_file.close()

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -8,13 +8,15 @@ import os
 import time
 import warnings
 
+import mock
 import pytest
 from ...testing import TempFATFS
 from ...utils.filemanip import (
     save_json, load_json, fname_presuffix, fnames_presuffix, hash_rename,
     check_forhash, _parse_mount_table, _cifs_table, on_cifs, copyfile,
     copyfiles, ensure_list, simplify_list, check_depends,
-    split_filename, get_related_files, indirectory)
+    split_filename, get_related_files, indirectory,
+    loadpkl, loadcrash, savepkl)
 
 
 def _ignore_atime(stat):
@@ -521,3 +523,50 @@ def test_indirectory(tmpdir):
     except ValueError:
         pass
     assert os.getcwd() == tmpdir.strpath
+
+
+def test_pklization(tmpdir):
+    tmpdir.chdir()
+
+    exc = Exception("There is something wrong here")
+    savepkl('./except.pkz', exc)
+    newexc = loadpkl('./except.pkz')
+
+    assert exc.args == newexc.args
+    assert os.getcwd() == tmpdir.strpath
+
+
+class Pickled:
+
+    def __getstate__(self):
+        return self.__dict__
+
+
+class PickledBreaker:
+
+    def __setstate__(self, d):
+        raise Exception()
+
+        
+def test_versioned_pklization(tmpdir):
+    tmpdir.chdir()
+
+    obj = Pickled()
+    savepkl('./pickled.pkz', obj, versioning=True)
+
+    with pytest.raises(Exception):
+        with mock.patch('nipype.utils.tests.test_filemanip.Pickled', PickledBreaker), \
+             mock.patch('nipype.__version__', '0.0.0'):
+
+            loadpkl('./pickled.pkz', versioning=True)
+
+        
+def test_unversioned_pklization(tmpdir):
+    tmpdir.chdir()
+
+    obj = Pickled()
+    savepkl('./pickled.pkz', obj)
+
+    with pytest.raises(Exception):
+        with mock.patch('nipype.utils.tests.test_filemanip.Pickled', PickledBreaker):
+            loadpkl('./pickled.pkz', versioning=True)


### PR DESCRIPTION
Fixes #2625.

Changes proposed in this pull request
- Add a JSON header as metadata for the crash files, containing the original nipype version.
- When opening a crash file with the cli utility, it can check for the nipype version and warn the user about problems that different versions of nipype may generate when using the utility.
- It shows the version from the header.
- It works seamlessly with old versions.
