### PR TITLE
FIX: LegacyMultiProc workflow logger

### DIFF
--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -37,7 +37,7 @@ except ImportError:
 
 
 # Init logger
-logger = logging.getLogger('workflow')
+logger = logging.getLogger('nipype.workflow')
 
 
 # Run node


### PR DESCRIPTION
#2598 did not incorporate #2611's move to hierarchical loggers.

This is likely to be a breaking change for a lot of downstream users, so we should make a particular note of it in the release notes.