### PR TITLE
[ENH] Minor improvements to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-Pull-request guidelines (Remove this section after reading):
+<!--
+
+Pull-request guidelines
+-----------------------
 
 1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
 2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
@@ -6,10 +9,16 @@ Pull-request guidelines (Remove this section after reading):
 4. The person who accepts/merges your PR will include an update to the CHANGES file: prefix: description (URL of pull request)
 5. Run `make check-before-commit` before submitting the PR.
 
------ REMOVE TILL HERE -----
+-->
+## Summary
+<!-- Please reference any related issue and use fixes/close to automatically
+close them, if pertinent -->
 
 Fixes # .
 
-Changes proposed in this pull request
--
--
+## List of changes proposed in this PR (pull-request)
+<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
+
+## Acknowledgment
+
+- [ ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,7 @@ Pull-request guidelines
 1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
 2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
 3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
-4. The person who accepts/merges your PR will include an update to the CHANGES file: prefix: description (URL of pull request)
-5. Run `make check-before-commit` before submitting the PR.
+4. Run `make check-before-commit` before submitting the PR.
 
 -->
 ## Summary


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. The person who accepts/merges your PR will include an update to the CHANGES file: prefix: description (URL of pull request)
5. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
After our experience with https://github.com/poldracklab/fmriprep/blob/master/docs/pull_request_template.md, I apply here @effigies' suggestion of using HTML comments, and add a checkbox for the license.

Please, have a look into FMRIPREP's template to decide whether we want to import any more ideas into nipype.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- [x] Use HTML comments in the PR template to avoid asking contributors to remove text.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.