### PR TITLE
FIX: Un-set incorrect default options in TOPUP

### DIFF
--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -201,13 +201,12 @@ class TOPUPInputSpec(FSLCommandInputSpec):
     warp_res = traits.Float(
         argstr='--warpres=%f',
         desc=('(approximate) resolution (in mm) of warp '
-              'basis for the different sub-sampling levels'
-              '(default in FSL 10).'))
+              'basis for the different sub-sampling levels'))
     subsamp = traits.Int(argstr='--subsamp=%d',
-                         desc='sub-sampling scheme (default in FSL 1)')
+                         desc='sub-sampling scheme')
     fwhm = traits.Float(
         argstr='--fwhm=%f',
-        desc='FWHM (in mm) of gaussian smoothing kernel (default in FSL 8)')
+        desc='FWHM (in mm) of gaussian smoothing kernel')
     config = traits.String(
         'b02b0.cnf',
         argstr='--config=%s',
@@ -216,7 +215,7 @@ class TOPUPInputSpec(FSLCommandInputSpec):
               'arguments'))
     max_iter = traits.Int(
         argstr='--miter=%d',
-        desc='max # of non-linear iterations (default in FSL 5)')
+        desc='max # of non-linear iterations')
     reg_lambda = traits.Float(
         argstr='--lambda=%0.f',
         desc=('Weight of regularisation, default '
@@ -257,7 +256,7 @@ class TOPUPInputSpec(FSLCommandInputSpec):
     splineorder = traits.Int(
         argstr='--splineorder=%d',
         desc=('order of spline, 2->Qadratic spline, '
-              '3->Cubic spline (default in FSL 3)'))
+              '3->Cubic spline'))
     numprec = traits.Enum(
         'double',
         'float',

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -199,18 +199,15 @@ class TOPUPInputSpec(FSLCommandInputSpec):
     # TODO: the following traits admit values separated by commas, one value
     # per registration level inside topup.
     warp_res = traits.Float(
-        10.0, usedefault=True,
         argstr='--warpres=%f',
         desc=('(approximate) resolution (in mm) of warp '
               'basis for the different sub-sampling levels'
-              '.'))
-    subsamp = traits.Int(1, usedefault=True,
-                         argstr='--subsamp=%d', desc='sub-sampling scheme')
+              '(default in FSL 10).'))
+    subsamp = traits.Int(argstr='--subsamp=%d',
+                         desc='sub-sampling scheme (default in FSL 1)')
     fwhm = traits.Float(
-        8.0,
-        usedefault=True,
         argstr='--fwhm=%f',
-        desc='FWHM (in mm) of gaussian smoothing kernel')
+        desc='FWHM (in mm) of gaussian smoothing kernel (default in FSL 8)')
     config = traits.String(
         'b02b0.cnf',
         argstr='--config=%s',
@@ -218,8 +215,8 @@ class TOPUPInputSpec(FSLCommandInputSpec):
         desc=('Name of config file specifying command line '
               'arguments'))
     max_iter = traits.Int(
-        5, usedefault=True,
-        argstr='--miter=%d', desc='max # of non-linear iterations')
+        argstr='--miter=%d',
+        desc='max # of non-linear iterations (default in FSL 5)')
     reg_lambda = traits.Float(
         argstr='--lambda=%0.f',
         desc=('Weight of regularisation, default '
@@ -258,10 +255,9 @@ class TOPUPInputSpec(FSLCommandInputSpec):
         desc=('Minimisation method 0=Levenberg-Marquardt, '
               '1=Scaled Conjugate Gradient'))
     splineorder = traits.Int(
-        3, usedefault=True,
         argstr='--splineorder=%d',
         desc=('order of spline, 2->Qadratic spline, '
-              '3->Cubic spline'))
+              '3->Cubic spline (default in FSL 3)'))
     numprec = traits.Enum(
         'double',
         'float',
@@ -320,10 +316,9 @@ class TOPUP(FSLCommand):
     >>> topup.inputs.output_type = "NIFTI_GZ"
     >>> topup.cmdline # doctest: +ELLIPSIS
     'topup --config=b02b0.cnf --datain=topup_encoding.txt \
---fwhm=8.000000 --imain=b0_b0rev.nii --miter=5 \
---out=b0_b0rev_base --iout=b0_b0rev_corrected.nii.gz \
+--imain=b0_b0rev.nii --out=b0_b0rev_base --iout=b0_b0rev_corrected.nii.gz \
 --fout=b0_b0rev_field.nii.gz --jacout=jac --logout=b0_b0rev_topup.log \
---rbmout=xfm --dfout=warpfield --splineorder=3 --subsamp=1 --warpres=10.000000'
+--rbmout=xfm --dfout=warpfield'
     >>> res = topup.run() # doctest: +SKIP
 
     """

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -221,10 +221,9 @@ class TOPUPInputSpec(FSLCommandInputSpec):
         5, usedefault=True,
         argstr='--miter=%d', desc='max # of non-linear iterations')
     reg_lambda = traits.Float(
-        1.0, usedefault=True,
-        argstr='--miter=%0.f',
-        desc=('lambda weighting value of the '
-              'regularisation term'))
+        argstr='--lambda=%0.f',
+        desc=('Weight of regularisation, default '
+              'depending on --ssqlambda and --regmod switches.'))
     ssqlambda = traits.Enum(
         1,
         0,
@@ -324,8 +323,7 @@ class TOPUP(FSLCommand):
 --fwhm=8.000000 --imain=b0_b0rev.nii --miter=5 \
 --out=b0_b0rev_base --iout=b0_b0rev_corrected.nii.gz \
 --fout=b0_b0rev_field.nii.gz --jacout=jac --logout=b0_b0rev_topup.log \
---rbmout=xfm --dfout=warpfield --miter=1 --splineorder=3 --subsamp=1 \
---warpres=10.000000'
+--rbmout=xfm --dfout=warpfield --splineorder=3 --subsamp=1 --warpres=10.000000'
     >>> res = topup.run() # doctest: +SKIP
 
     """

--- a/nipype/interfaces/fsl/tests/test_auto_TOPUP.py
+++ b/nipype/interfaces/fsl/tests/test_auto_TOPUP.py
@@ -26,19 +26,13 @@ def test_TOPUP_inputs():
             usedefault=True,
         ),
         estmov=dict(argstr='--estmov=%d', ),
-        fwhm=dict(
-            argstr='--fwhm=%f',
-            usedefault=True,
-        ),
+        fwhm=dict(argstr='--fwhm=%f', ),
         in_file=dict(
             argstr='--imain=%s',
             mandatory=True,
         ),
         interp=dict(argstr='--interp=%s', ),
-        max_iter=dict(
-            argstr='--miter=%d',
-            usedefault=True,
-        ),
+        max_iter=dict(argstr='--miter=%d', ),
         minmet=dict(argstr='--minmet=%d', ),
         numprec=dict(argstr='--numprec=%s', ),
         out_base=dict(
@@ -91,19 +85,10 @@ def test_TOPUP_inputs():
         regmod=dict(argstr='--regmod=%s', ),
         regrid=dict(argstr='--regrid=%d', ),
         scale=dict(argstr='--scale=%d', ),
-        splineorder=dict(
-            argstr='--splineorder=%d',
-            usedefault=True,
-        ),
+        splineorder=dict(argstr='--splineorder=%d', ),
         ssqlambda=dict(argstr='--ssqlambda=%d', ),
-        subsamp=dict(
-            argstr='--subsamp=%d',
-            usedefault=True,
-        ),
-        warp_res=dict(
-            argstr='--warpres=%f',
-            usedefault=True,
-        ),
+        subsamp=dict(argstr='--subsamp=%d', ),
+        warp_res=dict(argstr='--warpres=%f', ),
     )
     inputs = TOPUP.input_spec()
 

--- a/nipype/interfaces/fsl/tests/test_auto_TOPUP.py
+++ b/nipype/interfaces/fsl/tests/test_auto_TOPUP.py
@@ -87,10 +87,7 @@ def test_TOPUP_inputs():
             requires=['encoding_direction'],
             xor=['encoding_file'],
         ),
-        reg_lambda=dict(
-            argstr='--miter=%0.f',
-            usedefault=True,
-        ),
+        reg_lambda=dict(argstr='--lambda=%0.f', ),
         regmod=dict(argstr='--regmod=%s', ),
         regrid=dict(argstr='--regrid=%d', ),
         scale=dict(argstr='--scale=%d', ),


### PR DESCRIPTION
This is follow-up to the #2533. I started from `topup`, issues were reported by @atsuch  in the comments to the PR.

- I removed the default values and `usedefault=True` and introduced default value in the description (it's probably better to let FSL set these values)
- fixing reg_labda input

If this is ok, I should probably add similar changes to other FSL interfaces changed in #2533 