### PR TITLE
changing Node._output_dir to realpath

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -275,7 +275,7 @@ class Node(EngineBase):
                 params_str = [_parameterization_dir(p) for p in params_str]
             outputdir = op.join(outputdir, *params_str)
 
-        self._output_dir = op.abspath(op.join(outputdir, self.name))
+        self._output_dir = op.realpath(op.join(outputdir, self.name))
         return self._output_dir
 
     def set_input(self, parameter, val):


### PR DESCRIPTION
I changed `abspath` to `realpath` in `Node._output_dir` to fix problems with temporary directories on OSX. `abspath` gives `/var/...` and `realpath` returns `/private/var...`.  In [`clean_working_directory`](https://github.com/nipy/nipype/blob/master/nipype/pipeline/engine/utils.py#L1385) we had `needed_files` that used `/private/var/...` and `cwd` used `/var/...`, so many files were removed.

I'm not sure if this is the best place to change the path, I can do it also in `clean_working_directory`, if for any reason we should keep `abspath` in `_output_dir`.

There is a chance that this will solve the general issue from #2395. For now it fixed all tests from `heudiconv`, so should also solve [this issue](https://github.com/nipy/heudiconv/issues/231)