### PR TITLE
ENH: Allow transform to be saved from AFNI 3dWarp

### DIFF
--- a/nipype/interfaces/afni/tests/test_auto_Warp.py
+++ b/nipype/interfaces/afni/tests/test_auto_Warp.py
@@ -34,7 +34,7 @@ def test_Warp_inputs():
             name_template='%s_warp',
         ),
         outputtype=dict(),
-        save_warp=dict(usedefault=True, ),
+        save_warp=dict(requires=['verbose'], ),
         tta2mni=dict(argstr='-tta2mni', ),
         verbose=dict(argstr='-verb', ),
         zpad=dict(argstr='-zpad %d', ),

--- a/nipype/interfaces/afni/tests/test_auto_Warp.py
+++ b/nipype/interfaces/afni/tests/test_auto_Warp.py
@@ -29,10 +29,12 @@ def test_Warp_inputs():
         oblique_parent=dict(argstr='-oblique_parent %s', ),
         out_file=dict(
             argstr='-prefix %s',
+            keep_extension=True,
             name_source='in_file',
             name_template='%s_warp',
         ),
         outputtype=dict(),
+        save_warp=dict(usedefault=True, ),
         tta2mni=dict(argstr='-tta2mni', ),
         verbose=dict(argstr='-verb', ),
         zpad=dict(argstr='-zpad %d', ),
@@ -43,7 +45,10 @@ def test_Warp_inputs():
         for metakey, value in list(metadata.items()):
             assert getattr(inputs.traits()[key], metakey) == value
 def test_Warp_outputs():
-    output_map = dict(out_file=dict(), )
+    output_map = dict(
+        out_file=dict(),
+        warp_file=dict(),
+    )
     outputs = Warp.output_spec()
 
     for key, metadata in list(output_map.items()):


### PR DESCRIPTION
I added an option to save the warp from the stdout because it can be useful. But the warp transform is printed only if  `verbose` is set to True, otherwise the saved file is empty. I don't know if there is something like the `xor` and `requires` that checks if a required trait is set to True.