### PR TITLE
DOC: update neurodocker tutorial for neurodocker version 0.4.0

### DIFF
--- a/doc/links_names.txt
+++ b/doc/links_names.txt
@@ -105,8 +105,8 @@
 .. _mingw: http://www.mingw.org
 .. _macports: http://www.macports.org/
 .. _Vagrant: http://www.vagrantup.com/
-.. _Docker: http://www.docker.io/
-.. _Singularity: http://singularity.lbl.gov/
+.. _Docker: http://www.docker.com/
+.. _Singularity: https://www.sylabs.io/singularity/
 .. _Virtualbox: https://www.virtualbox.org/
 
 .. Functional imaging labs

--- a/doc/users/neurodocker.rst
+++ b/doc/users/neurodocker.rst
@@ -20,7 +20,9 @@ Usage
 
 To view the Neurodocker help message
 ::
-    docker run --rm kaczmarj/neurodocker:0.4.0 generate --help
+    docker run --rm kaczmarj/neurodocker:0.4.0 generate [docker|singularity] --help
+
+Note: choose between ``docker`` and ``singularity`` in ``[docker|singularity]``.
 
 1. Users must specify a base Docker image and the package manager. Any Docker
    image on DockerHub can be used as your base image. Common base images
@@ -44,20 +46,11 @@ To view the Neurodocker help message
 Create a Dockerfile or Singularity recipe with FSL, Python 3.6, and Nipype
 --------------------------------------------------------------------------
 
-This command prints a Dockerfile (the specification for a Docker image) to the
+This command prints a Dockerfile (the specification for a Docker image) or a
+Singularity recipe (the specification for a Singularity container) to the
 terminal.
 ::
-  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate docker \
-    --base debian:stretch --pkg-manager apt \
-    --fsl version=5.0.10 \
-    --miniconda create_env=neuro \
-                conda_install="python=3.6 traits" \
-                pip_install="nipype"
-
-This command prints a Singularity recipe (the specification for a Singularity
-container) to the terminal.
-::
-  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate singularity \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate [docker|singularity] \
     --base debian:stretch --pkg-manager apt \
     --fsl version=5.0.10 \
     --miniconda create_env=neuro \
@@ -92,7 +85,7 @@ The Singularity recipe can be saved and used to build the Singularity container
     --miniconda create_env=neuro \
                 conda_install="python=3.6 traits" \
                 pip_install="nipype" > Singularity
-  $ singularity build Singularity my_nipype.sqsh
+  $ singularity build my_nipype.simg Singularity
 
 
 Use NeuroDebian
@@ -120,7 +113,7 @@ running the container.
 ::
   $ docker run --rm kaczmarj/neurodocker:0.4.0 generate docker \
     --base centos:7 --pkg-manager yum \
-    --dcm2niix version=master \
+    --dcm2niix version=master method=source \
     --user neuro \
     --miniconda create_env=neuro conda_install="jupyter traits nipype" \
     > Dockerfile
@@ -129,8 +122,10 @@ running the container.
 
 Copy local files into a container.
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate [docker|singularity] \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate [docker|singularity] \
     --base ubuntu:16.04 --pkg-manager apt \
     --copy relative/path/to/source.txt /absolute/path/to/destination.txt
+
+See the `Neurodocker examples page <https://github.com/kaczmarj/neurodocker/tree/master/examples/>`_ for more.
 
 .. include:: ../links_names.txt

--- a/doc/users/neurodocker.rst
+++ b/doc/users/neurodocker.rst
@@ -7,13 +7,11 @@ Neurodocker tutorial
 This page covers the steps to create containers with Neurodocker_.
 
 Neurodocker_ is a command-line program that enables users to generate Docker_
-containers that include neuroimaging software. These containers can be
-converted to Singularity_ containers for use in high-performance computing
-centers.
+containers and Singularity_ images that include neuroimaging software.
 
 Requirements:
 
-* Docker_
+* Docker_ or Singularity_
 * Internet connection
 
 
@@ -22,7 +20,7 @@ Usage
 
 To view the Neurodocker help message
 ::
-    docker run --rm kaczmarj/neurodocker:v0.3.2 generate --help
+    docker run --rm kaczmarj/neurodocker:0.4.0 generate --help
 
 1. Users must specify a base Docker image and the package manager. Any Docker
    image on DockerHub can be used as your base image. Common base images
@@ -37,20 +35,32 @@ To view the Neurodocker help message
    machine into the container, and other operations. The list of supported
    neuroimaging software packages is available in the ``neurodocker`` help
    message.
-3. The ``neurodocker`` command will generate a Dockerfile. This Dockerfile can
-   be used to build a Docker image with the ``docker build`` command.
+3. The ``neurodocker`` command will generate a Dockerfile or Singularity recipe.
+   The Dockerfile can be used with the ``docker build`` command to build a
+   Docker image. The Singularity recipe can be used to build a Singularity
+   container with the ``singularity build`` command.
 
 
-Create a Dockerfile with FSL, Python 3.6, and Nipype
-----------------------------------------------------
+Create a Dockerfile or Singularity recipe with FSL, Python 3.6, and Nipype
+--------------------------------------------------------------------------
 
 This command prints a Dockerfile (the specification for a Docker image) to the
 terminal.
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate docker \
     --base debian:stretch --pkg-manager apt \
     --fsl version=5.0.10 \
-    --miniconda env_name=neuro \
+    --miniconda create_env=neuro \
+                conda_install="python=3.6 traits" \
+                pip_install="nipype"
+
+This command prints a Singularity recipe (the specification for a Singularity
+container) to the terminal.
+::
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate singularity \
+    --base debian:stretch --pkg-manager apt \
+    --fsl version=5.0.10 \
+    --miniconda create_env=neuro \
                 conda_install="python=3.6 traits" \
                 pip_install="nipype"
 
@@ -60,15 +70,29 @@ Build the Docker image
 
 The Dockerfile can be saved and used to build the Docker image
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate docker \
     --base debian:stretch --pkg-manager apt \
     --fsl version=5.0.10 \
-    --miniconda env_name=neuro \
+    --miniconda create_env=neuro \
                 conda_install="python=3.6 traits" \
                 pip_install="nipype" > Dockerfile
   $ docker build --tag my_image .
   $ # or
   $ docker build --tag my_image - < Dockerfile
+
+
+Build the Singularity container
+-------------------------------
+
+The Singularity recipe can be saved and used to build the Singularity container
+::
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate singularity \
+    --base debian:stretch --pkg-manager apt \
+    --fsl version=5.0.10 \
+    --miniconda create_env=neuro \
+                conda_install="python=3.6 traits" \
+                pip_install="nipype" > Singularity
+  $ singularity build Singularity my_nipype.sqsh
 
 
 Use NeuroDebian
@@ -77,7 +101,7 @@ Use NeuroDebian
 This example installs AFNI and ANTs from the NeuroDebian repositories. It also
 installs ``git`` and ``vim``.
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate [docker|singularity] \
     --base neurodebian:stretch --pkg-manager apt \
     --install afni ants git vim
 
@@ -94,18 +118,18 @@ Create a container with ``dcm2niix``, Nipype, and jupyter notebook. Install
 Miniconda as a non-root user, and activate the Miniconda environment upon
 running the container.
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+  $ docker run --rm kaczmarj/neurodocker:0.4.0 generate docker \
     --base centos:7 --pkg-manager yum \
     --dcm2niix version=master \
     --user neuro \
-    --miniconda env_name=neuro conda_install="jupyter traits nipype" \
+    --miniconda create_env=neuro conda_install="jupyter traits nipype" \
     > Dockerfile
   $ docker build --tag my_nipype - < Dockerfile
 
 
 Copy local files into a container.
 ::
-  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate \
+  $ docker run --rm kaczmarj/neurodocker:v0.3.2 generate [docker|singularity] \
     --base ubuntu:16.04 --pkg-manager apt \
     --copy relative/path/to/source.txt /absolute/path/to/destination.txt
 


### PR DESCRIPTION
## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- update [neurodocker tutorial](https://nipype.readthedocs.io/en/latest/users/neurodocker.html)
- update links to docker and singularity websites. The departing singularity website displays the message
  > This website is going away soon! Update your bookmarks! Documentation is now hosted at https://www.sylabs.io/docs.
  - docker.io redirects to docker.com, so i changed the link to docker.com.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
