### PR TITLE
MAINT: Make pytest-xdist a dependency

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -143,6 +143,7 @@ REQUIRES = [
     'click>=%s' % CLICK_MIN_VERSION,
     'funcsigs',
     'pytest>=%s' % PYTEST_MIN_VERSION,
+    'pytest-xdist',
     'mock',
     'pydotplus',
     'pydot>=%s' % PYDOT_MIN_VERSION,
@@ -153,7 +154,7 @@ REQUIRES = [
 if sys.version_info <= (3, 4):
     REQUIRES.append('configparser')
 
-TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-xdist', 'pytest-env']
+TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-env']
 
 EXTRA_REQUIRES = {
     'doc': ['Sphinx>=1.4', 'numpydoc', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],


### PR DESCRIPTION
Since we have `pytest` in `REQUIRES` I added also `pytest-xdist`, since this is now required to run `nipype.test()` (motivated by #2645)