### PR TITLE
FIX: Various BIDSDataGrabber fixes

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2828,7 +2828,8 @@ class BIDSDataGrabber(IOBase):
         return runtime
 
     def _list_outputs(self):
-        layout = gb.BIDSLayout(self.inputs.base_dir)
+        layout = gb.BIDSLayout(self.inputs.base_dir,
+                               exclude=['derivatives/', 'code/', 'sourcedata/'])
 
         # If infield is not given nm input value, silently ignore
         filters = {}

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2804,8 +2804,8 @@ class BIDSDataGrabber(IOBase):
 
         if not isdefined(self.inputs.output_query):
             self.inputs.output_query = {
-                "func": {"modality": "func", extensions=['nii', '.nii.gz']},
-                "anat": {"modality": "anat", extensions=['nii', '.nii.gz']},
+                "func": {"modality": "func", 'extensions': ['nii', '.nii.gz']},
+                "anat": {"modality": "anat", 'extensions': ['nii', '.nii.gz']},
                 }
 
         # If infields is empty, use all BIDS entities

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2803,8 +2803,10 @@ class BIDSDataGrabber(IOBase):
         super(BIDSDataGrabber, self).__init__(**kwargs)
 
         if not isdefined(self.inputs.output_query):
-            self.inputs.output_query = {"func": {"modality": "func"},
-                                        "anat": {"modality": "anat"}}
+            self.inputs.output_query = {
+                "func": {"modality": "func", extensions=['nii', '.nii.gz']},
+                "anat": {"modality": "anat", extensions=['nii', '.nii.gz']},
+                }
 
         # If infields is empty, use all BIDS entities
         if infields is None and have_pybids:

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2755,6 +2755,8 @@ class BIDSDataGrabberInputSpec(DynamicTraitedSpec):
                                  desc='Generate exception if list is empty '
                                  'for a given field')
     return_type = traits.Enum('file', 'namedtuple', usedefault=True)
+    strict = traits.Bool(desc='Return only BIDS "proper" files (e.g., '
+                              'ignore derivatives/, sourcedata/, etc.)')
 
 
 class BIDSDataGrabber(IOBase):
@@ -2828,8 +2830,10 @@ class BIDSDataGrabber(IOBase):
         return runtime
 
     def _list_outputs(self):
-        layout = gb.BIDSLayout(self.inputs.base_dir,
-                               exclude=['derivatives/', 'code/', 'sourcedata/'])
+        exclude = None
+        if self.inputs.strict:
+            exclude = ['derivatives/', 'code/', 'sourcedata/']
+        layout = gb.BIDSLayout(self.inputs.base_dir, exclude=exclude)
 
         # If infield is not given nm input value, silently ignore
         filters = {}

--- a/nipype/interfaces/tests/test_io.py
+++ b/nipype/interfaces/tests/test_io.py
@@ -592,9 +592,9 @@ def test_bids_grabber(tmpdir):
     bg.inputs.base_dir = os.path.join(datadir, 'ds005')
     bg.inputs.subject = '01'
     results = bg.run()
-    assert os.path.basename(results.outputs.anat[0]) == 'sub-01_T1w.nii.gz'
-    assert os.path.basename(results.outputs.func[0]) == (
-        'sub-01_task-mixedgamblestask_run-01_bold.nii.gz')
+    assert 'sub-01_T1w.nii.gz' in map(os.path.basename, results.outputs.anat)
+    assert 'sub-01_task-mixedgamblestask_run-01_bold.nii.gz' in \
+        map(os.path.basename, results.outputs.func)
 
 
 @pytest.mark.skipif(not have_pybids,
@@ -610,7 +610,7 @@ def test_bids_fields(tmpdir):
     bg.inputs.subject = '01'
     bg.inputs.output_query['dwi'] = dict(modality='dwi')
     results = bg.run()
-    assert os.path.basename(results.outputs.dwi[0]) == 'sub-01_dwi.nii.gz'
+    assert 'sub-01_dwi.nii.gz' in map(os.path.basename, results.outputs.dwi)
 
 
 @pytest.mark.skipif(not have_pybids,


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

In future pybids versions, derivatives will not be automatically indexed, and test data has been added to help ensure that derivatives are properly handled.

This is a potentially breaking change, so we should consider if we would prefer some other approach.

Fixes #2650.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Add `strict` input to `BIDSDataGrabber` that currently excludes `derivatives/`, `code/` and `sourcedata/` subdirectories from indexing.
* Only return images by default, per documentation.
* Make test more resilient by checking whether expected file is present, not first.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
