### PR TITLE
FIX: replace the MRtrix3 command fs_parc_replace_sgm_first to labelsgmfix

### DIFF
--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -249,12 +249,12 @@ class ReplaceFSwithFIRST(CommandLine):
     >>> prep.inputs.in_t1w = 'T1.nii.gz'
     >>> prep.inputs.in_config = 'mrtrix3_labelconfig.txt'
     >>> prep.cmdline                               # doctest: +ELLIPSIS
-    'fs_parc_replace_sgm_first aparc+aseg.nii T1.nii.gz \
+    'labelsgmfix aparc+aseg.nii T1.nii.gz \
 mrtrix3_labelconfig.txt aparc+first.mif'
     >>> prep.run()                                 # doctest: +SKIP
     """
 
-    _cmd = 'fs_parc_replace_sgm_first'
+    _cmd = 'labelsgmfix'
     input_spec = ReplaceFSwithFIRSTInputSpec
     output_spec = ReplaceFSwithFIRSTOutputSpec
 


### PR DESCRIPTION
The MRtrix3 has renamed the fs_parc_replace_sgm_first to labelsgmfix

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
