### PR TITLE
FIX: Copy FSCommand.version to ReconAll.version

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -1326,6 +1326,12 @@ class ReconAll(CommandLine):
         with open(xopts_file, 'r') as fobj:
             return fobj.read()
 
+    @property
+    def version(self):
+        ver = Info.looseversion()
+        if ver > LooseVersion("0.0.0"):
+            return ver.vstring
+
 
 class BBRegisterInputSpec(FSTraitedSpec):
     subject_id = traits.Str(


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #2655. See discussion there for justification.

## List of changes proposed in this PR (pull-request)

* Copy `FSCommand.version` to `ReconAll.version`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
