### PR TITLE
CI: removing travis_retry for pip install pytest xdist 1.22.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_install:
     export FSLOUTPUTTYPE=NIFTI_GZ;
   fi;
 
-- travis_retry pip install --upgrade pytest>=3.4  # Work around pip failure
 - travis_retry pip install -r requirements.txt
 - travis_retry pip install grabbit==0.1.2
 - travis_retry git clone https://github.com/INCF/pybids.git ${HOME}/pybids &&


### PR DESCRIPTION
reverse #2659 
It looks like the new release of `xdist` resolve the dependencies better and `travis retry` not needed.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
