### PR TITLE
FIX: Node __repr__ and detailed graph expansion

### DIFF
--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -36,7 +36,7 @@ class EngineBase(object):
 
         """
         self._hierarchy = None
-        self._name = name
+        self.name = name
         self._id = self.name # for compatibility with node expansion using iterables
 
         self.base_dir = base_dir

--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -41,6 +41,7 @@ class EngineBase(object):
         self.base_dir = base_dir
         self.config = deepcopy(config._sections)
         self.name = name
+        self._id = self.name # for compatibility with node expansion using iterables
 
     @property
     def name(self):
@@ -65,6 +66,14 @@ class EngineBase(object):
     @property
     def outputs(self):
         raise NotImplementedError
+
+    @property
+    def itername(self):
+        """Name for expanded iterable"""
+        itername = self._id
+        if self._hierarchy:
+            itername = '%s.%s' % (self._hierarchy, self._id)
+        return itername
 
     def clone(self, name):
         """Clone an EngineBase object

--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -95,6 +95,9 @@ class EngineBase(object):
     def __str__(self):
         return self.fullname
 
+    def __repr__(self):
+        return self.itername
+
     def save(self, filename=None):
         if filename is None:
             filename = 'temp.pklz'

--- a/nipype/pipeline/engine/base.py
+++ b/nipype/pipeline/engine/base.py
@@ -36,12 +36,11 @@ class EngineBase(object):
 
         """
         self._hierarchy = None
-        self._name = None
+        self._name = name
+        self._id = self.name # for compatibility with node expansion using iterables
 
         self.base_dir = base_dir
         self.config = deepcopy(config._sections)
-        self.name = name
-        self._id = self.name # for compatibility with node expansion using iterables
 
     @property
     def name(self):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -159,7 +159,6 @@ class Node(EngineBase):
         self._got_inputs = False
         self._originputs = None
         self._output_dir = None
-        self._id = self.name  # for compatibility with node expansion using iterables
 
         self.iterables = iterables
         self.synchronize = synchronize
@@ -248,14 +247,6 @@ class Node(EngineBase):
         # Overwrite interface's dynamic input of num_threads
         if hasattr(self._interface.inputs, 'num_threads'):
             self._interface.inputs.num_threads = self._n_procs
-
-    @property
-    def itername(self):
-        """Name for expanded iterable"""
-        itername = self._id
-        if self._hierarchy:
-            itername = '%s.%s' % (self._hierarchy, self._id)
-        return itername
 
     def output_dir(self):
         """Return the location of the output directory for the node"""

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 from builtins import open
 from copy import deepcopy
 from glob import glob
-import os, pdb
+import os
 
 
 import pytest
@@ -499,12 +499,6 @@ dotfile_detailed_orig = ['digraph structs {\n',
                          'pipemod1:outoutput1:e -> pipemod2:ininput1:w;\n',
                          '}']
 
-dotfile_flat = dotfile_orig
-dotfile_detailed_flat = dotfile_detailed_orig
-
-dotfile_exec = dotfile_orig
-dotfile_detailed_exec = dotfile_detailed_orig
-
 
 dotfile_hierarchical = ['digraph pipe{\n',
                         '  label="pipe";\n',
@@ -519,6 +513,14 @@ dotfile_colored = ['digraph pipe{\n',
                    '  pipe_mod2[label="mod2 (engine)", style=filled, fillcolor="#FFFFC8"];\n',
                    '  pipe_mod1 -> pipe_mod2;\n',
                    '}']
+
+dotfiles = {
+    "orig": dotfile_orig,
+    "flat": dotfile_orig,
+    "exec": dotfile_orig,
+    "hierarchical": dotfile_hierarchical,
+    "colored": dotfile_colored
+    }
 
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("graph_type", ['orig', 'flat', 'exec', 'hierarchical', 'colored'])
@@ -537,35 +539,29 @@ def test_write_graph_dotfile(tmpdir, graph_type, simple):
         graph_str = f.read()
 
     if simple:
-        for str in eval("dotfile_{}".format(graph_type)):
-            assert str in graph_str
+        for line in dotfiles[graph_type]:
+            assert line in graph_str
     else:
         # if simple=False graph.dot uses longer names
-        for str in eval("dotfile_{}".format(graph_type)):
+        for line in dotfiles[graph_type]:
             if graph_type in ["hierarchical", "colored"]:
-                assert str.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
+                assert line.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
                     "mod2 (engine)", "mod2.EngineTestInterface.engine") in graph_str
             else:
-                assert str.replace(
+                assert line.replace(
                     "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
                     "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine") in graph_str
 
+    # graph_detailed is the same for orig, flat, exec (if no iterables)
     # graph_detailed is not created for hierachical or colored
     if graph_type not in ["hierarchical", "colored"]:
         with open("graph_detailed.dot") as f:
             graph_str = f.read()
-        for str in eval("dotfile_detailed_{}".format(graph_type)):
-            assert str in graph_str
+        for line in dotfile_detailed_orig:
+            assert line in graph_str
 
 
 # examples of dot files used in the following test
-dotfile_iter_orig = dotfile_orig
-dotfile_detailed_iter_orig = dotfile_detailed_orig
-
-dotfile_iter_flat = dotfile_orig
-dotfile_detailed_iter_flat = dotfile_detailed_orig
-
-dotfile_iter_exec = dotfile_orig
 dotfile_detailed_iter_exec = [
     'digraph structs {\n',
     'node [shape=record];\n',
@@ -593,6 +589,20 @@ dotfile_iter_colored = [
     '  pipe_mod1 -> pipe_mod2;\n',
     '}']
 
+dotfiles_iter = {
+    "orig": dotfile_orig,
+    "flat": dotfile_orig,
+    "exec": dotfile_orig,
+    "hierarchical": dotfile_iter_hierarchical,
+    "colored": dotfile_iter_colored
+    }
+
+dotfiles_detailed_iter = {
+    "orig": dotfile_detailed_orig,
+    "flat": dotfile_detailed_orig,
+    "exec": dotfile_detailed_iter_exec
+    }
+
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("graph_type", ['orig', 'flat', 'exec', 'hierarchical', 'colored'])
 def test_write_graph_dotfile_iterables(tmpdir, graph_type, simple):
@@ -611,16 +621,16 @@ def test_write_graph_dotfile_iterables(tmpdir, graph_type, simple):
         graph_str = f.read()
 
     if simple:
-        for str in eval("dotfile_iter_{}".format(graph_type)):
-            assert str in graph_str
+        for line in dotfiles_iter[graph_type]:
+            assert line in graph_str
     else:
         # if simple=False graph.dot uses longer names
-        for str in eval("dotfile_iter_{}".format(graph_type)):
+        for line in dotfiles_iter[graph_type]:
             if graph_type in ["hierarchical", "colored"]:
-                assert str.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
+                assert line.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
                     "mod2 (engine)", "mod2.EngineTestInterface.engine") in graph_str
             else:
-                assert str.replace(
+                assert line.replace(
                     "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
                     "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine") in graph_str
 
@@ -628,8 +638,8 @@ def test_write_graph_dotfile_iterables(tmpdir, graph_type, simple):
     if graph_type not in ["hierarchical", "colored"]:
         with open("graph_detailed.dot") as f:
             graph_str = f.read()
-        for str in eval("dotfile_detailed_iter_{}".format(graph_type)):
-            assert str in graph_str
+        for line in dotfiles_detailed_iter[graph_type]:
+            assert line in graph_str
 
 
 

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -486,18 +486,18 @@ def test_deep_nested_write_graph_runs(tmpdir):
 
 
 # examples of dot files used in the following test
-dotfile_orig = ('strict digraph  {\n'
-                '"mod1 (engine)";\n'
-                '"mod2 (engine)";\n'
-                '"mod1 (engine)" -> "mod2 (engine)";\n'
-                '}\n')
+dotfile_orig = ['strict digraph  {\n',
+                '"mod1 (engine)";\n',
+                '"mod2 (engine)";\n',
+                '"mod1 (engine)" -> "mod2 (engine)";\n',
+                '}\n']
 
-dotfile_detailed_orig = ('digraph structs {\n'
-                         'node [shape=record];\n'
-                         'pipemod1 [label="{IN}|{ mod1 | engine |  }|{OUT|<outoutput1> output1}"];\n'
-                         'pipemod2 [label="{IN|<ininput1> input1}|{ mod2 | engine |  }|{OUT}"];\n'
-                         'pipemod1:outoutput1:e -> pipemod2:ininput1:w;\n'
-                         '}')
+dotfile_detailed_orig = ['digraph structs {\n',
+                         'node [shape=record];\n',
+                         'pipemod1 [label="{IN}|{ mod1 | engine |  }|{OUT|<outoutput1> output1}"];\n',
+                         'pipemod2 [label="{IN|<ininput1> input1}|{ mod2 | engine |  }|{OUT}"];\n',
+                         'pipemod1:outoutput1:e -> pipemod2:ininput1:w;\n',
+                         '}']
 
 dotfile_flat = dotfile_orig
 dotfile_detailed_flat = dotfile_detailed_orig
@@ -506,19 +506,19 @@ dotfile_exec = dotfile_orig
 dotfile_detailed_exec = dotfile_detailed_orig
 
 
-dotfile_hierarchical = ('digraph pipe{\n'
-                        '  label="pipe";\n'
-                        '  pipe_mod1[label="mod1 (engine)"];\n'
-                        '  pipe_mod2[label="mod2 (engine)"];\n'
-                        '  pipe_mod1 -> pipe_mod2;\n'
-                        '}')
+dotfile_hierarchical = ['digraph pipe{\n',
+                        '  label="pipe";\n',
+                        '  pipe_mod1[label="mod1 (engine)"];\n',
+                        '  pipe_mod2[label="mod2 (engine)"];\n',
+                        '  pipe_mod1 -> pipe_mod2;\n',
+                        '}']
 
-dotfile_colored = ('digraph pipe{\n'
-                        '  label="pipe";\n'
-                        '  pipe_mod1[label="mod1 (engine)", style=filled, fillcolor="#FFFFC8"];\n'
-                        '  pipe_mod2[label="mod2 (engine)", style=filled, fillcolor="#FFFFC8"];\n'
-                        '  pipe_mod1 -> pipe_mod2;\n'
-                        '}')
+dotfile_colored = ['digraph pipe{\n',
+                   '  label="pipe";\n',
+                   '  pipe_mod1[label="mod1 (engine)", style=filled, fillcolor="#FFFFC8"];\n',
+                   '  pipe_mod2[label="mod2 (engine)", style=filled, fillcolor="#FFFFC8"];\n',
+                   '  pipe_mod1 -> pipe_mod2;\n',
+                   '}']
 
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("graph_type", ['orig', 'flat', 'exec', 'hierarchical', 'colored'])
@@ -535,24 +535,27 @@ def test_write_graph_dotfile(tmpdir, graph_type, simple):
 
     with open("graph.dot") as f:
         graph_str = f.read()
+
     if simple:
-        assert graph_str == eval("dotfile_{}".format(graph_type))
+        for str in eval("dotfile_{}".format(graph_type)):
+            assert str in graph_str
     else:
         # if simple=False graph.dot uses longer names
-        if graph_type in ["hierarchical", "colored"]:
-            assert graph_str == eval("dotfile_{}".format(graph_type)).replace(
-                "mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
-                "mod2 (engine)", "mod2.EngineTestInterface.engine")
-        else:
-            assert graph_str == eval("dotfile_{}".format(graph_type)).replace(
-                "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
-                "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine")
+        for str in eval("dotfile_{}".format(graph_type)):
+            if graph_type in ["hierarchical", "colored"]:
+                assert str.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
+                    "mod2 (engine)", "mod2.EngineTestInterface.engine") in graph_str
+            else:
+                assert str.replace(
+                    "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
+                    "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine") in graph_str
 
     # graph_detailed is not created for hierachical or colored
     if graph_type not in ["hierarchical", "colored"]:
         with open("graph_detailed.dot") as f:
-            graph_str =f.read()
-        assert graph_str == eval("dotfile_detailed_{}".format(graph_type))
+            graph_str = f.read()
+        for str in eval("dotfile_detailed_{}".format(graph_type)):
+            assert str in graph_str
 
 
 # examples of dot files used in the following test
@@ -563,32 +566,32 @@ dotfile_iter_flat = dotfile_orig
 dotfile_detailed_iter_flat = dotfile_detailed_orig
 
 dotfile_iter_exec = dotfile_orig
-dotfile_detailed_iter_exec = (
-    'digraph structs {\n'
-    'node [shape=record];\n'
-    'pipemod1aIa1 [label="{IN}|{ a1 | engine | mod1.aI }|{OUT|<outoutput1> output1}"];\n'
-    'pipemod2a1 [label="{IN|<ininput1> input1}|{ a1 | engine | mod2 }|{OUT}"];\n'
-    'pipemod1aIa0 [label="{IN}|{ a0 | engine | mod1.aI }|{OUT|<outoutput1> output1}"];\n'
-    'pipemod2a0 [label="{IN|<ininput1> input1}|{ a0 | engine | mod2 }|{OUT}"];\n'
-    'pipemod1aIa0:outoutput1:e -> pipemod2a0:ininput1:w;\n'
-    'pipemod1aIa1:outoutput1:e -> pipemod2a1:ininput1:w;\n'
-    '}')
+dotfile_detailed_iter_exec = [
+    'digraph structs {\n',
+    'node [shape=record];\n',
+    'pipemod1aIa1 [label="{IN}|{ a1 | engine | mod1.aI }|{OUT|<outoutput1> output1}"];\n',
+    'pipemod2a1 [label="{IN|<ininput1> input1}|{ a1 | engine | mod2 }|{OUT}"];\n',
+    'pipemod1aIa0 [label="{IN}|{ a0 | engine | mod1.aI }|{OUT|<outoutput1> output1}"];\n',
+    'pipemod2a0 [label="{IN|<ininput1> input1}|{ a0 | engine | mod2 }|{OUT}"];\n',
+    'pipemod1aIa0:outoutput1:e -> pipemod2a0:ininput1:w;\n',
+    'pipemod1aIa1:outoutput1:e -> pipemod2a1:ininput1:w;\n',
+    '}']
 
-dotfile_iter_hierarchical = (
-    'digraph pipe{\n'
-    '  label="pipe";\n'
-    '  pipe_mod1[label="mod1 (engine)", shape=box3d,style=filled, color=black, colorscheme=greys7 fillcolor=2];\n'
-    '  pipe_mod2[label="mod2 (engine)"];\n'
-    '  pipe_mod1 -> pipe_mod2;\n'
-    '}')
+dotfile_iter_hierarchical = [
+    'digraph pipe{\n',
+    '  label="pipe";\n',
+    '  pipe_mod1[label="mod1 (engine)", shape=box3d,style=filled, color=black, colorscheme=greys7 fillcolor=2];\n',
+    '  pipe_mod2[label="mod2 (engine)"];\n',
+    '  pipe_mod1 -> pipe_mod2;\n',
+    '}']
 
-dotfile_iter_colored = (
-    'digraph pipe{\n'
-    '  label="pipe";\n'
-    '  pipe_mod1[label="mod1 (engine)", shape=box3d,style=filled, color=black, colorscheme=greys7 fillcolor=2];\n'
-    '  pipe_mod2[label="mod2 (engine)", style=filled, fillcolor="#FFFFC8"];\n'
-    '  pipe_mod1 -> pipe_mod2;\n'
-    '}')
+dotfile_iter_colored = [
+    'digraph pipe{\n',
+    '  label="pipe";\n',
+    '  pipe_mod1[label="mod1 (engine)", shape=box3d,style=filled, color=black, colorscheme=greys7 fillcolor=2];\n',
+    '  pipe_mod2[label="mod2 (engine)", style=filled, fillcolor="#FFFFC8"];\n',
+    '  pipe_mod1 -> pipe_mod2;\n',
+    '}']
 
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("graph_type", ['orig', 'flat', 'exec', 'hierarchical', 'colored'])
@@ -606,24 +609,28 @@ def test_write_graph_dotfile_iterables(tmpdir, graph_type, simple):
 
     with open("graph.dot") as f:
         graph_str = f.read()
+
     if simple:
-        assert graph_str == eval("dotfile_iter_{}".format(graph_type))
+        for str in eval("dotfile_iter_{}".format(graph_type)):
+            assert str in graph_str
     else:
         # if simple=False graph.dot uses longer names
-        if graph_type in ["hierarchical", "colored"]:
-            assert graph_str == eval("dotfile_iter_{}".format(graph_type)).replace(
-                "mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
-                "mod2 (engine)", "mod2.EngineTestInterface.engine")
-        else:
-            assert graph_str == eval("dotfile_iter_{}".format(graph_type)).replace(
-                "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
-                "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine")
+        for str in eval("dotfile_iter_{}".format(graph_type)):
+            if graph_type in ["hierarchical", "colored"]:
+                assert str.replace("mod1 (engine)", "mod1.EngineTestInterface.engine").replace(
+                    "mod2 (engine)", "mod2.EngineTestInterface.engine") in graph_str
+            else:
+                assert str.replace(
+                    "mod1 (engine)", "pipe.mod1.EngineTestInterface.engine").replace(
+                    "mod2 (engine)", "pipe.mod2.EngineTestInterface.engine") in graph_str
 
     # graph_detailed is not created for hierachical or colored
     if graph_type not in ["hierarchical", "colored"]:
         with open("graph_detailed.dot") as f:
-            graph_str =f.read()
-        assert graph_str == eval("dotfile_detailed_iter_{}".format(graph_type))
+            graph_str = f.read()
+        for str in eval("dotfile_detailed_iter_{}".format(graph_type)):
+            assert str in graph_str
+
 
 
 def test_io_subclass():

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -507,7 +507,7 @@ def _write_detailed_dot(graph, dotfilename):
     # write nodes
     edges = []
     for n in nx.topological_sort(graph):
-        nodename = str(n.itername)
+        nodename = n.itername
         inports = []
         for u, v, d in graph.in_edges(nbunch=n, data=True):
             for cd in d['connect']:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -507,7 +507,7 @@ def _write_detailed_dot(graph, dotfilename):
     # write nodes
     edges = []
     for n in nx.topological_sort(graph):
-        nodename = str(n)
+        nodename = str(n.itername)
         inports = []
         for u, v, d in graph.in_edges(nbunch=n, data=True):
             for cd in d['connect']:
@@ -519,8 +519,8 @@ def _write_detailed_dot(graph, dotfilename):
                 ipstrip = 'in%s' % _replacefunk(inport)
                 opstrip = 'out%s' % _replacefunk(outport)
                 edges.append(
-                    '%s:%s:e -> %s:%s:w;' % (str(u).replace('.', ''), opstrip,
-                                             str(v).replace('.', ''), ipstrip))
+                    '%s:%s:e -> %s:%s:w;' % (u.itername.replace('.', ''), opstrip,
+                                             v.itername.replace('.', ''), ipstrip))
                 if inport not in inports:
                     inports.append(inport)
         inputstr = ['{IN'] + [


### PR DESCRIPTION

## Summary
fixing the detailed graph and printing `workflow.run().nodes() ` for workflows with iterables, the issue was due to the changes in the node `__str__`/`__repr__`

Fixes #2668 


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
