### PR TITLE
FIX: Prevent double-collapsing of nested lists by OutputMultiObject

### DIFF
--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -290,3 +290,18 @@ def test_inputs_removal(tmpdir):
     n1.overwrite = True
     n1.run()
     assert not tmpdir.join(n1.name, 'file1.txt').check()
+
+
+def test_outputmultipath_collapse(tmpdir):
+    """Test an OutputMultiPath whose initial value is ``[[x]]`` to ensure that
+    it is returned as ``[x]``, regardless of how accessed."""
+    select_if = niu.Select(inlist=[[1, 2, 3], [4]], index=1)
+    select_nd = pe.Node(niu.Select(inlist=[[1, 2, 3], [4]], index=1),
+                        name='select_nd')
+
+    ifres = select_if.run()
+    ndres = select_nd.run()
+
+    assert ifres.outputs.out == [4]
+    assert ndres.outputs.out == [4]
+    assert select_nd.result.outputs.out == [4]

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -237,7 +237,7 @@ def _protect_collapses(hastraits):
     raw = hastraits.trait_get()
     cloned = hastraits.clone_traits().trait_get()
 
-    for key in raw:
+    for key in cloned:
         val = raw[key]
         c = cloned[key]
         if c != val and hasattr(val, '__getitem__') and c == val[0]:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -233,12 +233,25 @@ def write_report(node, report_type=None, is_mapnode=False):
     return
 
 
+def _protect_collapses(hastraits):
+    raw = hastraits.trait_get()
+    cloned = hastraits.clone_traits().trait_get()
+
+    for key in raw:
+        val = raw[key]
+        c = cloned[key]
+        if c != val and hasattr(val, '__getitem__') and c == val[0]:
+            raw[key] = [val]
+
+    return raw
+
+
 def save_resultfile(result, cwd, name):
     """Save a result pklz file to ``cwd``"""
     resultsfile = os.path.join(cwd, 'result_%s.pklz' % name)
     if result.outputs:
         try:
-            outputs = result.outputs.trait_get()
+            outputs = _protect_collapses(result.outputs)
         except AttributeError:
             outputs = result.outputs.dictcopy()  # outputs was a bunch
         result.outputs.set(**modify_paths(outputs, relative=True, basedir=cwd))


### PR DESCRIPTION
## Summary
The saving/loading of results in `Node` causes an `OutputMultiObject` that looks like `[[x]]` to be collapsed twice into `x`, as opposed to the expected `[x]`.

This PR detects collapses by performing a `clone_traits()`, which also collapses such traits, and wraps those values in a list.

Fixes #2670.

## List of changes proposed in this PR (pull-request)

* Create a `_protect_collapses` helper function that mimics `trait_get`, but re-wraps collapsing traits in lists before returning the values.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
