### PR TITLE
MAINT: Fix wheel build to ensure futures is only required in Python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,4 @@ workflows:
               only: /rel\/.*/
             tags:
               only: /.*/
-      - pypi_precheck:
-          filters:
-            branches:
-              only: /rel\/.*/
+      - pypi_precheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,8 +342,6 @@ jobs:
             pip install twine future wheel readme_renderer
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
-      - store_artifacts: *store_artifacts_kwds
-          path: /home/circleci/nipype/dist
 
   deploy_pypi:
     machine: *machine_kwds
@@ -438,4 +436,7 @@ workflows:
               only: /rel\/.*/
             tags:
               only: /.*/
-      - pypi_precheck
+      - pypi_precheck:
+          filters:
+            branches:
+              only: /rel\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,8 @@ jobs:
             pip install twine future wheel readme_renderer
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
+      - store_artifacts: *store_artifacts_kwds
+          path: /home/circleci/nipype/dist
 
   deploy_pypi:
     machine: *machine_kwds
@@ -436,7 +438,4 @@ workflows:
               only: /rel\/.*/
             tags:
               only: /.*/
-      - pypi_precheck:
-          filters:
-            branches:
-              only: /rel\/.*/
+      - pypi_precheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
       - run:
           name: Check pypi preconditions
           command: |
-            pip install twine future wheel readme_renderer
+            pip install --upgrade twine future wheel readme_renderer setuptools
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,20 @@ jobs:
             pip install --upgrade twine future wheel readme_renderer setuptools
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
+      - run:
+          name: Validate Python 2 installation
+          command: |
+            pyenv local 2.7.12
+            pip install dist/nipype-*-py2.py3-none-any.whl
+            # Futures should install in Python 2
+            pip show futures 2>/dev/null | grep "Name: futures"
+      - run:
+          name: Validate Python 3 installation
+          command: |
+            pyenv local 3.5.2
+            pip install dist/nipype-*-py2.py3-none-any.whl
+            # Futures should not install in Python 3
+            test $(pip show futures 2>/dev/null | wc -l) = "0"
       - store_artifacts:
           path: /home/circleci/nipype/dist
 
@@ -354,7 +368,7 @@ jobs:
       - run:
           name: Deploy to PyPI
           command: |
-            pip install twine future wheel readme_renderer
+            pip install --upgrade twine future wheel readme_renderer setuptools
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
             twine upload dist/*
@@ -395,6 +409,7 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
+      - pypi_precheck
       - compare_base_dockerfiles:
           filters:
             tags:
@@ -430,6 +445,7 @@ workflows:
             tags:
               only: /.*/
           requires:
+            - pypi_precheck
             - test_pytest
       - update_feedstock:
           context: nipybot
@@ -438,4 +454,3 @@ workflows:
               only: /rel\/.*/
             tags:
               only: /.*/
-      - pypi_precheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,8 @@ jobs:
             pip install twine future wheel readme_renderer
             python setup.py check -r -s
             python setup.py sdist bdist_wheel
+      - store_artifacts:
+          path: /home/circleci/nipype/dist
 
   deploy_pypi:
     machine: *machine_kwds


### PR DESCRIPTION
## Summary

```Shell
conda create -y -n test python=3.6
source activate test
pip install nipype==1.1.1
pip show futures
```

Output:

```
Name: futures
Version: 3.1.1
Summary: Backport of the concurrent.futures package from Python 3.2
Home-page: https://github.com/agronholm/pythonfutures
Author: Brian Quinlan
Author-email: brian@sweetapp.com
License: PSF
Location: /anaconda3/envs/test/lib/python3.6/site-packages
Requires: 
Required-by: nipype
```

This PR will attempt to ensure the wheel is correctly created to only install `futures` in Python 2. My suspicion is that upgrading setuptools before building the wheel is the correct fix.

I suggest that we add a hot-fix release, so that downstream Python 3 packages can stop installing `futures` ASAP.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
