### PR TITLE
FIX: Read BIDS config.json under grabbids or layout

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -42,9 +42,15 @@ from .base import (
 
 have_pybids = True
 try:
-    from bids import grabbids as gb
+    import bids
 except ImportError:
     have_pybids = False
+
+if have_pybids:
+    try:
+        from bids import layout as bidslayout
+    except ImportError:
+        from bids import grabbids as bidslayout
 
 try:
     import pyxnat
@@ -2810,7 +2816,7 @@ class BIDSDataGrabber(IOBase):
 
         # If infields is empty, use all BIDS entities
         if infields is None and have_pybids:
-            bids_config = join(dirname(gb.__file__), 'config', 'bids.json')
+            bids_config = join(dirname(bidslayout.__file__), 'config', 'bids.json')
             bids_config = json.load(open(bids_config, 'r'))
             infields = [i['name'] for i in bids_config['entities']]
 
@@ -2835,7 +2841,7 @@ class BIDSDataGrabber(IOBase):
         exclude = None
         if self.inputs.strict:
             exclude = ['derivatives/', 'code/', 'sourcedata/']
-        layout = gb.BIDSLayout(self.inputs.base_dir, exclude=exclude)
+        layout = bidslayout.BIDSLayout(self.inputs.base_dir, exclude=exclude)
 
         # If infield is not given nm input value, silently ignore
         filters = {}

--- a/nipype/interfaces/tests/test_io.py
+++ b/nipype/interfaces/tests/test_io.py
@@ -77,7 +77,6 @@ except CalledProcessError:
 have_pybids = True
 try:
     import bids
-    from bids import grabbids as gb
     filepath = os.path.realpath(os.path.dirname(bids.__file__))
     datadir = os.path.realpath(os.path.join(filepath, 'tests/data/'))
 except ImportError:


### PR DESCRIPTION
## Summary
PyBIDS just renamed `bids.grabbids` to `bids.layout` (INCF/pybids#230). Althrough `grabbids` links back to `layout`, we look for files through the filesystem, which didn't survive the change.

This change should handle the new layout without breaking backwards compatibility.

@adelavega @tyarkoni I would appreciate reviews from you.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
