### PR TITLE
CI: Test 3.7, resume testing nipy extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,8 +417,10 @@ workflows:
               only: /.*/
       - compare_base_dockerfiles:
           filters:
-            tags:
+            branches:
               ignore: /^(ci\/)?travis.*/
+            tags:
+              only: /.*/
       - test_pytest:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,34 +417,21 @@ workflows:
               only: /.*/
       - compare_base_dockerfiles:
           filters:
-            branches:
-              ignore: /^(ci\/)?travis.*/
             tags:
               only: /.*/
       - test_pytest:
           filters:
-            branches:
-              ignore: /^(ci\/)?travis.*/
             tags:
               only: /.*/
           requires:
             - compare_base_dockerfiles
       - test_py3_fmri_fsl_spm:
-          filters:
-            branches:
-              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - test_py3_fmri_spm_dartel_multiproc:
-          filters:
-            branches:
-              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - test_fmri_spm_nested_fsl_feeds:
-          filters:
-            branches:
-              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - deploy_dockerhub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,17 +423,28 @@ workflows:
               only: /.*/
       - test_pytest:
           filters:
+            branches:
+              ignore: /^(ci\/)?travis.*/
             tags:
               only: /.*/
           requires:
             - compare_base_dockerfiles
       - test_py3_fmri_fsl_spm:
+          filters:
+            branches:
+              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - test_py3_fmri_spm_dartel_multiproc:
+          filters:
+            branches:
+              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - test_fmri_spm_nested_fsl_feeds:
+          filters:
+            branches:
+              ignore: /^(ci\/)?travis.*/
           requires:
             - compare_base_dockerfiles
       - deploy_dockerhub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ workflows:
       - compare_base_dockerfiles:
           filters:
             tags:
-              only: /.*/
+              ignore: /^(ci\/)?travis.*/
       - test_pytest:
           filters:
             tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: required
+dist: xenial
+sudo: true
 
 language: python
 # our build matrix
@@ -8,12 +8,7 @@ python:
 - 3.4
 - 3.5
 - 3.6
-
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+- 3.7
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ language: python
 # our build matrix
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 - 3.7
 
+# NOTE: Any changes to the matrix section should be duplicated below for
+#       Python 3.4
 env:
   global:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -29,6 +30,36 @@ env:
       NIPYPE_EXTRAS="doc,tests,profiler"
       EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
       CI_SKIP_TEST=1
+
+# Python 3.4 is only available on Trusty, so we need to duplicate the
+# env matrix specifically for it.
+matrix:
+  include:
+    - python: 3.4
+      dist: trusty
+      env:
+        - INSTALL_DEB_DEPENDECIES=true
+          NIPYPE_EXTRAS="doc,tests,profiler"
+          CI_SKIP_TEST=1
+    - python: 3.4
+      dist: trusty
+      env:
+        - INSTALL_DEB_DEPENDECIES=false
+          NIPYPE_EXTRAS="doc,tests,profiler"
+          CI_SKIP_TEST=1
+    - python: 3.4
+      dist: trusty
+      env:
+        - INSTALL_DEB_DEPENDECIES=true
+          NIPYPE_EXTRAS="doc,tests,profiler,duecredit,ssh"
+          CI_SKIP_TEST=1
+    - python: 3.4
+      dist: trusty
+      env:
+        - INSTALL_DEB_DEPENDECIES=true
+          NIPYPE_EXTRAS="doc,tests,profiler"
+          EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
+          CI_SKIP_TEST=1
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,12 @@ python:
 - 3.4
 - 3.5
 - 3.6
-- 3.7-dev
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ env:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
   matrix:
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,profiler"
+      NIPYPE_EXTRAS="doc,tests,nipy,profiler"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=false
       NIPYPE_EXTRAS="doc,tests,profiler"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,profiler,duecredit,ssh"
+      NIPYPE_EXTRAS="doc,tests,nipy,profiler,duecredit,ssh"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,profiler"
+      NIPYPE_EXTRAS="doc,tests,nipy,profiler"
       EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
       CI_SKIP_TEST=1
 
@@ -39,7 +39,7 @@ matrix:
       dist: trusty
       env:
         - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,profiler"
+          NIPYPE_EXTRAS="doc,tests,nipy,profiler"
           CI_SKIP_TEST=1
     - python: 3.4
       dist: trusty
@@ -51,13 +51,13 @@ matrix:
       dist: trusty
       env:
         - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,profiler,duecredit,ssh"
+          NIPYPE_EXTRAS="doc,tests,nipy,profiler,duecredit,ssh"
           CI_SKIP_TEST=1
     - python: 3.4
       dist: trusty
       env:
         - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,profiler"
+          NIPYPE_EXTRAS="doc,tests,nipy,profiler"
           EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
           CI_SKIP_TEST=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 - 3.4
 - 3.5
 - 3.6
+- 3.7-dev
 
 env:
   global:
@@ -16,16 +17,16 @@ env:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
   matrix:
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,fmri,profiler"
+      NIPYPE_EXTRAS="doc,tests,profiler"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=false
-      NIPYPE_EXTRAS="doc,tests,fmri,profiler"
+      NIPYPE_EXTRAS="doc,tests,profiler"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,fmri,profiler,duecredit,ssh"
+      NIPYPE_EXTRAS="doc,tests,profiler,duecredit,ssh"
       CI_SKIP_TEST=1
     - INSTALL_DEB_DEPENDECIES=true
-      NIPYPE_EXTRAS="doc,tests,fmri,profiler"
+      NIPYPE_EXTRAS="doc,tests,profiler"
       EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
       CI_SKIP_TEST=1
 


### PR DESCRIPTION
## List of changes proposed in this PR (pull-request)

* Add Python 3.7-dev to test matrix
* Remove "fmri" extra removed in 3500213074f28def0f011ff59a1519fb2fd377b4

@satra Should `fmri` instead be replaced with `nipy` in Travis?

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
