### PR TITLE
[DOC] Update links to user and developer help forums

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,10 @@ To participate in the Nipype development related discussions please use the foll
 
 Please add *[nipype]* to the subject line when posting on the mailing list.
 
+You can even hangout with the Nipype developers in their 
+`Gitter <https://gitter.im/nipy/nipype>`_ channel or in the BrainHack `Slack <https://brainhack.slack.com/messages/C1FR76RAL>`_ channel. (Click `here <https://brainhack-slack-invite.herokuapp.com>`_ to join the Slack workspace.)
+
+
 Contributing to the project
 ---------------------------
 

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -5,9 +5,10 @@
     <li>Docs: <a href="http://nipy.org/nipype">Stable</a> · <a href="http://nipype.readthedocs.org/en/latest/">Dev</a></li>
     <li>Code: <a href="http://github.com/nipy/nipype">Github</a> · <a href="http://github.com/nipy/nipype/issues">Bugs-Requests</a></li>
     <li>Forum: <a href="https://neurostars.org/search?q=nipype">User</a> · <a href="https://mail.python.org/mailman/listinfo/neuroimaging">Developer</a></li>
+    <li>Chat: <a href="https://gitter.im/nipy/nipype">Gitter</a> · <a href="https://brainhack.slack.com/messages/C1FR76RAL">Slack</a></li>
     <li><a href="about.html#funding">Funding</a> · <a href="http://nipy.org/software/license/index.html"><img src="https://img.shields.io/pypi/l/nipype.svg" alt="License"></a></li>
     <li><a href="https://travis-ci.org/nipy/nipype"><img src="https://travis-ci.org/nipy/nipype.png?branch=master" alt="travis"></a> · <a href='https://codecov.io/gh/nipy/nipype'><img src='https://codecov.io/gh/nipy/nipype/branch/master/graph/badge.svg' alt='Coverage Status' /></a></li>
     <a href='https://pypi.python.org/pypi/nipype/'><img src='https://img.shields.io/pypi/pyversions/nipype.svg' alt='Python Versions' /></a></li>
 </ul>
 
-{% endblock %}
+{% endblock %} 

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -4,7 +4,7 @@
 <ul>
     <li>Docs: <a href="http://nipy.org/nipype">Stable</a> · <a href="http://nipype.readthedocs.org/en/latest/">Dev</a></li>
     <li>Code: <a href="http://github.com/nipy/nipype">Github</a> · <a href="http://github.com/nipy/nipype/issues">Bugs-Requests</a></li>
-    <li>Forum: <a href="http://neurostars.org/t/nipype">User</a> · <a href="http://projects.scipy.org/mailman/listinfo/nipy-devel">Developer</a></li>
+    <li>Forum: <a href="https://neurostars.org/search?q=nipype">User</a> · <a href="https://mail.python.org/mailman/listinfo/neuroimaging">Developer</a></li>
     <li><a href="about.html#funding">Funding</a> · <a href="http://nipy.org/software/license/index.html"><img src="https://img.shields.io/pypi/l/nipype.svg" alt="License"></a></li>
     <li><a href="https://travis-ci.org/nipy/nipype"><img src="https://travis-ci.org/nipy/nipype.png?branch=master" alt="travis"></a> · <a href='https://codecov.io/gh/nipy/nipype'><img src='https://codecov.io/gh/nipy/nipype/branch/master/graph/badge.svg' alt='Coverage Status' /></a></li>
     <a href='https://pypi.python.org/pypi/nipype/'><img src='https://img.shields.io/pypi/pyversions/nipype.svg' alt='Python Versions' /></a></li>

--- a/doc/devel/gitwash/known_projects.inc
+++ b/doc/devel/gitwash/known_projects.inc
@@ -3,7 +3,7 @@
 .. PROJECTNAME placeholders
 .. _PROJECTNAME: http://neuroimaging.scipy.org
 .. _`PROJECTNAME github`: http://github.com/nipy
-.. _`PROJECTNAME mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
+.. _`PROJECTNAME mailing list`: https://mail.python.org/mailman/listinfo/neuroimaging
 
 .. numpy
 .. _numpy: http://numpy.scipy.org

--- a/doc/devel/interface_specs.rst
+++ b/doc/devel/interface_specs.rst
@@ -12,6 +12,10 @@ In case of trouble, we encourage you to post on `NeuroStars <https://neurostars.
 NeuroStars.org is a platform similar to StackOverflow but dedicated to neuroinformatics.
 You can also post on the nipype developers mailing list: http://mail.python.org/mailman/listinfo/neuroimaging.
 As we are sharing a mailing list with the nipy community, please add ``[nipype]`` to the message title.
+Alternatively, you're welcome to chat with us in the Nipype 
+`Gitter <https://gitter.im/nipy/nipype>`_ channel or in the 
+BrainHack `Slack <https://brainhack.slack.com/messages/C1FR76RAL>`_ channel.
+(Click `here <https://brainhack-slack-invite.herokuapp.com>`_ to join the Slack workspace.)
 
 
 Overview

--- a/doc/links_names.txt
+++ b/doc/links_names.txt
@@ -38,7 +38,7 @@
 .. _`nipy launchpad`: https://launchpad.net/nipy
 .. _launchpad: https://launchpad.net/
 .. _`nipy trunk`: https://code.launchpad.net/~nipy-developers/nipy/trunk
-.. _`nipy mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
+.. _`nipy mailing list`: https://mail.python.org/mailman/listinfo/neuroimaging
 .. _`nipy bugs`: https://bugs.launchpad.net/nipy
 
 .. Code support stuff


### PR DESCRIPTION
## Summary

I was trying to find the right place to ask a question and these links were both broken so I figured I'd send a little PR to update the two places to ask questions as linked from the index bar.

*updated*: I've also done a quick search for other instances of the old mailing list link and updated those.

Additionally I've added the gitter and slack links. Happy to remove those if you don't want to provide so many options!

Please disregard this pull request if this isn't correct or helpful! Very happy to adapt anything that's needed.

## List of changes proposed in this PR (pull-request)

Changed links:

* http://neurostars.org/t/nipype
 ---> https://neurostars.org/search?q=nipype
* http://projects.scipy.org/mailman/listinfo/nipy-devel ---> https://mail.python.org/mailman/listinfo/neuroimaging

Added links to 

* https://gitter.im/nipy/nipype
* https://brainhack.slack.com/messages/C1FR76RAL

## Acknowledgment

- [x] I acknowledge that this contribution will be available under the Apache 2 license.
