### PR TITLE
RF: Use runtime.cwd in Rename

### DIFF
--- a/nipype/interfaces/utility/base.py
+++ b/nipype/interfaces/utility/base.py
@@ -20,7 +20,7 @@ import nibabel as nb
 
 from ..base import (traits, TraitedSpec, DynamicTraitedSpec, File, Undefined,
                     isdefined, OutputMultiPath, InputMultiPath, BaseInterface,
-                    BaseInterfaceInputSpec, Str)
+                    BaseInterfaceInputSpec, Str, SimpleInterface)
 from ..io import IOBase, add_traits
 from ...utils.filemanip import ensure_list, copyfile, split_filename
 
@@ -204,7 +204,6 @@ class Merge(IOBase):
 
 
 class RenameInputSpec(DynamicTraitedSpec):
-
     in_file = File(exists=True, mandatory=True, desc="file to rename")
     keep_ext = traits.Bool(
         desc=("Keep in_file extension, replace "
@@ -218,12 +217,11 @@ class RenameInputSpec(DynamicTraitedSpec):
 
 
 class RenameOutputSpec(TraitedSpec):
-
     out_file = traits.File(
         exists=True, desc="softlink to original file with new name")
 
 
-class Rename(IOBase):
+class Rename(SimpleInterface, IOBase):
     """Change the name of a file based on a mapped format string.
 
     To use additional inputs that will be defined at run-time, the class
@@ -303,14 +301,10 @@ class Rename(IOBase):
 
     def _run_interface(self, runtime):
         runtime.returncode = 0
-        _ = copyfile(self.inputs.in_file,
-                     os.path.join(os.getcwd(), self._rename()))
+        out_file = os.path.join(runtime.cwd, self._rename())
+        _ = copyfile(self.inputs.in_file, out_file)
+        self._results['out_file'] = out_file
         return runtime
-
-    def _list_outputs(self):
-        outputs = self._outputs().get()
-        outputs["out_file"] = os.path.join(os.getcwd(), self._rename())
-        return outputs
 
 
 class SplitInputSpec(BaseInterfaceInputSpec):


### PR DESCRIPTION
## Summary

Rename calculates the output path twice, in `_run_interface` and `_list_outputs`. By moving to `SimpleInterface`, we can calculate the path once, and use `runtime.cwd` as insurance against unexpected working directory changes.

Fixes #2687.

## List of changes proposed in this PR (pull-request)

* Add `SimpleInterface` as mixin to `Rename`
* Calculate output path via `runtime.cwd`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
