### PR TITLE
FIX: Provide informative error for interfaces that fail to return runtime object

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -540,6 +540,9 @@ class BaseInterface(Interface):
             if not ignore_exception:
                 raise
         finally:
+            if runtime is None:
+                raise RuntimeError("{} interface failed to return runtime "
+                                   "object".format(interface.__class__.__name__))
             # This needs to be done always
             runtime.endTime = dt.isoformat(dt.utcnow())
             timediff = parseutc(runtime.endTime) - parseutc(runtime.startTime)


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

If an interface has a `_run_interface` implementation that in some (or all) cases fails to return the passed `runtime` object, then the error you currently get is:

```
Traceback (most recent call last):
  File "/usr/local/miniconda/lib/python3.6/site-packages/nipype/pipeline/plugins/multiproc.py", line 69, in run_node
    result['result'] = node.run(updatehash=updatehash)
  File "/usr/local/miniconda/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 471, in run
    result = self._run_interface(execute=True)
  File "/usr/local/miniconda/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 555, in _run_interface
    return self._run_command(execute)
  File "/usr/local/miniconda/lib/python3.6/site-packages/nipype/pipeline/engine/nodes.py", line 635, in _run_command
    result = self._interface.run(cwd=outdir)
  File "/usr/local/miniconda/lib/python3.6/site-packages/nipype/interfaces/base/core.py", line 544, in run
    runtime.endTime = dt.isoformat(dt.utcnow())
AttributeError: 'NoneType' object has no attribute 'endTime'
```

Arising from this chunk of code:

https://github.com/nipy/nipype/blob/37f3781a4f765a7793d17389cd959d2eb4fcd617/nipype/interfaces/base/core.py#L542-L553

This PR simply makes an absent `runtime` object raise a `RuntimeError` and give a likely cause.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
