### PR TITLE
[FIX] load_results in nodes.py now uses node output directory as wd

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -559,28 +559,29 @@ class Node(EngineBase):
         result, aggregate, attribute_error = _load_resultfile(cwd, self.name)
         # try aggregating first
         if aggregate:
-            logger.debug('aggregating results')
-            if attribute_error:
-                old_inputs = loadpkl(op.join(cwd, '_inputs.pklz'))
-                self.inputs.trait_set(**old_inputs)
-            if not isinstance(self, MapNode):
-                self._copyfiles_to_wd(linksonly=True)
-                aggouts = self._interface.aggregate_outputs(
-                    needed_outputs=self.needed_outputs)
-                runtime = Bunch(
-                    cwd=cwd,
-                    returncode=0,
-                    environ=dict(os.environ),
-                    hostname=socket.gethostname())
-                result = InterfaceResult(
-                    interface=self._interface.__class__,
-                    runtime=runtime,
-                    inputs=self._interface.inputs.get_traitsfree(),
-                    outputs=aggouts)
-                _save_resultfile(result, cwd, self.name)
-            else:
-                logger.debug('aggregating mapnode results')
-                result = self._run_interface()
+            with indirectory(cwd):
+                logger.debug('aggregating results')
+                if attribute_error:
+                    old_inputs = loadpkl(op.join(cwd, '_inputs.pklz'))
+                    self.inputs.trait_set(**old_inputs)
+                if not isinstance(self, MapNode):
+                    self._copyfiles_to_wd(linksonly=True)
+                    aggouts = self._interface.aggregate_outputs(
+                        needed_outputs=self.needed_outputs)
+                    runtime = Bunch(
+                        cwd=cwd,
+                        returncode=0,
+                        environ=dict(os.environ),
+                        hostname=socket.gethostname())
+                    result = InterfaceResult(
+                        interface=self._interface.__class__,
+                        runtime=runtime,
+                        inputs=self._interface.inputs.get_traitsfree(),
+                        outputs=aggouts)
+                    _save_resultfile(result, cwd, self.name)
+                else:
+                    logger.debug('aggregating mapnode results')
+                    result = self._run_interface()
         return result
 
     def _run_command(self, execute, copyfiles=True):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -559,29 +559,30 @@ class Node(EngineBase):
         result, aggregate, attribute_error = _load_resultfile(cwd, self.name)
         # try aggregating first
         if aggregate:
-            with indirectory(cwd):
-                logger.debug('aggregating results')
-                if attribute_error:
-                    old_inputs = loadpkl(op.join(cwd, '_inputs.pklz'))
-                    self.inputs.trait_set(**old_inputs)
-                if not isinstance(self, MapNode):
-                    self._copyfiles_to_wd(linksonly=True)
+            logger.debug('aggregating results')
+            if attribute_error:
+                old_inputs = loadpkl(op.join(cwd, '_inputs.pklz'))
+                self.inputs.trait_set(**old_inputs)
+            if not isinstance(self, MapNode):
+                self._copyfiles_to_wd(linksonly=True)
+                with indirectory(cwd):
                     aggouts = self._interface.aggregate_outputs(
                         needed_outputs=self.needed_outputs)
-                    runtime = Bunch(
-                        cwd=cwd,
-                        returncode=0,
-                        environ=dict(os.environ),
-                        hostname=socket.gethostname())
-                    result = InterfaceResult(
-                        interface=self._interface.__class__,
-                        runtime=runtime,
-                        inputs=self._interface.inputs.get_traitsfree(),
-                        outputs=aggouts)
-                    _save_resultfile(result, cwd, self.name)
-                else:
-                    logger.debug('aggregating mapnode results')
-                    result = self._run_interface()
+                        
+                runtime = Bunch(
+                    cwd=cwd,
+                    returncode=0,
+                    environ=dict(os.environ),
+                    hostname=socket.gethostname())
+                result = InterfaceResult(
+                    interface=self._interface.__class__,
+                    runtime=runtime,
+                    inputs=self._interface.inputs.get_traitsfree(),
+                    outputs=aggouts)
+                _save_resultfile(result, cwd, self.name)
+            else:
+                logger.debug('aggregating mapnode results')
+                result = self._run_interface()
         return result
 
     def _run_command(self, execute, copyfiles=True):


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

Fixes #2689. Makes sure that when results are loaded the current working directory is a node's output directory so that autogenerated filenames will have the right paths.

## List of changes proposed in this PR (pull-request)
* add indirectory to Node._load_results
## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
