### PR TITLE
fix/enh: added the colorfa as an output in DTI

### DIFF
--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -21,6 +21,7 @@ class DTIOutputSpec(TraitedSpec):
     md_file = File(exists=True)
     rd_file = File(exists=True)
     ad_file = File(exists=True)
+    color_fa_file = File(exists=True)
 
 
 class DTI(DipyDiffusionInterface):
@@ -62,7 +63,7 @@ class DTI(DipyDiffusionInterface):
         IFLOGGER.info('DTI parameters image saved as %s', out_file)
 
         # FA MD RD and AD
-        for metric in ["fa", "md", "rd", "ad"]:
+        for metric in ["fa", "md", "rd", "ad", "color_fa"]:
             data = getattr(ten_fit, metric).astype("float32")
             out_name = self._gen_filename(metric)
             nb.Nifti1Image(data, affine).to_filename(out_name)
@@ -74,7 +75,7 @@ class DTI(DipyDiffusionInterface):
         outputs = self._outputs().get()
         outputs['out_file'] = self._gen_filename('dti')
 
-        for metric in ["fa", "md", "rd", "ad"]:
+        for metric in ["fa", "md", "rd", "ad", "color_fa"]:
             outputs["{}_file".format(metric)] = self._gen_filename(metric)
 
         return outputs


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* return the color_fa file in the  dipy DTI interface

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
