### PR TITLE
DOC: Fix naming of motion parameters (roll/yaw swapped)

### DIFF
--- a/nipype/utils/misc.py
+++ b/nipype/utils/misc.py
@@ -233,8 +233,8 @@ def normalize_mc_params(params, source):
         y   Anterior-Posterior  (mm)
         z   Superior-Inferior   (mm)
         rx  Pitch               (rad)
-        ry  Yaw                 (rad)
-        rz  Roll                (rad)
+        ry  Roll                (rad)
+        rz  Yaw                 (rad)
     """
     if source.upper() == 'FSL':
         params = params[[3, 4, 5, 0, 1, 2]]


### PR DESCRIPTION
I've modified the docstring in the function normalize_mc_params, after discussing with @satra.
There was a mismatch in the description of the parameters ry and rz.
ry -> roll, rz -> yaw

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [ ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
