### PR TITLE
[FIX] Lock travis pybids 0.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,7 @@ before_install:
 
 - travis_retry pip install -r requirements.txt
 - travis_retry pip install grabbit==0.1.2
-- travis_retry git clone https://github.com/INCF/pybids.git ${HOME}/pybids &&
-  pip install -e ${HOME}/pybids
+- travis_retry git clone -b 0.6.5 https://github.com/INCF/pybids.git ${HOME}/pybids && pip install -e ${HOME}/pybids
 
 install:
 - travis_retry pip install $EXTRA_PIP_FLAGS -e .[$NIPYPE_EXTRAS]

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -164,7 +164,7 @@ EXTRA_REQUIRES = {
     'profiler': ['psutil>=5.0'],
     'duecredit': ['duecredit'],
     'xvfbwrapper': ['xvfbwrapper'],
-    'pybids': ['pybids'],
+    'pybids': ['pybids==0.6.5'],
     'ssh': ['paramiko'],
     # 'mesh': ['mayavi']  # Enable when it works
 }


### PR DESCRIPTION
This is just a patch to attempt to pin pybids to 0.6.5, until we updates the interfaces that depend on pybids.