### PR TITLE
FIX: corrects readthedocs build error

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,7 @@ extensions = ['sphinx.ext.todo',
               'sphinx.ext.autosummary',
               'numpydoc',
               'matplotlib.sphinxext.plot_directive',
-              'matplotlib.sphinxext.only_directives',
+              #'matplotlib.sphinxext.only_directives',
               'nipype.sphinxext.plot_workflow',
               #'IPython.sphinxext.ipython_directive',
               #'IPython.sphinxext.ipython_console_highlighting'

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -53,11 +53,11 @@ do
 done
 
 
-# neurodocker version 0.3.1-22-gb0ee069
-NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:f15ca90803f4b89acfca55cd1c7269bf2ec2dfd95b3de1118b08afa34b87d9d1"
+# neurodocker:master pulled on October 9, 2018
+NEURODOCKER_IMAGE="kaczmarj/neurodocker@sha256:c5c10fc11cbd7efe18ac10d2370742b8ecb3588c3aa9b2c15ca7e18363bfa9dc"
 
-# neurodebian:stretch-non-free pulled on November 3, 2017
-BASE_IMAGE="neurodebian@sha256:7590552afd0e7a481a33314724ae27f76ccedd05ffd7ac06ec38638872427b9b"
+# neurodebian:stretch-non-free pulled on October 9, 2018
+BASE_IMAGE="neurodebian@sha256:7cd978427d7ad215834fee221d0536ed7825b3cddebc481eba2d792dfc2f7332"
 
 NIPYPE_BASE_IMAGE="nipype/nipype:base"
 PKG_MANAGER="apt"

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -64,7 +64,7 @@ PKG_MANAGER="apt"
 DIR="$(dirname "$0")"
 
 function generate_base_dockerfile() {
-  docker run --rm "$NEURODOCKER_IMAGE" generate \
+  docker run --rm "$NEURODOCKER_IMAGE" generate docker \
   --base "$BASE_IMAGE" --pkg-manager "$PKG_MANAGER" \
   --label maintainer="The nipype developers https://github.com/nipy/nipype" \
   --spm version=12 matlab_version=R2017a \
@@ -81,7 +81,7 @@ function generate_base_dockerfile() {
 
 
 function generate_main_dockerfile() {
-  docker run --rm "$NEURODOCKER_IMAGE" generate \
+  docker run --rm "$NEURODOCKER_IMAGE" generate docker \
   --base "$NIPYPE_BASE_IMAGE" --pkg-manager "$PKG_MANAGER" \
   --label maintainer="The nipype developers https://github.com/nipy/nipype" \
   --env MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 \

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -67,7 +67,7 @@ function generate_base_dockerfile() {
   docker run --rm "$NEURODOCKER_IMAGE" generate docker \
   --base "$BASE_IMAGE" --pkg-manager "$PKG_MANAGER" \
   --label maintainer="The nipype developers https://github.com/nipy/nipype" \
-  --spm version=12 matlab_version=R2017a \
+  --spm12 version=r7219 \
   --afni version=latest install_python2=true \
   --freesurfer version=6.0.0 min=true \
   --run 'echo "cHJpbnRmICJrcnp5c3p0b2YuZ29yZ29sZXdza2lAZ21haWwuY29tXG41MTcyXG4gKkN2dW12RVYzelRmZ1xuRlM1Si8yYzFhZ2c0RVxuIiA+IC9vcHQvZnJlZXN1cmZlci9saWNlbnNlLnR4dAo=" | base64 -d | sh' \
@@ -75,8 +75,7 @@ function generate_base_dockerfile() {
             fusefat g++ git graphviz make ruby unzip xvfb \
   --add-to-entrypoint "source /etc/fsl/fsl.sh" \
   --env ANTSPATH='/usr/lib/ants' PATH='/usr/lib/ants:$PATH' \
-  --run "gem install fakes3" \
-  --no-check-urls > "$DIR/Dockerfile.base"
+  --run "gem install fakes3" > "$DIR/Dockerfile.base"
 }
 
 
@@ -86,7 +85,7 @@ function generate_main_dockerfile() {
   --label maintainer="The nipype developers https://github.com/nipy/nipype" \
   --env MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 \
   --user neuro \
-  --miniconda env_name=neuro \
+  --miniconda create_env=neuro \
               activate=true \
   --copy docker/files/run_builddocs.sh docker/files/run_examples.sh \
          docker/files/run_pytests.sh nipype/external/fsl_imglob.py /usr/bin/ \
@@ -100,13 +99,13 @@ function generate_main_dockerfile() {
 && chown neuro /work' \
   --user neuro \
   --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=6 BUILD_DATE VCS_REF VERSION \
-  --miniconda env_name=neuro \
+  --miniconda create_env=neuro \
               conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
                              icu=58.1 libxml2 libxslt matplotlib mkl numpy paramiko
                              pandas psutil scikit-learn scipy traits=4.6.0' \
               pip_opts="-e" \
               pip_install="/src/nipype[all]" \
-  --miniconda env_name=neuro \
+  --miniconda create_env=neuro \
               pip_install="grabbit==0.1.2" \
   --run-bash "mkdir -p /src/pybids
          && curl -sSL --retry 5 https://github.com/INCF/pybids/tarball/0.6.5
@@ -121,8 +120,7 @@ function generate_main_dockerfile() {
           org.label-schema.vcs-ref='$VCS_REF' \
           org.label-schema.vcs-url="https://github.com/nipy/nipype" \
           org.label-schema.version='$VERSION' \
-          org.label-schema.schema-version="1.0" \
-  --no-check-urls
+          org.label-schema.schema-version="1.0"
 }
 
 

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -109,7 +109,7 @@ function generate_main_dockerfile() {
   --miniconda env_name=neuro \
               pip_install="grabbit==0.1.2" \
   --run-bash "mkdir -p /src/pybids
-         && curl -sSL --retry 5 https://github.com/INCF/pybids/tarball/0.5.1
+         && curl -sSL --retry 5 https://github.com/INCF/pybids/tarball/0.6.5
          | tar -xz -C /src/pybids --strip-components 1
          && source activate neuro
          && pip install --no-cache-dir -e /src/pybids" \

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -86,6 +86,7 @@ function generate_main_dockerfile() {
   --env MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 \
   --user neuro \
   --miniconda create_env=neuro \
+              conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}' \
               activate=true \
   --copy docker/files/run_builddocs.sh docker/files/run_examples.sh \
          docker/files/run_pytests.sh nipype/external/fsl_imglob.py /usr/bin/ \
@@ -99,13 +100,12 @@ function generate_main_dockerfile() {
 && chown neuro /work' \
   --user neuro \
   --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=6 BUILD_DATE VCS_REF VERSION \
-  --miniconda create_env=neuro \
-              conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
-                             icu=58.1 libxml2 libxslt matplotlib mkl numpy paramiko
+  --miniconda use_env=neuro \
+              conda_install='icu=58.1 libxml2 libxslt matplotlib mkl numpy paramiko
                              pandas psutil scikit-learn scipy traits=4.6.0' \
               pip_opts="-e" \
               pip_install="/src/nipype[all]" \
-  --miniconda create_env=neuro \
+  --miniconda use_env=neuro \
               pip_install="grabbit==0.1.2" \
   --run-bash "mkdir -p /src/pybids
          && curl -sSL --retry 5 https://github.com/INCF/pybids/tarball/0.6.5


### PR DESCRIPTION
Closes https://github.com/nipy/nipype/issues/2713.

Small PR that takes care of the readthedocs build error mentioned under https://github.com/nipy/nipype/issues/2713.

The problem was that `matplotlib` version 3.0.0 doesn't include the `sphinxext.only_directives` anymore.