### PR TITLE
ENH: enable/disable resource monitor in the fixture per test

### DIFF
--- a/nipype/interfaces/base/tests/test_resource_monitor.py
+++ b/nipype/interfaces/base/tests/test_resource_monitor.py
@@ -18,8 +18,14 @@ from ...base import traits, CommandLine, CommandLineInputSpec
 from ... import utility as niu
 
 # Try to enable the resource monitor
-config.enable_resource_monitor()
 run_profile = config.resource_monitor
+
+
+@pytest.fixture(scope="module")
+def use_resource_monitor():
+    config.enable_resource_monitor()
+    yield
+    config.disable_resource_monitor()
 
 
 class UseResourcesInputSpec(CommandLineInputSpec):
@@ -51,7 +57,7 @@ class UseResources(CommandLine):
     os.getenv('CI_SKIP_TEST', False), reason='disabled in CI tests')
 @pytest.mark.parametrize("mem_gb,n_procs", [(0.5, 3), (2.2, 8), (0.8, 4),
                                             (1.5, 1)])
-def test_cmdline_profiling(tmpdir, mem_gb, n_procs):
+def test_cmdline_profiling(tmpdir, mem_gb, n_procs, use_resource_monitor):
     """
     Test runtime profiler correctly records workflow RAM/CPUs consumption
     of a CommandLine-derived interface
@@ -73,7 +79,7 @@ def test_cmdline_profiling(tmpdir, mem_gb, n_procs):
     True, reason='test disabled temporarily, until funcion profiling works')
 @pytest.mark.parametrize("mem_gb,n_procs", [(0.5, 3), (2.2, 8), (0.8, 4),
                                             (1.5, 1)])
-def test_function_profiling(tmpdir, mem_gb, n_procs):
+def test_function_profiling(tmpdir, mem_gb, n_procs, use_resource_monitor):
     """
     Test runtime profiler correctly records workflow RAM/CPUs consumption
     of a Function interface

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -291,6 +291,10 @@ class NipypeConfig(object):
         """Sets the resource monitor on"""
         self.resource_monitor = True
 
+    def disable_resource_monitor(self):
+        """Sets the resource monitor off"""
+        self.resource_monitor = False
+
     def get_display(self):
         """Returns the first display available"""
 


### PR DESCRIPTION
This is just a more "kosher" way to avoid side-effects across tests etc.
It was "inspired" to mitigate an issue of some stale processes being
kept in background preventing pytest run completion, see
https://github.com/nipy/nipype/issues/2719

So, even though it avoids that issue now (both tests are skipped anyways
unconditionally ATM), it does not solve it -- some issue causing that
was introduced somewhere between 1.1.2 and 1.1.3