### PR TITLE
BF: provide "" into target graph dot depending on networkx version

### DIFF
--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -484,9 +484,12 @@ def test_deep_nested_write_graph_runs(tmpdir):
             except OSError:
                 pass
 
+import networkx
+# Format of the graph has slightly changed
+graph_str = '""' if int(networkx.__version__.split('.')[0]) == 1 else ''
 
 # examples of dot files used in the following test
-dotfile_orig = ['strict digraph  {\n',
+dotfile_orig = ['strict digraph ' + graph_str + ' {\n',
                 '"mod1 (engine)";\n',
                 '"mod2 (engine)";\n',
                 '"mod1 (engine)" -> "mod2 (engine)";\n',


### PR DESCRIPTION
Not sure if that started to happen with networkx `2` but comparing between networkx 1.11 and 2.1 this seems to work