### PR TITLE
FIX: Remove 'reg_term'/'regularisation' from dwi2tensor interface

### DIFF
--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -4,9 +4,37 @@
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 
-from ... import logging
-from ..base import (CommandLineInputSpec, CommandLine, traits, File, isdefined)
+from ... import logging, LooseVersion
+from ...utils.filemanip import which
+from ..base import (CommandLineInputSpec, CommandLine, traits, File, isdefined, PackageInfo)
 iflogger = logging.getLogger('nipype.interface')
+
+
+class Info(PackageInfo):
+    version_cmd = 'mrconvert --version'
+
+    @staticmethod
+    def parse_version(raw_info):
+        # info is like: "== mrconvert 0.3.15-githash"
+        for line in raw_info.splitlines():
+            if line.startswith('== mrconvert '):
+                v_string = line.split()[2]
+                break
+        else:
+            return None
+
+        # -githash may or may not be appended
+        v_string = v_string.split('-')[0]
+
+        return '.'.join(v_string.split('.')[:3])
+
+    @classmethod
+    def looseversion(cls):
+        """ Return a comparable version object
+
+        If no version found, use LooseVersion('0.0.0')
+        """
+        return LooseVersion(cls.version() or '0.0.0')
 
 
 class MRTrix3BaseInputSpec(CommandLineInputSpec):
@@ -78,3 +106,7 @@ class MRTrix3Base(CommandLine):
             pass
 
         return super(MRTrix3Base, self)._parse_inputs(skip=skip)
+
+    @property
+    def version(self):
+        return Info.version()

--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -64,8 +64,7 @@ class FitTensor(MRTrix3Base):
     >>> tsr.inputs.in_mask = 'mask.nii.gz'
     >>> tsr.inputs.grad_fsl = ('bvecs', 'bvals')
     >>> tsr.cmdline                               # doctest: +ELLIPSIS
-    'dwi2tensor -fslgrad bvecs bvals -mask mask.nii.gz \
--regularisation 5000.000000 dwi.mif dti.mif'
+    'dwi2tensor -fslgrad bvecs bvals -mask mask.nii.gz dwi.mif dti.mif'
     >>> tsr.run()                                 # doctest: +SKIP
     """
 

--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -39,8 +39,8 @@ class FitTensorInputSpec(MRTrix3BaseInputSpec):
         argstr='-method %s',
         desc=('select method used to perform the fitting'))
     reg_term = traits.Float(
-        5.e3, usedefault=True,
         argstr='-regularisation %f',
+        max_ver='0.3.13',
         desc=('specify the strength of the regularisation term on the '
               'magnitude of the tensor elements (default = 5000). This '
               'only applies to the non-linear methods'))

--- a/nipype/interfaces/mrtrix3/tests/test_auto_FitTensor.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_FitTensor.py
@@ -34,7 +34,7 @@ def test_FitTensor_inputs():
         ),
         reg_term=dict(
             argstr='-regularisation %f',
-            usedefault=True,
+            max_ver='0.3.13',
         ),
     )
     inputs = FitTensor.input_spec()


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

- remove `regularisation` (`reg_term`) option from MRtrix3 dwi2tensor interface.

This option was removed as part of refactoring in:

  https://github.com/MRtrix3/mrtrix3/commit/9b886a94289a

Fixes

```
dwi2tensor: [ERROR] unknown option "-regularisation"
```

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
