### PR TITLE
FIX: Ensure outputs can be listed in camino.ProcStreamlines by defining instance variable 

### DIFF
--- a/nipype/interfaces/camino/convert.py
+++ b/nipype/interfaces/camino/convert.py
@@ -441,6 +441,10 @@ class ProcStreamlines(StdOutCommandLine):
             return spec.argstr % self._get_actual_outputroot(value)
         return super(ProcStreamlines, self)._format_arg(name, spec, value)
 
+    def __init__(self, *args, **kwargs):
+            super(ProcStreamlines, self).__init__(*args, **kwargs)
+            self.outputroot_files = []
+
     def _run_interface(self, runtime):
         outputroot = self.inputs.outputroot
         if isdefined(outputroot):


### PR DESCRIPTION
## Summary
Camino procstreamlines can be used without -outputroot to filter streamlines. The function  _list_outputs insits on a definition of outputroot_files in contrast to _run_interface.


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
