### PR TITLE
FIX: Refine FSL.split output identification

### DIFF
--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -551,9 +551,9 @@ class Split(FSLCommand):
         """
         outputs = self._outputs().get()
         ext = Info.output_type_to_ext(self.inputs.output_type)
-        outbase = 'vol*'
+        outbase = 'vol[0-9]*'
         if isdefined(self.inputs.out_base_name):
-            outbase = '%s*' % self.inputs.out_base_name
+            outbase = '%s[0-9]*' % self.inputs.out_base_name
         outputs['out_files'] = sorted(
             glob(os.path.join(os.getcwd(), outbase + ext)))
         return outputs


### PR DESCRIPTION
The current implementation of FSL's split selects all files that start with `vol*` (or the specified prefix) as output.

This caused a problem in my setup, because I had additional files in the same folder, that started with `vol_*`. This small PR corrects this, by forcing the output to start with a number.