### PR TITLE
ENH: Add 'sse' output to FSL DTIFit interface

### DIFF
--- a/nipype/interfaces/fsl/tests/test_auto_DTIFit.py
+++ b/nipype/interfaces/fsl/tests/test_auto_DTIFit.py
@@ -66,6 +66,7 @@ def test_DTIFit_outputs():
         V2=dict(),
         V3=dict(),
         tensor=dict(),
+        sse=dict(),
     )
     outputs = DTIFit.output_spec()
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
Add Sum-Squared-Error to DTIFit output.

Fixes #2743  .

## List of changes proposed in this PR (pull-request)
* add 'sse' to DTIFitOutputSpec
* add logic to ignore this output if the corresponding input-flag was not set

I was not able to run the tests since i cannot install all requirements on my work system.
My changes are very similar to the already existing 'save_tensor' input with 'tensor' output.
The logic to only add the output if the corresponding input-flag was defined and set to True, was only tested manually with an example dataset, since it depends on the actual output/file creation!
I did not find any tests for the 'save tensor' -> 'tensor' input-output pair, so i had no orientation how to approach this for my new output.
In fact i did not find any tests that go further than the correct assembly of the cmdline.

I think the approach to define a dictionary which maps an optional output to the corresponding input-flag is quite generic and might be useful in similar use-cases. In the old code 'save_tensor' was handled as a special case with some duplication.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
