### PR TITLE
[ENH] added slice_encoding_direction input to TShift

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -320,7 +320,9 @@
       "name": "Ghayoor, Ali"
     },
     {
-      "name": "Liem, Franz"
+      "affiliation": "University of Zurich",
+      "name": "Liem, Franz",
+      "orcid": "0000-0003-0646-4810"
     },
     {
       "name": "Millman, Jarrod"

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2665,6 +2665,17 @@ class TShift(AFNICommand):
     >>> tshift._list_outputs()['timing_file']  # doctest: +ELLIPSIS
     '.../slice_timing.1D'
 
+    >>> np.loadtxt(tshift._list_outputs()['timing_file'])[:5]
+    [0.0, 0.4, 0.8, 1.2, 1.6]
+
+    If ``slice_encoding_direction`` is set to ``'k-'``, the slice timing is reversed:
+
+    >>> tshift.inputs.slice_encoding_direction = 'k-'
+    >>> tshift.cmdline
+    '3dTshift -prefix functional_tshift -tpattern @slice_timing.1D -TR 2.5s -tzero 0.0 functional.nii'
+    >>> np.loadtxt(tshift._list_outputs()['timing_file'])[:5]
+    [15.6, 15.2, 14.8, 14.4, 14.0]
+
     This method creates a ``slice_timing.1D`` file to be passed to ``3dTshift``.
     A pre-existing slice-timing file may be used in the same way:
 

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2668,7 +2668,7 @@ class TShift(AFNICommand):
     >>> tshift._list_outputs()['timing_file']  # doctest: +ELLIPSIS
     '.../slice_timing.1D'
 
-    >>> np.loadtxt(tshift._list_outputs()['timing_file'])[:5]
+    >>> np.loadtxt(tshift._list_outputs()['timing_file']).tolist()[:5]
     [0.0, 0.4, 0.8, 1.2, 1.6]
 
     If ``slice_encoding_direction`` is set to ``'k-'``, the slice timing is reversed:
@@ -2676,7 +2676,7 @@ class TShift(AFNICommand):
     >>> tshift.inputs.slice_encoding_direction = 'k-'
     >>> tshift.cmdline
     '3dTshift -prefix functional_tshift -tpattern @slice_timing.1D -TR 2.5s -tzero 0.0 functional.nii'
-    >>> np.loadtxt(tshift._list_outputs()['timing_file'])[:5]
+    >>> np.loadtxt(tshift._list_outputs()['timing_file']).tolist()[:5]
     [15.6, 15.2, 14.8, 14.4, 14.0]
 
     This method creates a ``slice_timing.1D`` file to be passed to ``3dTshift``.

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2618,6 +2618,10 @@ class TShiftInputSpec(AFNICommandInputSpec):
         desc='time offsets from the volume acquisition onset for each slice',
         argstr='-tpattern @%s',
         xor=['tpattern'])
+    slice_encoding_direction = traits.Enum(
+        ('k', 'k-'),
+        desc='Direction in which slice_timing is specified (default: k). If negative,'
+             'slice_timing is defined in reverse order -- see BIDS specification for details.',)
     rlt = traits.Bool(
         desc='Before shifting, remove the mean and linear trend',
         argstr='-rlt')
@@ -2723,9 +2727,17 @@ class TShift(AFNICommand):
         return super(TShift, self)._format_arg(name, trait_spec, value)
 
     def _write_slice_timing(self):
+        slice_timing = self.inputs.slice_timing.copy()
+        if not self.inputs.slice_encoding_direction:
+            slice_encoding_direction = "k"
+        else:
+            slice_encoding_direction = self.inputs.slice_encoding_direction
+        if slice_encoding_direction.endswith("-"):
+            slice_timing.reverse()
+            
         fname = 'slice_timing.1D'
         with open(fname, 'w') as fobj:
-            fobj.write('\t'.join(map(str, self.inputs.slice_timing)))
+            fobj.write('\t'.join(map(str, slice_timing)))
         return fname
 
     def _list_outputs(self):

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2619,7 +2619,8 @@ class TShiftInputSpec(AFNICommandInputSpec):
         argstr='-tpattern @%s',
         xor=['tpattern'])
     slice_encoding_direction = traits.Enum(
-        ('k', 'k-'),
+        'k', 'k-',
+        usedefault=True,
         desc='Direction in which slice_timing is specified (default: k). If negative,'
              'slice_timing is defined in reverse order -- see BIDS specification for details.',)
     rlt = traits.Bool(
@@ -2728,13 +2729,9 @@ class TShift(AFNICommand):
 
     def _write_slice_timing(self):
         slice_timing = self.inputs.slice_timing.copy()
-        if not self.inputs.slice_encoding_direction:
-            slice_encoding_direction = "k"
-        else:
-            slice_encoding_direction = self.inputs.slice_encoding_direction
-        if slice_encoding_direction.endswith("-"):
+        if self.inputs.slice_encoding_direction.endswith("-"):
             slice_timing.reverse()
-            
+
         fname = 'slice_timing.1D'
         with open(fname, 'w') as fobj:
             fobj.write('\t'.join(map(str, slice_timing)))

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2622,7 +2622,10 @@ class TShiftInputSpec(AFNICommandInputSpec):
         'k', 'k-',
         usedefault=True,
         desc='Direction in which slice_timing is specified (default: k). If negative,'
-             'slice_timing is defined in reverse order -- see BIDS specification for details.',)
+             'slice_timing is defined in reverse order, that is, the first entry '
+             'corresponds to the slice with the largest index, and the final entry '
+             'corresponds to slice index zero. Only in effect when slice_timing is '
+             'passed as list, not when it is passed as file.',)
     rlt = traits.Bool(
         desc='Before shifting, remove the mean and linear trend',
         argstr='-rlt')

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2742,7 +2742,7 @@ class TShift(AFNICommand):
         return super(TShift, self)._format_arg(name, trait_spec, value)
 
     def _write_slice_timing(self):
-        slice_timing = self.inputs.slice_timing.copy()
+        slice_timing = list(self.inputs.slice_timing)
         if self.inputs.slice_encoding_direction.endswith("-"):
             slice_timing.reverse()
 


### PR DESCRIPTION
## Summary

Fixes #2752 

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* adds slice_encoding_direction input to TShift
* if `slice_encoding_direction == k-`, reverse `slice_timing`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.