### PR TITLE
FIX: Python 2.7-3.7.1 compatible NonDaemonPool

### DIFF
--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -11,7 +11,8 @@ from __future__ import (print_function, division, unicode_literals,
 
 # Import packages
 import os
-from multiprocessing import Process, Pool, cpu_count, pool
+import multiprocessing as mp
+from multiprocessing import Pool, cpu_count, pool
 from traceback import format_exception
 import sys
 from logging import INFO
@@ -74,7 +75,7 @@ def run_node(node, updatehash, taskid):
     return result
 
 
-class NonDaemonProcess(Process):
+class NonDaemonProcess(mp.Process):
     """A non-daemon process to support internal multiprocessing.
     """
 
@@ -93,7 +94,7 @@ class NonDaemonPool(pool.Pool):
     def Process(self, *args, **kwds):
         if hasattr(self, '_ctx'):
             ctx = self._ctx
-            if isinstance(args[0], multiprocessing.context.BaseContext):
+            if args and isinstance(args[0], mp.context.BaseContext):
                 ctx = args.pop(0)
             process = ctx.Process
             kwds['daemon'] = False

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -90,7 +90,16 @@ class NonDaemonProcess(Process):
 class NonDaemonPool(pool.Pool):
     """A process pool with non-daemon processes.
     """
-    Process = NonDaemonProcess
+    def Process(self, *args, **kwds):
+        if hasattr(self, '_ctx'):
+            ctx = self._ctx
+            if isinstance(args[0], multiprocessing.context.BaseContext):
+                ctx = args.pop(0)
+            process = ctx.Process
+            kwds['daemon'] = False
+        else:
+            process = NonDaemonProcess
+        return process(*args, **kwds)
 
 
 class LegacyMultiProcPlugin(DistributedPluginBase):

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -11,7 +11,6 @@ from __future__ import (print_function, division, unicode_literals,
 
 # Import packages
 import os
-import multiprocessing as mp
 from multiprocessing import Pool, cpu_count, pool
 from traceback import format_exception
 import sys
@@ -80,6 +79,7 @@ class NonDaemonPool(pool.Pool):
     """
     def Process(self, *args, **kwds):
         proc = super(NonDaemonPool, self).Process(*args, **kwds)
+
         class NonDaemonProcess(proc.__class__):
             """Monkey-patch process to ensure it is never daemonized"""
             @property

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -75,32 +75,22 @@ def run_node(node, updatehash, taskid):
     return result
 
 
-class NonDaemonProcess(mp.Process):
-    """A non-daemon process to support internal multiprocessing.
-    """
-
-    def _get_daemon(self):
-        return False
-
-    def _set_daemon(self, value):
-        pass
-
-    daemon = property(_get_daemon, _set_daemon)
-
-
 class NonDaemonPool(pool.Pool):
     """A process pool with non-daemon processes.
     """
     def Process(self, *args, **kwds):
-        if hasattr(self, '_ctx'):
-            ctx = self._ctx
-            if args and isinstance(args[0], mp.context.BaseContext):
-                ctx = args.pop(0)
-            process = ctx.Process
-            kwds['daemon'] = False
-        else:
-            process = NonDaemonProcess
-        return process(*args, **kwds)
+        proc = super(NonDaemonPool, self).Process(*args, **kwds)
+        class NonDaemonProcess(proc.__class__):
+            """Monkey-patch process to ensure it is never daemonized"""
+            @property
+            def daemon(self):
+                return False
+
+            @daemon.setter
+            def daemon(self, val):
+                pass
+        proc.__class__ = NonDaemonProcess
+        return proc
 
 
 class LegacyMultiProcPlugin(DistributedPluginBase):


### PR DESCRIPTION
Fixes #2745.

Python 2.7, 3.4-3.7.0, and 3.7.1 all have different interpretations of `Pool.Process`.

In [Python 2.7](https://github.com/python/cpython/blob/4a59c9699ca8688359c460f98127a12e2db6e63b/Lib/multiprocessing/pool.py#L132-L136), it's a class:

```Python
class Pool(object):
    '''
    Class which supports an async version of the `apply()` builtin
    '''
    Process = Process
```

In [Python 3.4](https://github.com/python/cpython/blob/cd1d5c554c40b5b348de2e77d65986aa154e4477/Lib/multiprocessing/pool.py#L138-L145)-[3.7.0](https://github.com/python/cpython/blob/1bf9cc509326bc42cd8cb1650eb9bf64550d817e/Lib/multiprocessing/pool.py#L146-L153), it's a method that calls `self._ctx.Process`:

```Python
class Pool(object):
    '''
    Class which supports an async version of applying functions to arguments.
    '''
    _wrap_exception = True


    def Process(self, *args, **kwds):
        return self._ctx.Process(*args, **kwds)
```

And now, in [Python 3.7.1](https://github.com/python/cpython/blob/69a3f153a92fd8c86080e8da477ee50df18fc0d1/Lib/multiprocessing/pool.py#L146-L154), it's a static method that takes a context:

```Python
class Pool(object):
    '''
    Class which supports an async version of applying functions to arguments.
    '''
    _wrap_exception = True


    @staticmethod
    def Process(ctx, *args, **kwds):
        return ctx.Process(*args, **kwds)
```