### PR TITLE
FIX: VRML typo (VMRL) in MeshFix

### DIFF
--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -38,10 +38,10 @@ class MeshFixInputSpec(CommandLineInputSpec):
     dont_clean = traits.Bool(argstr='--no-clean', desc="Don't Clean")
 
     save_as_stl = traits.Bool(
-        xor=['save_as_vmrl', 'save_as_freesurfer_mesh'],
+        xor=['save_as_vrml', 'save_as_freesurfer_mesh'],
         argstr='--stl',
         desc="Result is saved in stereolithographic format (.stl)")
-    save_as_vmrl = traits.Bool(
+    save_as_vrml = traits.Bool(
         argstr='--wrl',
         xor=['save_as_stl', 'save_as_freesurfer_mesh'],
         desc="Result is saved in VRML1.0 format (.wrl)")
@@ -210,7 +210,7 @@ class MeshFix(CommandLine):
         if self.inputs.save_as_stl or self.inputs.output_type == 'stl':
             self.inputs.output_type = 'stl'
             self.inputs.save_as_stl = True
-        if self.inputs.save_as_vmrl or self.inputs.output_type == 'vmrl':
-            self.inputs.output_type = 'vmrl'
-            self.inputs.save_as_vmrl = True
+        if self.inputs.save_as_vrml or self.inputs.output_type == 'vrml':
+            self.inputs.output_type = 'vrml'
+            self.inputs.save_as_vrml = True
         return name + '_fixed.' + self.inputs.output_type

--- a/nipype/interfaces/tests/test_auto_MeshFix.py
+++ b/nipype/interfaces/tests/test_auto_MeshFix.py
@@ -67,9 +67,9 @@ def test_MeshFix_inputs():
         ),
         save_as_stl=dict(
             argstr='--stl',
-            xor=['save_as_vmrl', 'save_as_freesurfer_mesh'],
+            xor=['save_as_vrml', 'save_as_freesurfer_mesh'],
         ),
-        save_as_vmrl=dict(
+        save_as_vrml=dict(
             argstr='--wrl',
             xor=['save_as_stl', 'save_as_freesurfer_mesh'],
         ),


### PR DESCRIPTION
## Summary
VRML is a [format](http://www.web3d.org/documents/specifications/19776-2/V3.3/index.html), VMRL doesn't seem to be, so it looks like the opposite of the problem I thought we had in #2755.

@martingrignard can you pull this branch and verify that it resolves your issue?

Fixes #2755.

## List of changes proposed in this PR (pull-request)

* Change `save_as_vmrl` to `save_as_vrml`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
