### PR TITLE
RF: Subclass non-daemon variants of all multiprocessing contexts

### DIFF
--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -73,22 +73,25 @@ def run_node(node, updatehash, taskid):
     # Return the result dictionary
     return result
 
+# Pythons 2.7, 3.4-3.7.0, and 3.7.1 have three different implementations of
+# pool.Pool().Process(), but a common interface, so construct a Process and
+# subclass its __class__
+class NonDaemonProcess(pool.Pool().Process().__class__):
+    @property
+    def daemon(self):
+        return False
+    
+    @daemon.setter
+    def daemon(self, val):
+        pass
+
 
 class NonDaemonPool(pool.Pool):
     """A process pool with non-daemon processes.
     """
     def Process(self, *args, **kwds):
         proc = super(NonDaemonPool, self).Process(*args, **kwds)
-
-        class NonDaemonProcess(proc.__class__):
-            """Monkey-patch process to ensure it is never daemonized"""
-            @property
-            def daemon(self):
-                return False
-
-            @daemon.setter
-            def daemon(self, val):
-                pass
+        # Monkey-patch newly created processes to ensure they are never daemonized
         proc.__class__ = NonDaemonProcess
         return proc
 

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -92,7 +92,7 @@ class NonDaemonPool(pool.Pool):
     def Process(self, *args, **kwds):
         proc = super(NonDaemonPool, self).Process(*args, **kwds)
         # Monkey-patch newly created processes to ensure they are never daemonized
-        proc.__class__ = type('NonDaemonProcess', (NonDaemonMixin, proc.__class__), {})
+        proc.__class__ = type(str('NonDaemonProcess'), (NonDaemonMixin, proc.__class__), {})
         return proc
 
 


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Attempting to pickle `Process`es or `Pool`s directly fails, so I've been unable to figure out how to test pickling except to reproduce the condition that leads to this, which is to run fMRIPrep with the `LegacyMultiProc` plugin. See https://circleci.com/gh/effigies/fmriprep/2200.

Will test by patching into fMRIPrep.

Update: Working as of f1f3845: https://circleci.com/gh/effigies/fmriprep/2224?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Related to #2754, poldracklab/fmriprep#1363 and poldracklab/fmriprep#1368.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Python 2.7: Reverts to file-level `NonDaemonProcess` definition
* Python 3.x: Subclasses all `Process` and `multiprocessing.Context` variants, and selects these variants in `NonDaemonPool`.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
