### PR TITLE
ENH: Create a crashfile even if 'stop_on_first_crash' is set

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -220,9 +220,9 @@ class DistributedPluginBase(PluginBase):
             result = {'result': None,
                       'traceback': '\n'.join(format_exception(*sys.exc_info()))}
 
+        crashfile = self._report_crash(self.procs[jobid], result=result)
         if str2bool(self._config['execution']['stop_on_first_crash']):
             raise RuntimeError("".join(result['traceback']))
-        crashfile = self._report_crash(self.procs[jobid], result=result)
         if jobid in self.mapnodesubids:
             # remove current jobid
             self.proc_pending[jobid] = False

--- a/nipype/pipeline/plugins/linear.py
+++ b/nipype/pipeline/plugins/linear.py
@@ -46,11 +46,11 @@ class LinearPlugin(PluginBase):
                     self._status_callback(node, 'end')
             except:
                 os.chdir(old_wd)
-                if str2bool(config['execution']['stop_on_first_crash']):
-                    raise
                 # bare except, but i really don't know where a
                 # node might fail
                 crashfile = report_crash(node)
+                if str2bool(config['execution']['stop_on_first_crash']):
+                    raise
                 # remove dependencies from queue
                 subnodes = [s for s in dfs_preorder(graph, node)]
                 notrun.append(


### PR DESCRIPTION
This makes error reporting more consistent and helps building apps (such as fmriprep) on top of nipype.