### PR TITLE
[PIN] Force numpy>=1.15.4 when Python>=3.7

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -101,7 +101,9 @@ existing pipeline systems.
 # versions
 NIBABEL_MIN_VERSION = '2.1.0'
 NETWORKX_MIN_VERSION = '1.9'
-NUMPY_MIN_VERSION = '1.9.0'
+# Numpy bug in python 3.7:
+# https://www.opensourceanswers.com/blog/you-shouldnt-use-python-37-for-data-science-right-now.html
+NUMPY_MIN_VERSION = '1.9.0' if sys.version_info < (3, 7) else '1.15.4'
 SCIPY_MIN_VERSION = '0.14'
 TRAITS_MIN_VERSION = '4.6'
 DATEUTIL_MIN_VERSION = '2.2'


### PR DESCRIPTION
Addresses the [numpy
bug](https://www.opensourceanswers.com/blog/you-shouldnt-use-python-37-for-data-science-right-now.html).

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
