### PR TITLE
DOC: use https in css stylesheet url

### DIFF
--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="http://www.google.com/cse/style/look/default.css" type="text/css" />
+<link rel="stylesheet" href="https://www.google.com/cse/style/look/default.css" type="text/css" />
 <style type="text/css">
     a.navbar {
     color: {{ theme_linkcolor }};


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
This PR proposes using https instead of http for the stylesheet https://www.google.com/cse/style/look/default.css. Currently, Chrome 70.0.3538.102 on macOS blocks that stylesheet from being loaded via http, with the error:

> Mixed Content: The page at 'https://nipype.readthedocs.io/en/latest/index.html' was loaded over HTTPS, but requested an insecure stylesheet 'http://www.google.com/cse/style/look/default.css'. This request has been blocked; the content must be served over HTTPS.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Use https instead of http for stylesheet

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
