### PR TITLE
Fix --fineTune arguments order for MeshFix command

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -587,6 +587,11 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "affiliation": "GIGA Institute",
+      "name": "Grignard, Martin",
+      "orcid": "0000-0001-5549-1861"
     }
   ],
   "keywords": [

--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -70,8 +70,7 @@ class MeshFixInputSpec(CommandLineInputSpec):
 
     x_shift = traits.Int(
         argstr='--smooth %d',
-        desc=
-        "Shifts the coordinates of the vertices when saving. Output must be in FreeSurfer format"
+        desc="Shifts the coordinates of the vertices when saving. Output must be in FreeSurfer format"
     )
 
     # Cutting, decoupling, dilation
@@ -80,8 +79,7 @@ class MeshFixInputSpec(CommandLineInputSpec):
         desc="Remove triangles of 1st that are outside of the 2nd shell.")
     cut_inner = traits.Int(
         argstr='--cut-inner %d',
-        desc=
-        "Remove triangles of 1st that are inside of the 2nd shell. Dilate 2nd by N; Fill holes and keep only 1st afterwards."
+        desc="Remove triangles of 1st that are inside of the 2nd shell. Dilate 2nd by N; Fill holes and keep only 1st afterwards."
     )
     decouple_inin = traits.Int(
         argstr='--decouple-inin %d',
@@ -102,7 +100,8 @@ class MeshFixInputSpec(CommandLineInputSpec):
     finetuning_inwards = traits.Bool(
         argstr='--fineTuneIn ',
         requires=['finetuning_distance', 'finetuning_substeps'],
-        position=-3
+        position=-3,
+        desc="Used to fine-tune the minimal distance between surfaces."
     )
     finetuning_outwards = traits.Bool(
         argstr='--fineTuneOut ',

--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -103,7 +103,7 @@ class MeshFixInputSpec(CommandLineInputSpec):
         argstr='--fineTuneIn ',
         requires=['finetuning_distance', 'finetuning_substeps'])
     finetuning_outwards = traits.Bool(
-        argstr='--fineTuneIn ',
+        argstr='--fineTuneOut ',
         requires=['finetuning_distance', 'finetuning_substeps'],
         xor=['finetuning_inwards'],
         desc=

--- a/nipype/interfaces/meshfix.py
+++ b/nipype/interfaces/meshfix.py
@@ -101,23 +101,27 @@ class MeshFixInputSpec(CommandLineInputSpec):
 
     finetuning_inwards = traits.Bool(
         argstr='--fineTuneIn ',
-        requires=['finetuning_distance', 'finetuning_substeps'])
+        requires=['finetuning_distance', 'finetuning_substeps'],
+        position=-3
+    )
     finetuning_outwards = traits.Bool(
         argstr='--fineTuneOut ',
         requires=['finetuning_distance', 'finetuning_substeps'],
+        position=-3,
         xor=['finetuning_inwards'],
-        desc=
-        'Similar to finetuning_inwards, but ensures minimal distance in the other direction'
+        desc='Similar to finetuning_inwards, but ensures minimal distance in the other direction'
     )
     finetuning_distance = traits.Float(
         argstr='%f',
         requires=['finetuning_substeps'],
+        position=-2,
         desc="Used to fine-tune the minimal distance between surfaces."
         "A minimal distance d is ensured, and reached in n substeps. When using the surfaces for subsequent volume meshing by gmsh, this step prevent too flat tetrahedra2)"
     )
     finetuning_substeps = traits.Int(
         argstr='%d',
         requires=['finetuning_distance'],
+        position=-1,
         desc="Used to fine-tune the minimal distance between surfaces."
         "A minimal distance d is ensured, and reached in n substeps. When using the surfaces for subsequent volume meshing by gmsh, this step prevent too flat tetrahedra2)"
     )

--- a/nipype/interfaces/tests/test_auto_MeshFix.py
+++ b/nipype/interfaces/tests/test_auto_MeshFix.py
@@ -27,7 +27,7 @@ def test_MeshFix_inputs():
             requires=['finetuning_distance', 'finetuning_substeps'],
         ),
         finetuning_outwards=dict(
-            argstr='--fineTuneIn ',
+            argstr='--fineTuneOut ',
             requires=['finetuning_distance', 'finetuning_substeps'],
             xor=['finetuning_inwards'],
         ),
@@ -89,6 +89,8 @@ def test_MeshFix_inputs():
     for key, metadata in list(input_map.items()):
         for metakey, value in list(metadata.items()):
             assert getattr(inputs.traits()[key], metakey) == value
+
+
 def test_MeshFix_outputs():
     output_map = dict(mesh_file=dict(), )
     outputs = MeshFix.output_spec()


### PR DESCRIPTION
## Summary
This PR allows to use `--fineTuneIn` and `--fineTuneOut` instrutions from MeshFix input spec.

Fixes #2770 .

## List of changes proposed in this PR (pull-request)
- Add description to `--fineTuneIn` MeshFix input spec.
- Set the order of the `--fineTuneIn` and `--fineTuneOut` MeshFix arguments.
- Fix the fact that the command for `--fineTuneOut` was actually `--fineTuneIn` due to a copy-paste.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
