### PR TITLE
[MAINT] Reduce minimal code redundancy in filemanip.get_dependencies

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -888,14 +888,21 @@ def get_dependencies(name, environ):
     else:
         return 'Platform %s not supported' % sys.platform
 
-    proc = sp.Popen(
-        command,
-        stdout=sp.PIPE,
-        stderr=sp.PIPE,
-        shell=True,
-        env=environ)
-    o, e = proc.communicate()
-    return o.rstrip()
+    deps = None
+    try:
+        proc = sp.Popen(
+            command,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            shell=True,
+            env=environ)
+        o, e = proc.communicate()
+        deps = o.rstrip()
+    except Exception as ex:
+        deps = '"%s" failed' % command
+        fmlogger.warning('Could not get dependencies of %s. Error:\n%s',
+                         name, ex.message)
+    return deps
 
 
 def canonicalize_env(env):

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -880,22 +880,20 @@ def get_dependencies(name, environ):
     Uses otool on darwin, ldd on linux. Currently doesn't support windows.
 
     """
+    command = None
     if sys.platform == 'darwin':
-        proc = sp.Popen(
-            'otool -L `which %s`' % name,
-            stdout=sp.PIPE,
-            stderr=sp.PIPE,
-            shell=True,
-            env=environ)
+        command = 'otool -L `which %s`' % name
     elif 'linux' in sys.platform:
-        proc = sp.Popen(
-            'ldd `which %s`' % name,
-            stdout=sp.PIPE,
-            stderr=sp.PIPE,
-            shell=True,
-            env=environ)
+        command = 'ldd `which %s`' % name
     else:
         return 'Platform %s not supported' % sys.platform
+
+    proc = sp.Popen(
+        command,
+        stdout=sp.PIPE,
+        stderr=sp.PIPE,
+        shell=True,
+        env=environ)
     o, e = proc.communicate()
     return o.rstrip()
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
A very minimal cleanup of code duplication, and protection for a more reliable execution (basically don't stop nipype if get_dependencies failed).

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
