### PR TITLE
[FIX] MapNodes fail when ``MultiProcPlugin`` passed by instance

### DIFF
--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -566,6 +566,8 @@ connected.
             plugin = config.get('execution', 'plugin')
         if not isinstance(plugin, (str, bytes)):
             runner = plugin
+            plugin = runner.__class__.__name__[:-len('Plugin')]
+            plugin_args = runner.plugin_args
         else:
             name = '.'.join(__name__.split('.')[:-2] + ['plugins'])
             try:


### PR DESCRIPTION
When calling ``workflow.run(plugin=MultiProcPlugin())``, MapNodes are set the ``use_plugin`` member that is not pickleable if ``plugin`` is a ``MultiProcPlugin`` object.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
