### PR TITLE
[MAINT] Stop using deprecated ``logger.warn()``

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -327,7 +327,7 @@ Bradley L. and Petersen, Steven E.},
                 tr = self.inputs.series_tr
 
             if self.inputs.normalize and tr is None:
-                IFLOGGER.warn('FD plot cannot be normalized if TR is not set')
+                IFLOGGER.warning('FD plot cannot be normalized if TR is not set')
 
             self._results['out_figure'] = op.abspath(self.inputs.out_figure)
             fig = plot_confound(
@@ -1267,7 +1267,7 @@ def _full_rank(X, cmax=1e15):
     c = smax / smin
     if c < cmax:
         return X, c
-    IFLOGGER.warn('Matrix is singular at working precision, regularizing...')
+    IFLOGGER.warning('Matrix is singular at working precision, regularizing...')
     lda = (smax - cmax * smin) / (cmax - 1)
     s = s + lda
     X = np.dot(U, np.dot(np.diag(s), V))

--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -422,5 +422,5 @@ class P2PDistance(ComputeMeshWarp):
 
     def __init__(self, **inputs):
         super(P2PDistance, self).__init__(**inputs)
-        IFLOGGER.warn('This interface has been deprecated since 1.0, please '
-                      'use ComputeMeshWarp')
+        IFLOGGER.warning('This interface has been deprecated since 1.0, please '
+                         'use ComputeMeshWarp')

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -589,7 +589,7 @@ class MergeCSVFiles(BaseInterface):
             extraheadingBool = True
 
         if len(self.inputs.in_files) == 1:
-            iflogger.warn('Only one file input!')
+            iflogger.warning('Only one file input!')
 
         if isdefined(self.inputs.row_headings):
             iflogger.info('Row headings have been provided. Adding "labels"'

--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -602,7 +602,7 @@ class SpecifySPMModel(SpecifyModel):
                 try:
                     out = np.loadtxt(filename)
                 except IOError:
-                    iflogger.warn('Error reading outliers file %s', filename)
+                    iflogger.warning('Error reading outliers file %s', filename)
                     out = np.array([])
 
                 if out.size > 0:

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -1180,8 +1180,8 @@ class LibraryBaseInterface(BaseInterface):
                 except ImportError:
                     failed_imports.append(pkg)
             if failed_imports:
-                iflogger.warn('Unable to import %s; %s interface may fail to '
-                              'run', failed_imports, self.__class__.__name__)
+                iflogger.warning('Unable to import %s; %s interface may fail to '
+                                 'run', failed_imports, self.__class__.__name__)
 
     @property
     def version(self):

--- a/nipype/interfaces/dipy/reconstruction.py
+++ b/nipype/interfaces/dipy/reconstruction.py
@@ -124,9 +124,9 @@ class RESTORE(DipyDiffusionInterface):
         sigma = mean_std * (1 + bias)
 
         if sigma == 0:
-            IFLOGGER.warn('Noise std is 0.0, looks like data was masked and '
-                          'noise cannot be estimated correctly. Using default '
-                          'tensor model instead of RESTORE.')
+            IFLOGGER.warning('Noise std is 0.0, looks like data was masked and '
+                             'noise cannot be estimated correctly. Using default '
+                             'tensor model instead of RESTORE.')
             dti = TensorModel(gtab)
         else:
             IFLOGGER.info('Performing RESTORE with noise std=%.4f.', sigma)
@@ -258,11 +258,11 @@ class EstimateResponseSH(DipyDiffusionInterface):
             ratio = abs(response[1] / response[0])
 
         if ratio > 0.25:
-            IFLOGGER.warn('Estimated response is not prolate enough. '
-                          'Ratio=%0.3f.', ratio)
+            IFLOGGER.warning('Estimated response is not prolate enough. '
+                             'Ratio=%0.3f.', ratio)
         elif ratio < 1.e-5 or np.any(np.isnan(response)):
             response = np.array([1.8e-3, 3.6e-4, 3.6e-4, S0])
-            IFLOGGER.warn(
+            IFLOGGER.warning(
                 'Estimated response is not valid, using a default one')
         else:
             IFLOGGER.info('Estimated response: %s', str(response[:3]))
@@ -344,8 +344,8 @@ class CSD(DipyDiffusionInterface):
         ratio = response[0][1] / response[0][0]
 
         if abs(ratio - 0.2) > 0.1:
-            IFLOGGER.warn('Estimated response is not prolate enough. '
-                          'Ratio=%0.3f.', ratio)
+            IFLOGGER.warning('Estimated response is not prolate enough. '
+                             'Ratio=%0.3f.', ratio)
 
         csd_model = ConstrainedSphericalDeconvModel(
             gtab, response, sh_order=self.inputs.sh_order)

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -73,8 +73,8 @@ class TrackDensityMap(DipyBaseInterface):
             data_dims = refnii.shape[:3]
             kwargs = dict(affine=affine)
         else:
-            IFLOGGER.warn('voxel_dims and data_dims are deprecated as of dipy '
-                          '0.7.1. Please use reference input instead')
+            IFLOGGER.warning('voxel_dims and data_dims are deprecated as of dipy '
+                             '0.7.1. Please use reference input instead')
 
             if not isdefined(self.inputs.data_dims):
                 data_dims = header['dim']

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -316,8 +316,8 @@ class SampleToSurface(FSCommand):
                             "Cannot create {} file with extension "
                             "{}".format(value, ext))
                     else:
-                        logger.warn('Creating %s file with extension %s: %s%s',
-                                    value, ext, base, ext)
+                        logger.warning('Creating %s file with extension %s: %s%s',
+                                       value, ext, base, ext)
 
             if value in implicit_filetypes:
                 return ""
@@ -554,8 +554,8 @@ class SurfaceTransform(FSCommand):
                             "Cannot create {} file with extension "
                             "{}".format(value, ext))
                     else:
-                        logger.warn('Creating %s file with extension %s: %s%s',
-                                    value, ext, base, ext)
+                        logger.warning('Creating %s file with extension %s: %s%s',
+                                       value, ext, base, ext)
             if value in implicit_filetypes:
                 return ""
         return super(SurfaceTransform, self)._format_arg(name, spec, value)

--- a/nipype/interfaces/fsl/base.py
+++ b/nipype/interfaces/fsl/base.py
@@ -107,8 +107,8 @@ class Info(PackageInfo):
         try:
             return os.environ['FSLOUTPUTTYPE']
         except KeyError:
-            IFLOGGER.warn('FSLOUTPUTTYPE environment variable is not set. '
-                          'Setting FSLOUTPUTTYPE=NIFTI')
+            IFLOGGER.warning('FSLOUTPUTTYPE environment variable is not set. '
+                             'Setting FSLOUTPUTTYPE=NIFTI')
             return 'NIFTI'
 
     @staticmethod

--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -77,7 +77,7 @@ class MRTrix3Base(CommandLine):
                 from multiprocessing import cpu_count
                 value = cpu_count()
             except:
-                iflogger.warn('Number of threads could not be computed')
+                iflogger.warning('Number of threads could not be computed')
                 pass
             return trait_spec.argstr % value
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -471,7 +471,7 @@ def copyfile(originalfile,
             fmlogger.debug('Copying File: %s->%s', newfile, originalfile)
             shutil.copyfile(originalfile, newfile)
         except shutil.Error as e:
-            fmlogger.warn(e.message)
+            fmlogger.warning(e.message)
 
     # Associated files
     if copy_related_files:


### PR DESCRIPTION
Trying to avoid:

```
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
