### PR TITLE
Revert "[FIX] MapNodes fail when ``MultiProcPlugin`` passed by instance"

### DIFF
--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -566,8 +566,6 @@ connected.
             plugin = config.get('execution', 'plugin')
         if not isinstance(plugin, (str, bytes)):
             runner = plugin
-            plugin = runner.__class__.__name__[:-len('Plugin')]
-            plugin_args = runner.plugin_args
         else:
             name = '.'.join(__name__.split('.')[:-2] + ['plugins'])
             try:


### PR DESCRIPTION
Reverts nipy/nipype#2786