### PR TITLE
REL: 1.1.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,8 +360,11 @@ jobs:
           name: Validate Python 3.7 installation
           command: |
             pyenv local 3.7.0
+            pip install --upgrade pip
+            # Pre-install a version of numpy that will not pass
+            pip install numpy==1.15.0
             pip install dist/nipype-*-py2.py3-none-any.whl
-            # Futures should not install in Python 3
+            # Numpy should be upgraded to >= 1.15.3
             test "$(pip show numpy | grep Version)" \> "Version: 1.15.2"
       - store_artifacts:
           path: /home/circleci/nipype/dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 _machine_kwds: &machine_kwds
-  image: circleci/classic:201710-02
+  image: circleci/classic:201808-01
 
 _store_artifacts_kwds: &store_artifacts_kwds
   path: /home/circleci/work/tests
@@ -356,6 +356,13 @@ jobs:
             pip install dist/nipype-*-py2.py3-none-any.whl
             # Futures should not install in Python 3
             test $(pip show futures 2>/dev/null | wc -l) = "0"
+      - run:
+          name: Validate Python 3.7 installation
+          command: |
+            pyenv local 3.7.0
+            pip install dist/nipype-*-py2.py3-none-any.whl
+            # Futures should not install in Python 3
+            test "$(pip show numpy | grep Version)" \> "Version: 1.15.2"
       - store_artifacts:
           path: /home/circleci/nipype/dist
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -457,9 +457,6 @@
       "orcid": "0000-0001-9030-2202"
     },
     {
-      "name": "Mertz, Fred"
-    },
-    {
       "affiliation": "Technische Universit\u00e4t Dresden, Faculty of Medicine, Department of Child and Adolescent Psychiatry",
       "name": "Geisler, Daniel",
       "orcid": "0000-0003-2076-5329"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -381,6 +381,11 @@
       "name": "Hallquist, Michael"
     },
     {
+      "affiliation": "GIGA Institute",
+      "name": "Grignard, Martin",
+      "orcid": "0000-0001-5549-1861"
+    },
+    {
       "affiliation": "Donders Institute for Brain, Cognition and Behavior, Center for Cognitive Neuroimaging",
       "name": "Chetverikov, Andrey",
       "orcid": "0000-0003-2767-6310"
@@ -455,9 +460,6 @@
       "name": "Mertz, Fred"
     },
     {
-      "name": "Haehn, Daniel"
-    },
-    {
       "affiliation": "Technische Universit\u00e4t Dresden, Faculty of Medicine, Department of Child and Adolescent Psychiatry",
       "name": "Geisler, Daniel",
       "orcid": "0000-0003-2076-5329"
@@ -480,6 +482,9 @@
       "affiliation": "Technical University Munich",
       "name": "Molina-Romero, Miguel",
       "orcid": "0000-0001-8054-0426"
+    },
+    {
+      "name": "Haehn, Daniel"
     },
     {
       "name": "Weinstein, Alejandro"
@@ -587,11 +592,6 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    },
-    {
-      "affiliation": "GIGA Institute",
-      "name": "Grignard, Martin",
-      "orcid": "0000-0001-5549-1861"
     }
   ],
   "keywords": [

--- a/doc/changelog/1.X.X-changelog
+++ b/doc/changelog/1.X.X-changelog
@@ -1,3 +1,20 @@
+1.1.6 (November 26, 2018)
+=========================
+
+  * [FIX] MapNodes fail when ``MultiProcPlugin`` passed by instance (https://github.com/nipy/nipype/pull/2786)
+  * [FIX] --fineTune arguments order for MeshFix command (https://github.com/nipy/nipype/pull/2780)
+  * [ENH] Add mp_context plugin arg for MultiProc (https://github.com/nipy/nipype/pull/2778)
+  * [ENH] Create a crashfile even if 'stop_on_first_crash' is set (https://github.com/nipy/nipype/pull/2774)
+  * [DOC] use https in css stylesheet url (https://github.com/nipy/nipype/pull/2779)
+  * [MAINT] Outsource ``get_filecopy_info()`` from interfaces (https://github.com/nipy/nipype/pull/2798)
+  * [MAINT] Import only Sequence to avoid DeprecationWarning (https://github.com/nipy/nipype/pull/2793)
+  * [MAINT] One less DeprecationWarning (configparser) (https://github.com/nipy/nipype/pull/2794)
+  * [MAINT] DeprecationWarning: use ``HasTraits.trait_set`` instead (https://github.com/nipy/nipype/pull/2792)
+  * [MAINT] Stop using deprecated ``logger.warn()`` (https://github.com/nipy/nipype/pull/2788)
+  * [MAINT] Move ``interfaces.base.run_command`` to ``nipype.utils.subprocess`` (https://github.com/nipy/nipype/pull/2777)
+  * [MAINT] Force numpy>=1.15.4 when Python>=3.7 (https://github.com/nipy/nipype/pull/2775)
+
+
 1.1.5 (November 08, 2018)
 =========================
 

--- a/doc/changelog/1.X.X-changelog
+++ b/doc/changelog/1.X.X-changelog
@@ -1,10 +1,14 @@
 1.1.6 (November 26, 2018)
 =========================
 
+##### [Full changelog](https://github.com/nipy/nipype/milestone/27?closed=1)
+
   * [FIX] MapNodes fail when ``MultiProcPlugin`` passed by instance (https://github.com/nipy/nipype/pull/2786)
   * [FIX] --fineTune arguments order for MeshFix command (https://github.com/nipy/nipype/pull/2780)
   * [ENH] Add mp_context plugin arg for MultiProc (https://github.com/nipy/nipype/pull/2778)
   * [ENH] Create a crashfile even if 'stop_on_first_crash' is set (https://github.com/nipy/nipype/pull/2774)
+  * [ENH] Add ExtractedBrainN4 output to ANTs CorticalThickness interface (https://github.com/nipy/nipype/pull/2784)
+  * [STY] Combine split import (https://github.com/nipy/nipype/pull/2801)
   * [DOC] use https in css stylesheet url (https://github.com/nipy/nipype/pull/2779)
   * [MAINT] Outsource ``get_filecopy_info()`` from interfaces (https://github.com/nipy/nipype/pull/2798)
   * [MAINT] Import only Sequence to avoid DeprecationWarning (https://github.com/nipy/nipype/pull/2793)

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -136,7 +136,7 @@ PROVIDES = ['nipype']
 REQUIRES = [
     'nibabel>=%s' % NIBABEL_MIN_VERSION,
     'networkx>=%s' % NETWORKX_MIN_VERSION,
-    'numpy>=%s' % NUMPY_MIN_VERSION,
+    'numpy>=%s ; python_version < "3.7"' % NUMPY_MIN_VERSION,
     'numpy>=%s ; python_version >= "3.7"' % NUMPY_MIN_VERSION_37,
     'python-dateutil>=%s' % DATEUTIL_MIN_VERSION,
     'scipy>=%s' % SCIPY_MIN_VERSION,

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -101,9 +101,10 @@ existing pipeline systems.
 # versions
 NIBABEL_MIN_VERSION = '2.1.0'
 NETWORKX_MIN_VERSION = '1.9'
+NUMPY_MIN_VERSION = '1.9.0'
 # Numpy bug in python 3.7:
 # https://www.opensourceanswers.com/blog/you-shouldnt-use-python-37-for-data-science-right-now.html
-NUMPY_MIN_VERSION = '1.9.0' if sys.version_info < (3, 7) else '1.15.4'
+NUMPY_MIN_VERSION_37 = '1.15.3'
 SCIPY_MIN_VERSION = '0.14'
 TRAITS_MIN_VERSION = '4.6'
 DATEUTIL_MIN_VERSION = '2.2'
@@ -136,6 +137,7 @@ REQUIRES = [
     'nibabel>=%s' % NIBABEL_MIN_VERSION,
     'networkx>=%s' % NETWORKX_MIN_VERSION,
     'numpy>=%s' % NUMPY_MIN_VERSION,
+    'numpy>=%s ; python_version >= "3.7"' % NUMPY_MIN_VERSION_37,
     'python-dateutil>=%s' % DATEUTIL_MIN_VERSION,
     'scipy>=%s' % SCIPY_MIN_VERSION,
     'traits>=%s' % TRAITS_MIN_VERSION,

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -11,7 +11,7 @@ import sys
 # full release.  '.dev' as a version_extra string means this is a development
 # version
 # Remove -dev for release
-__version__ = '1.1.6-dev'
+__version__ = '1.1.6'
 
 
 def get_nipype_gitversion():

--- a/nipype/interfaces/tests/test_auto_MeshFix.py
+++ b/nipype/interfaces/tests/test_auto_MeshFix.py
@@ -20,19 +20,23 @@ def test_MeshFix_inputs():
         epsilon_angle=dict(argstr='-a %f', ),
         finetuning_distance=dict(
             argstr='%f',
+            position=-2,
             requires=['finetuning_substeps'],
         ),
         finetuning_inwards=dict(
             argstr='--fineTuneIn ',
+            position=-3,
             requires=['finetuning_distance', 'finetuning_substeps'],
         ),
         finetuning_outwards=dict(
             argstr='--fineTuneOut ',
+            position=-3,
             requires=['finetuning_distance', 'finetuning_substeps'],
             xor=['finetuning_inwards'],
         ),
         finetuning_substeps=dict(
             argstr='%d',
+            position=-1,
             requires=['finetuning_distance'],
         ),
         in_file1=dict(
@@ -89,8 +93,6 @@ def test_MeshFix_inputs():
     for key, metadata in list(input_map.items()):
         for metakey, value in list(metadata.items()):
             assert getattr(inputs.traits()[key], metakey) == value
-
-
 def test_MeshFix_outputs():
     output_map = dict(mesh_file=dict(), )
     outputs = MeshFix.output_spec()


### PR DESCRIPTION
## Summary

Prep for 1.1.6 release, targeting Monday, November 26.

## Release checklist

* [x] Update changelog
* [x] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py` and `doc/conf.py`
* [x] Update `doc/documentation.rst` with previous releases
* [x] Tutorial tests (@djarecka)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.