### PR TITLE
[FIX] ``status_callback`` not called with ``stop_on_first_crash``

### DIFF
--- a/nipype/pipeline/plugins/linear.py
+++ b/nipype/pipeline/plugins/linear.py
@@ -36,16 +36,15 @@ class LinearPlugin(PluginBase):
         donotrun = []
         nodes, _ = topological_sort(graph)
         for node in nodes:
+            endstatus = 'end'
             try:
                 if node in donotrun:
                     continue
                 if self._status_callback:
                     self._status_callback(node, 'start')
                 node.run(updatehash=updatehash)
-                if self._status_callback:
-                    self._status_callback(node, 'end')
             except:
-                os.chdir(old_wd)
+                endstatus = 'exception'
                 # bare except, but i really don't know where a
                 # node might fail
                 crashfile = report_crash(node)
@@ -53,9 +52,16 @@ class LinearPlugin(PluginBase):
                     raise
                 # remove dependencies from queue
                 subnodes = [s for s in dfs_preorder(graph, node)]
-                notrun.append(
-                    dict(node=node, dependents=subnodes, crashfile=crashfile))
+                notrun.append({'node': node, 'dependents': subnodes,
+                               'crashfile': crashfile})
                 donotrun.extend(subnodes)
+                # Delay raising the crash until we cleaned the house
+                if str2bool(config['execution']['stop_on_first_crash']):
+                    report_nodes_not_run(notrun)  # report before raising
+                    raise
+            finally:
+                # Return wherever we were before
+                os.chdir(old_wd)
                 if self._status_callback:
-                    self._status_callback(node, 'exception')
+                    self._status_callback(node, endstatus)
         report_nodes_not_run(notrun)

--- a/nipype/pipeline/plugins/linear.py
+++ b/nipype/pipeline/plugins/linear.py
@@ -57,11 +57,12 @@ class LinearPlugin(PluginBase):
                 donotrun.extend(subnodes)
                 # Delay raising the crash until we cleaned the house
                 if str2bool(config['execution']['stop_on_first_crash']):
+                    os.chdir(old_wd)  # Return wherever we were before
                     report_nodes_not_run(notrun)  # report before raising
                     raise
             finally:
-                # Return wherever we were before
-                os.chdir(old_wd)
                 if self._status_callback:
                     self._status_callback(node, endstatus)
+
+        os.chdir(old_wd)  # Return wherever we were before
         report_nodes_not_run(notrun)


### PR DESCRIPTION
Some tests were randomly failing in Travis for the Linear plugin. My
suspiction is that some other test changed the configuration of
``stop_on_first_crash`` and depending on the ordering tests were
actually run, this test would sometimes fail, apparently at random.

The tests have been expanded to test also LegacyMultiProc and to check
under both conditions (stop_on_first_crash on/off).

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
