### PR TITLE
[ENH] add option to include derivatives in BIDSDataGrabber

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2847,7 +2847,7 @@ class BIDSDataGrabber(IOBase):
         exclude = None
         if self.inputs.strict:
             exclude = ['derivatives/', 'code/', 'sourcedata/']
-        
+
         if pybids_ver < version.parse('0.5'):
             raise ImportError("pybids must be >= 0.5, "
             "installed version: {ver}".format(ver=pybids_ver))
@@ -2859,7 +2859,7 @@ class BIDSDataGrabber(IOBase):
             # pybids >= 0.6.0
             if self.inputs.domains is None:
                 self.inputs.domains = ['bids']
-            layout = bidslayout.BIDSLayout((self.inputs.base_dir, self.inputs.domains), 
+            layout = bidslayout.BIDSLayout((self.inputs.base_dir, self.inputs.domains),
                                            exclude=exclude)
 
         # If infield is not given nm input value, silently ignore

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2820,7 +2820,7 @@ class BIDSDataGrabber(LibraryBaseInterface, IOBase):
         except ImportError:
             from bids.grabbids import BIDSLayout
 
-       pybids_ver = version.parse(bids.__version__)
+        pybids_ver = version.parse(bids.__version__)
         exclude = None
         if self.inputs.strict:
             exclude = ['derivatives/', 'code/', 'sourcedata/']

--- a/nipype/interfaces/tests/test_auto_BIDSDataGrabber.py
+++ b/nipype/interfaces/tests/test_auto_BIDSDataGrabber.py
@@ -6,6 +6,7 @@ from ..io import BIDSDataGrabber
 def test_BIDSDataGrabber_inputs():
     input_map = dict(
         base_dir=dict(mandatory=True, ),
+        domains=dict(usedefault=True, ),
         output_query=dict(),
         raise_on_empty=dict(usedefault=True, ),
         return_type=dict(usedefault=True, ),


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
The behavior of pybids changed from `0.5.*` to `0.6.*` such that the derivatives domain is not included in the default search pattern.
Fixes #2814

This pull request is partially overlapping with #2737

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- add `domains` option in BIDSDataGrabber for user to select what domains should be used for indexing files
- add checks to modify behavior depending on which version of pybids is being used.
## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
