### PR TITLE
FIX: Order of SPM.NewSegment channel_info boolean tuple is (Field, Corrected)

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1487,7 +1487,7 @@ class NewSegmentInputSpec(SPMCommandInputSpec):
         desc="""A tuple with the following fields:
             - bias reguralisation (0-10)
             - FWHM of Gaussian smoothness of bias
-            - which maps to save (Corrected, Field) - a tuple of two boolean values""",
+            - which maps to save (Field, Corrected) - a tuple of two boolean values""",
         field='channel')
     tissues = traits.List(
         traits.Tuple(
@@ -1681,11 +1681,11 @@ class NewSegment(SPMCommand):
 
             if isdefined(self.inputs.channel_info):
                 if self.inputs.channel_info[2][0]:
-                    outputs['bias_corrected_images'].append(
-                        os.path.join(pth, "m%s.nii" % (base)))
-                if self.inputs.channel_info[2][1]:
                     outputs['bias_field_images'].append(
                         os.path.join(pth, "BiasField_%s.nii" % (base)))
+                if self.inputs.channel_info[2][1]:
+                    outputs['bias_corrected_images'].append(
+                        os.path.join(pth, "m%s.nii" % (base)))
         return outputs
 
 


### PR DESCRIPTION

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
* In SPM12, for Segment module (the NewSegment in Nipype), the spm.spatial.preproc.channel.write parameter (SPM's Save Bias Corrected parameter) takes [Save Bias Field = 0 or 1, Save Bias Corrected = 0 or 1]. In nypipe the initialisation of the outputs bias_field_images and bias_corrected_images are done with the inverse order. 

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* This commit fix this inconsistency.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
