### PR TITLE
ENH: Add FSL `eddy_quad` interface

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -594,7 +594,7 @@
       "affiliation": "University of Washington",
       "name": "Richie-Halford, Adam",
       "orcid": "0000-0001-9276-9084"
-    },
+    }
   ],
   "keywords": [
     "neuroimaging",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -589,7 +589,12 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    }
+    },
+    {
+      "affiliation": "University of Washington",
+      "name": "Richie-Halford, Adam",
+      "orcid": "0000-0001-9276-9084"
+    },
   ],
   "keywords": [
     "neuroimaging",

--- a/nipype/interfaces/fsl/__init__.py
+++ b/nipype/interfaces/fsl/__init__.py
@@ -21,7 +21,7 @@ from .utils import (
     WarpPointsFromStd, RobustFOV, CopyGeom, MotionOutliers)
 
 from .epi import (PrepareFieldmap, TOPUP, ApplyTOPUP, Eddy, EPIDeWarp, SigLoss,
-                  EddyCorrect, EpiReg)
+                  EddyCorrect, EpiReg, EddyQuad)
 from .dti import (BEDPOSTX, XFibres, DTIFit, ProbTrackX, ProbTrackX2, VecReg,
                   ProjThresh, FindTheBiggest, DistanceMap, TractSkeleton,
                   MakeDyadicVectors, BEDPOSTX5, XFibres5)

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1385,7 +1385,14 @@ class EddyQuad(FSLCommand):
     def _list_outputs(self):
         from glob import glob
         outputs = self.output_spec().get()
-        out_dir = os.path.abspath(self.inputs.output_dir)
+
+        # If the output directory isn't defined, the interface seems to use
+        # the default but not set its value in `self.inputs.output_dir`
+        if not isdefined(self.inputs.output_dir):
+            out_dir = os.path.abspath(self.inputs.base_name + '.qc.nii.gz')
+        else:
+            out_dir = os.path.abspath(self.inputs.output_dir)
+
         outputs['out_qc_json'] = os.path.join(out_dir, 'qc.json')
         outputs['out_qc_pdf'] = os.path.join(out_dir, 'qc.pdf')
 

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1389,11 +1389,6 @@ class EddyQuad(FSLCommand):
         outputs['out_qc_json'] = os.path.join(out_dir, 'qc.json')
         outputs['out_qc_pdf'] = os.path.join(out_dir, 'qc.pdf')
 
-        outputs['out_avg_b_png'] = [
-            os.path.join(out_dir, 'avg_b{bval:d}.png'.format(bval=bval))
-            for bval in list(set([0] + qc.get('data_unique_bvals')))
-        ]
-
         # Grab all b* files here. This will also grab the b0_pe* files
         # as well, but only if the field input was provided. So we'll remove
         # them later in the next conditional.

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1378,21 +1378,19 @@ class EddyQuad(FSLCommand):
 
     >>> from nipype.interfaces.fsl import EddyQuad
     >>> quad = EddyQuad()
-    >>> quad.inputs.in_file = 'epi.nii'
-    >>> quad.inputs.in_mask  = 'epi_mask.nii'
-    >>> quad.inputs.in_index = 'epi_index.txt'
-    >>> quad.inputs.in_acqp  = 'epi_acqp.txt'
-    >>> quad.inputs.in_bvec  = 'bvecs.scheme'
-    >>> quad.inputs.in_bval  = 'bvals.scheme'
-    >>> quad.inputs.use_cuda = True
+    >>> quad.inputs.base_name  = 'eddy_corrected'
+    >>> quad.inputs.idx_file   = 'index.txt'
+    >>> quad.inputs.param_file = 'encfile.txt'
+    >>> quad.inputs.mask_file  = 'mask.nii.gz'
+    >>> quad.inputs.bval_file  = 'dwi.bval'
+    >>> quad.inputs.bvec_file  = 'dwi.bvec'
+    >>> quad.inputs.output_dir = 'eddy_corrected.qc'
+    >>> quad.inputs.field      = 'field.nii.gz'
+    >>> quad.verbose           = True
     >>> quad.cmdline # doctest: +ELLIPSIS
-    'eddy_cuda --ff=10.0 --acqp=epi_acqp.txt --bvals=bvals.scheme \
---bvecs=bvecs.scheme --imain=epi.nii --index=epi_index.txt \
---mask=epi_mask.nii --niter=5 --nvoxhp=1000 --out=.../eddy_corrected'
-    >>> quad.cmdline # doctest: +ELLIPSIS
-    'eddy_openmp --ff=10.0 --acqp=epi_acqp.txt --bvals=bvals.scheme \
---bvecs=bvecs.scheme --imain=epi.nii --index=epi_index.txt \
---mask=epi_mask.nii --niter=5 --nvoxhp=1000 --out=.../eddy_corrected'
+    'eddy_quad eddy_corrected --eddyIdx=index.txt --eddyParams=encfile.txt \
+--mask=mask.nii.gz --bvals=dwi.bval --bvecs=dwi.bvec \
+--output-dir=eddy_corrected.qc --field=field.nii.gz --verbose'
     >>> res = quad.run() # doctest: +SKIP
 
     """

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1281,15 +1281,16 @@ class EddyQuadInputSpec(FSLCommandInputSpec):
         desc="Output directory - default = '<base_name>.qc'",
     )
     field = File(
+        exists=True,
         argstr='--field=%s',
         desc="TOPUP estimated field (in Hz)",
     )
     slice_spec = File(
+        exists=True,
         argstr='--slspec=%s',
         desc="Text file specifying slice/group acquisition",
     )
     verbose = traits.Bool(
-        False,
         argstr='--verbose',
         desc="Display debug messages",
     )
@@ -1301,45 +1302,38 @@ class EddyQuadOutputSpec(TraitedSpec):
         desc=("Single subject database containing quality metrics and data "
               "info.")
     )
-
     out_qc_pdf = File(
         exists=True,
         desc="Single subject QC report."
     )
-
     out_avg_b_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each averaged b-shell volume.")
     )
-
     out_avg_b0_pe_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each averaged pe-direction b0 volume. Generated when using "
               "the -f option.")
     )
-
     out_cnr_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each b-shell CNR volume. Generated when CNR maps are "
               "available.")
     )
-
     out_vdm_png = File(
         exists=True,
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "the voxel displacement map. Generated when using the -f "
               "option.")
     )
-
     out_residuals = File(
         exists=True,
         desc=("Text file containing the volume-wise mask-averaged squared "
               "residuals. Generated when residual maps are available.")
     )
-
     out_clean_volumes = File(
         exists=True,
         desc=("Text file containing a list of clean volumes, based on "
@@ -1370,7 +1364,7 @@ class EddyQuad(FSLCommand):
     >>> quad.inputs.output_dir = 'eddy_corrected.qc'
     >>> quad.inputs.field      = 'fieldmap_phase_fslprepared.nii'
     >>> quad.inputs.verbose    = True
-    >>> quad.cmdline # doctest: +ELLIPSIS
+    >>> quad.cmdline
     'eddy_quad eddy_corrected --bvals=bvals.scheme --bvecs=bvecs.scheme \
 --field=fieldmap_phase_fslprepared.nii --eddyIdx=epi_index.txt \
 --mask=epi_mask.nii --output-dir=eddy_corrected.qc --eddyParams=epi_acqp.txt \

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1297,44 +1297,44 @@ class EddyQuadInputSpec(FSLCommandInputSpec):
 
 
 class EddyQuadOutputSpec(TraitedSpec):
-    out_qc_json = File(
+    qc_json = File(
         exists=True,
         desc=("Single subject database containing quality metrics and data "
               "info.")
     )
-    out_qc_pdf = File(
+    qc_pdf = File(
         exists=True,
         desc="Single subject QC report."
     )
-    out_avg_b_png = traits.List(
+    avg_b_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each averaged b-shell volume.")
     )
-    out_avg_b0_pe_png = traits.List(
+    avg_b0_pe_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each averaged pe-direction b0 volume. Generated when using "
               "the -f option.")
     )
-    out_cnr_png = traits.List(
+    cnr_png = traits.List(
         File(exists=True),
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "each b-shell CNR volume. Generated when CNR maps are "
               "available.")
     )
-    out_vdm_png = File(
+    vdm_png = File(
         exists=True,
         desc=("Image showing mid-sagittal, -coronal and -axial slices of "
               "the voxel displacement map. Generated when using the -f "
               "option.")
     )
-    out_residuals = File(
+    residuals = File(
         exists=True,
         desc=("Text file containing the volume-wise mask-averaged squared "
               "residuals. Generated when residual maps are available.")
     )
-    out_clean_volumes = File(
+    clean_volumes = File(
         exists=True,
         desc=("Text file containing a list of clean volumes, based on "
               "the eddy squared residuals. To generate a version of the "
@@ -1387,38 +1387,38 @@ class EddyQuad(FSLCommand):
         else:
             out_dir = os.path.abspath(self.inputs.output_dir)
 
-        outputs['out_qc_json'] = os.path.join(out_dir, 'qc.json')
-        outputs['out_qc_pdf'] = os.path.join(out_dir, 'qc.pdf')
+        outputs['qc_json'] = os.path.join(out_dir, 'qc.json')
+        outputs['qc_pdf'] = os.path.join(out_dir, 'qc.pdf')
 
         # Grab all b* files here. This will also grab the b0_pe* files
         # as well, but only if the field input was provided. So we'll remove
         # them later in the next conditional.
-        outputs['out_avg_b_png'] = sorted(glob(
+        outputs['avg_b_png'] = sorted(glob(
             os.path.join(out_dir, 'avg_b*.png')
         ))
 
         if isdefined(self.inputs.field):
-            outputs['out_avg_b0_pe_png'] = sorted(glob(
+            outputs['avg_b0_pe_png'] = sorted(glob(
                 os.path.join(out_dir, 'avg_b0_pe*.png')
             ))
 
-            # The previous glob for `out_avg_b_png` also grabbed the
-            # `out_avg_b0_pe_png` files so we have to remove them
-            # from `out_avg_b_png`.
-            for fname in outputs['out_avg_b0_pe_png']:
-                outputs['out_avg_b_png'].remove(fname)
+            # The previous glob for `avg_b_png` also grabbed the
+            # `avg_b0_pe_png` files so we have to remove them
+            # from `avg_b_png`.
+            for fname in outputs['avg_b0_pe_png']:
+                outputs['avg_b_png'].remove(fname)
 
-            outputs['out_vdm_png'] = os.path.join(out_dir, 'vdm.png')
+            outputs['vdm_png'] = os.path.join(out_dir, 'vdm.png')
 
-        outputs['out_cnr_png'] = sorted(glob(os.path.join(out_dir, 'cnr*.png')))
+        outputs['cnr_png'] = sorted(glob(os.path.join(out_dir, 'cnr*.png')))
 
         residuals = os.path.join(out_dir, 'eddy_msr.txt')
         if os.path.isfile(residuals):
-            outputs['out_residuals'] = residuals
+            outputs['residuals'] = residuals
 
         clean_volumes = os.path.join(out_dir, 'vols_no_outliers.txt')
         if os.path.isfile(clean_volumes):
-            outputs['out_clean_volumes'] = clean_volumes
+            outputs['clean_volumes'] = clean_volumes
 
         return outputs
 

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1275,7 +1275,8 @@ class EddyQuadInputSpec(FSLCommandInputSpec):
     )
     output_dir = traits.Str(
         'eddy_corrected.qc',
-        mandatory=False,
+        mandatory=True,
+        usedefault=True,
         argstr='--output-dir=%s',
         desc="Output directory - default = '<base_name>.qc'",
     )

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1389,7 +1389,7 @@ class EddyQuad(FSLCommand):
         # If the output directory isn't defined, the interface seems to use
         # the default but not set its value in `self.inputs.output_dir`
         if not isdefined(self.inputs.output_dir):
-            out_dir = os.path.abspath(self.inputs.base_name + '.qc.nii.gz')
+            out_dir = os.path.abspath(os.path.basename(self.inputs.base_name) + '.qc.nii.gz')
         else:
             out_dir = os.path.abspath(self.inputs.output_dir)
 

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1237,8 +1237,10 @@ class EddyCorrect(FSLCommand):
 class EddyQuadInputSpec(FSLCommandInputSpec):
     base_name = traits.Str(
         'eddy_corrected',
+        usedefault=True,
         argstr='%s',
-        desc="Basename (including path) specified when running EDDY",
+        desc=("Basename (including path) for EDDY output files, i.e., "
+              "corrected images and QC files"),
         position=0,
     )
     idx_file = File(
@@ -1268,31 +1270,26 @@ class EddyQuadInputSpec(FSLCommandInputSpec):
     )
     bvec_file = File(
         exists=True,
-        mandatory=False,
         argstr="--bvecs=%s",
         desc=("b-vectors file - only used when <base_name>.eddy_residuals "
               "file is present")
     )
     output_dir = traits.Str(
-        'eddy_corrected.qc',
-        mandatory=True,
-        usedefault=True,
+        name_template='%s.qc',
+        name_source=['base_name'],
         argstr='--output-dir=%s',
         desc="Output directory - default = '<base_name>.qc'",
     )
     field = File(
-        mandatory=False,
         argstr='--field=%s',
         desc="TOPUP estimated field (in Hz)",
     )
-    slspec = File(
-        mandatory=False,
+    slice_spec = File(
         argstr='--slspec=%s',
         desc="Text file specifying slice/group acquisition",
     )
     verbose = traits.Bool(
         False,
-        mandatory=False,
         argstr='--verbose',
         desc="Display debug messages",
     )
@@ -1321,7 +1318,7 @@ class EddyQuadOutputSpec(TraitedSpec):
         )
     )
 
-    out_avg_b0_png = traits.List(
+    out_avg_b0_pe_png = traits.List(
         File(
             exists=True,
             mandatory=False,
@@ -1399,52 +1396,41 @@ class EddyQuad(FSLCommand):
     input_spec = EddyQuadInputSpec
     output_spec = EddyQuadOutputSpec
 
-    def __init__(self, **inputs):
-        super(EddyQuad, self).__init__(**inputs)
-
     def _list_outputs(self):
-        from glob import glob
+        import json
         outputs = self.output_spec().get()
-        out_dir = self.inputs.output_dir
-        outputs['out_qc_json'] = os.path.abspath(
-            os.path.join(out_dir, 'qc.json')
-        )
-        outputs['out_qc_pdf'] = os.path.abspath(
-            os.path.join(out_dir, 'qc.pdf')
-        )
+        out_dir = os.path.abspath(self.inputs.output_dir)
+        outputs['out_qc_json'] = os.path.join(out_dir, 'qc.json')
+        outputs['out_qc_pdf'] = os.path.join(out_dir, 'qc.pdf')
 
-        outputs['out_avg_b0_png'] = glob(os.path.abspath(
-            os.path.join(out_dir, 'avg_b0_pe*.png')
-        ))
+        with open(outputs['out_qc_json']) as fp:
+            qc = json.load(fp)
 
-        outputs['out_avg_b_png'] = [b for b in glob(os.path.abspath(
-            os.path.join(out_dir, 'avg_b*.png')
-        )) if b not in outputs['out_avg_b0_png']]
+        outputs['out_avg_b_png'] = [
+            os.path.join(out_dir, 'avg_b{bval:d}.png'.format(bval=bval))
+            for bval in list(set([0] + qc.get('data_unique_bvals')))
+        ]
 
-        outputs['out_cnr_png'] = glob(os.path.abspath(
-            os.path.join(out_dir, 'cnr*.png')
-        ))
+        if qc.get('qc_field_flag'):
+            outputs['out_avg_b0_pe_png'] = [
+                os.path.join(out_dir, 'avg_b0_pe{i:d}'.format(i=i))
+                for i in range(qc.get('data_no_PE_dirs'))
+            ]
 
-        vdm = os.path.abspath(
-            os.path.join(out_dir, 'vdm.png')
-        )
+            outputs['out_vdm_png'] = os.path.join(out_dir, 'vdm.png')
 
-        if os.path.exists(vdm):
-            outputs['out_vdm_png'] = vdm
+        if qc.get('qc_cnr_flag'):
+            outputs['out_cnr_png'] = [
+                os.path.join(out_dir, 'cnr{i:04d}.nii.gz.png')
+                for i, _ in enumerate(qc.get('qc_cnr_avg'))
+            ]
 
-        residuals = os.path.abspath(
-            os.path.join(out_dir, 'eddy_msr.txt')
-        )
+        if qc.get('qc_rss_flag'):
+            outputs['out_residuals'] = os.path.join(out_dir, 'eddy_msr.txt')
 
-        if os.path.exists(residuals):
-            outputs['out_residuals'] = residuals
-
-        outlier_vols = os.path.abspath(
-            os.path.join(out_dir, 'vols_no_outliers.txt')
-        )
-
-        if os.path.exists(outlier_vols):
-            outputs['out_clean_volumes'] = outlier_vols
+        if qc.get('qc_ol_flag'):
+            outputs['out_clean_volumes'] = os.path.join(out_dir,
+                                                        'vols_no_outliers.txt')
 
         return outputs
 

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1379,18 +1379,19 @@ class EddyQuad(FSLCommand):
     >>> from nipype.interfaces.fsl import EddyQuad
     >>> quad = EddyQuad()
     >>> quad.inputs.base_name  = 'eddy_corrected'
-    >>> quad.inputs.idx_file   = 'index.txt'
-    >>> quad.inputs.param_file = 'encfile.txt'
-    >>> quad.inputs.mask_file  = 'mask.nii.gz'
-    >>> quad.inputs.bval_file  = 'dwi.bval'
-    >>> quad.inputs.bvec_file  = 'dwi.bvec'
+    >>> quad.inputs.idx_file   = 'epi_index.txt'
+    >>> quad.inputs.param_file = 'epi_acqp.txt'
+    >>> quad.inputs.mask_file  = 'epi_mask.nii'
+    >>> quad.inputs.bval_file  = 'bvals.scheme'
+    >>> quad.inputs.bvec_file  = 'bvecs.scheme'
     >>> quad.inputs.output_dir = 'eddy_corrected.qc'
-    >>> quad.inputs.field      = 'field.nii.gz'
-    >>> quad.verbose           = True
+    >>> quad.inputs.field      = 'fieldmap_phase_fslprepared.nii'
+    >>> quad.inputs.verbose    = True
     >>> quad.cmdline # doctest: +ELLIPSIS
-    'eddy_quad eddy_corrected --eddyIdx=index.txt --eddyParams=encfile.txt \
---mask=mask.nii.gz --bvals=dwi.bval --bvecs=dwi.bvec \
---output-dir=eddy_corrected.qc --field=field.nii.gz --verbose'
+    'eddy_quad eddy_corrected --bvals=bvals.scheme --bvecs=bvecs.scheme \
+--field=fieldmap_phase_fslprepared.nii --eddyIdx=epi_index.txt \
+--mask=epi_mask.nii --output-dir=eddy_corrected.qc --eddyParams=epi_acqp.txt \
+--verbose'
     >>> res = quad.run() # doctest: +SKIP
 
     """


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

This PR adds an interface to `eddy_quad`, one of two tools in the EDDY QC framework.
See the [EDDY QC documentation](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddyqc/UsersGuide) for further details. Thanks to @akeshavan for help with my first nipype PR.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- Add `EddyQuadInputSpec` class
- Add `EddyQuadOutputSpec` class
- Add `EddyQuad` class with doctest

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
