### PR TITLE
RF: Drop various remaining compatibilities for Python < 3.5

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -2,7 +2,6 @@
 settings in setup.py, the nipy top-level docstring, and for building the
 docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 """
-import sys
 
 # nipype version information.  An empty version_extra corresponds to a
 # full release.  '.dev' as a version_extra string means this is a development
@@ -151,9 +150,6 @@ REQUIRES = [
     'packaging',
     'futures; python_version == "2.7"',
 ]
-
-if sys.version_info <= (3, 4):
-    REQUIRES.append('configparser')
 
 TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-env', 'coverage<5']
 

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from warnings import warn
 from packaging.version import Version
 
-from ...utils.filemanip import md5, hash_infile, hash_timestamp, to_str
+from ...utils.filemanip import md5, hash_infile, hash_timestamp
 from .traits_extension import (
     traits,
     Undefined,
@@ -251,7 +251,7 @@ class BaseTraitedSpec(traits.HasTraits):
                                       True,
                                       hash_method=hash_method,
                                       hash_files=hash_files)))
-        return list_withhash, md5(to_str(list_nofilename).encode()).hexdigest()
+        return list_withhash, md5(str(list_nofilename).encode()).hexdigest()
 
     def _get_sorteddict(self,
                         objekt,

--- a/nipype/interfaces/base/support.py
+++ b/nipype/interfaces/base/support.py
@@ -14,7 +14,7 @@ import re
 
 from ... import logging
 from ...utils.misc import is_container
-from ...utils.filemanip import md5, to_str, hash_infile
+from ...utils.filemanip import md5, hash_infile
 iflogger = logging.getLogger('nipype.interface')
 
 HELP_LINEWIDTH = 70
@@ -161,7 +161,7 @@ class Bunch(object):
         # Sort the items of the dictionary, before hashing the string
         # representation so we get a predictable order of the
         # dictionary.
-        sorted_dict = to_str(sorted(dict_nofilename.items()))
+        sorted_dict = str(sorted(dict_nofilename.items()))
         return dict_withhash, md5(sorted_dict.encode()).hexdigest()
 
     def _repr_pretty_(self, p, cycle):

--- a/nipype/interfaces/tests/test_io.py
+++ b/nipype/interfaces/tests/test_io.py
@@ -5,9 +5,7 @@ import os
 import copy
 import simplejson
 import glob
-import shutil
 import os.path as op
-import sys
 from subprocess import Popen
 import hashlib
 from collections import namedtuple
@@ -577,8 +575,6 @@ def test_jsonsink(tmpdir, inputs_attributes):
 # There are three reasons these tests will be skipped:
 @pytest.mark.skipif(not have_pybids,
                     reason="Pybids is not installed")
-@pytest.mark.skipif(sys.version_info < (3, 0),
-                    reason="Pybids no longer supports Python 2")
 @pytest.mark.skipif(not dist_is_editable('pybids'),
                     reason="Pybids is not installed in editable mode")
 def test_bids_grabber(tmpdir):
@@ -594,8 +590,6 @@ def test_bids_grabber(tmpdir):
 
 @pytest.mark.skipif(not have_pybids,
                     reason="Pybids is not installed")
-@pytest.mark.skipif(sys.version_info < (3, 0),
-                    reason="Pybids no longer supports Python 2")
 @pytest.mark.skipif(not dist_is_editable('pybids'),
                     reason="Pybids is not installed in editable mode")
 def test_bids_fields(tmpdir):
@@ -610,8 +604,6 @@ def test_bids_fields(tmpdir):
 
 @pytest.mark.skipif(not have_pybids,
                     reason="Pybids is not installed")
-@pytest.mark.skipif(sys.version_info < (3, 0),
-                    reason="Pybids no longer supports Python 2")
 @pytest.mark.skipif(not dist_is_editable('pybids'),
                     reason="Pybids is not installed in editable mode")
 def test_bids_infields_outfields(tmpdir):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -21,8 +21,8 @@ from ... import config, logging
 from ...utils.misc import flatten, unflatten, str2bool, dict_diff
 from ...utils.filemanip import (md5, FileNotFoundError, ensure_list,
                                 simplify_list, copyfiles, fnames_presuffix,
-                                loadpkl, split_filename, load_json, makedirs,
-                                emptydirs, savepkl, to_str, indirectory)
+                                loadpkl, split_filename, load_json,
+                                emptydirs, savepkl, indirectory)
 
 from ...interfaces.base import (traits, InputMultiPath, CommandLine, Undefined,
                                 DynamicTraitedSpec, Bunch, InterfaceResult,
@@ -267,7 +267,7 @@ class Node(EngineBase):
     def set_input(self, parameter, val):
         """Set interface input value"""
         logger.debug('[Node] %s - setting input %s = %s', self.name, parameter,
-                     to_str(val))
+                     str(val))
         setattr(self.inputs, parameter, deepcopy(val))
 
     def get_output(self, parameter):
@@ -453,7 +453,7 @@ class Node(EngineBase):
                 os.remove(filename)
 
         # Make sure outdir is created
-        makedirs(outdir, exist_ok=True)
+        os.makedirs(outdir, exist_ok=True)
 
         # Store runtime-hashfile, pre-execution report, the node and the inputs set.
         _save_hashfile(hashfile_unfinished, self._hashed_inputs)
@@ -663,7 +663,7 @@ class Node(EngineBase):
         if execute and linksonly:
             olddir = outdir
             outdir = op.join(outdir, '_tempinput')
-            makedirs(outdir, exist_ok=True)
+            os.makedirs(outdir, exist_ok=True)
 
         for info in filecopy_info:
             files = self.inputs.trait_get().get(info['key'])
@@ -1019,13 +1019,13 @@ class MapNode(Node):
         Set interface input value or nodewrapper attribute
         Priority goes to interface.
         """
-        logger.debug('setting nodelevel(%s) input %s = %s', to_str(self),
-                     parameter, to_str(val))
+        logger.debug('setting nodelevel(%s) input %s = %s', str(self),
+                     parameter, str(val))
         self._set_mapnode_input(parameter, deepcopy(val))
 
     def _set_mapnode_input(self, name, newvalue):
-        logger.debug('setting mapnode(%s) input: %s -> %s', to_str(self), name,
-                     to_str(newvalue))
+        logger.debug('setting mapnode(%s) input: %s -> %s', str(self), name,
+                     str(newvalue))
         if name in self.iterfield:
             setattr(self._inputs, name, newvalue)
         else:

--- a/nipype/pipeline/engine/tests/test_utils.py
+++ b/nipype/pipeline/engine/tests/test_utils.py
@@ -4,7 +4,6 @@
 """Tests for the engine utils module
 """
 import os
-import sys
 from copy import deepcopy
 import pytest
 
@@ -159,8 +158,6 @@ def dummy_func(value):
     return value + 1
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0), reason="the famous segfault #1788")
 def test_mapnode_crash(tmpdir):
     """Test mapnode crash when stop_on_first_crash is True"""
     cwd = os.getcwd()
@@ -180,8 +177,6 @@ def test_mapnode_crash(tmpdir):
     os.chdir(cwd)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0), reason="the famous segfault #1788")
 def test_mapnode_crash2(tmpdir):
     """Test mapnode crash when stop_on_first_crash is False"""
     cwd = os.getcwd()
@@ -200,8 +195,6 @@ def test_mapnode_crash2(tmpdir):
     os.chdir(cwd)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0), reason="the famous segfault #1788")
 def test_mapnode_crash3(tmpdir):
     """Test mapnode crash when mapnode is embedded in a workflow"""
     tmpdir.chdir()

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -21,9 +21,7 @@ import numpy as np
 from ... import logging, config, LooseVersion
 from ...utils.filemanip import (
     relpath,
-    makedirs,
     fname_presuffix,
-    to_str,
     ensure_list,
     get_related_files,
     FileNotFoundError,
@@ -117,7 +115,7 @@ def write_report(node, report_type=None, is_mapnode=False):
     cwd = node.output_dir()
     report_dir = os.path.join(cwd, '_report')
     report_file = os.path.join(report_dir, 'report.rst')
-    makedirs(report_dir, exist_ok=True)
+    os.makedirs(report_dir, exist_ok=True)
 
     logger.debug('[Node] Writing %s-exec report to "%s"', report_type[:-4],
                  report_file)
@@ -627,7 +625,7 @@ def _get_valid_pathstr(pathstr):
     Replaces: ',' -> '.'
     """
     if not isinstance(pathstr, (str, bytes)):
-        pathstr = to_str(pathstr)
+        pathstr = str(pathstr)
     pathstr = pathstr.replace(os.sep, '..')
     pathstr = re.sub(r'''[][ (){}?:<>#!|"';]''', '', pathstr)
     pathstr = pathstr.replace(',', '.')
@@ -1355,7 +1353,7 @@ def export_graph(graph_in,
     if base_dir is None:
         base_dir = os.getcwd()
 
-    makedirs(base_dir, exist_ok=True)
+    os.makedirs(base_dir, exist_ok=True)
     out_dot = fname_presuffix(
         dotfilename, suffix='_detailed.dot', use_ext=False, newpath=base_dir)
     _write_detailed_dot(graph, out_dot)

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -410,7 +410,7 @@ connected.
                     base_dir = op.join(base_dir, self.name)
             else:
                 base_dir = os.getcwd()
-        base_dir = os.makedirs(base_dir, exist_ok=True)
+        os.makedirs(base_dir, exist_ok=True)
         if graph2use in ['hierarchical', 'colored']:
             if self.name[:1].isdigit():  # these graphs break if int
                 raise ValueError('{} graph failed, workflow name cannot begin '

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -22,7 +22,7 @@ from ...utils.functions import (getsource, create_function_from_source)
 
 from ...interfaces.base import (traits, TraitedSpec, TraitDictObject,
                                 TraitListObject)
-from ...utils.filemanip import save_json, makedirs, to_str
+from ...utils.filemanip import save_json
 from .utils import (generate_expanded_graph, export_graph, write_workflow_prov,
                     write_workflow_resources, format_dot, topological_sort,
                     get_print_name, merge_dict, format_node)
@@ -218,12 +218,12 @@ connected.
             edge_data = self._graph.get_edge_data(srcnode, destnode, None)
             if edge_data:
                 logger.debug('(%s, %s): Edge data exists: %s', srcnode,
-                             destnode, to_str(edge_data))
+                             destnode, str(edge_data))
                 for data in connects:
                     if data not in edge_data['connect']:
                         edge_data['connect'].append(data)
                     if disconnect:
-                        logger.debug('Removing connection: %s', to_str(data))
+                        logger.debug('Removing connection: %s', str(data))
                         edge_data['connect'].remove(data)
                 if edge_data['connect']:
                     self._graph.add_edges_from([(srcnode, destnode,
@@ -240,7 +240,7 @@ connected.
                 })])
             edge_data = self._graph.get_edge_data(srcnode, destnode)
             logger.debug('(%s, %s): new edge data: %s', srcnode, destnode,
-                         to_str(edge_data))
+                         str(edge_data))
 
     def disconnect(self, *args):
         """Disconnect nodes
@@ -256,7 +256,7 @@ connected.
 
         for srcnode, dstnode, conn in connection_list:
             logger.debug('disconnect(): %s->%s %s', srcnode, dstnode,
-                         to_str(conn))
+                         str(conn))
             if self in [srcnode, dstnode]:
                 raise IOError(
                     'Workflow connect cannot contain itself as node: src[%s] '
@@ -277,10 +277,10 @@ connected.
                     # idx = ed_conns.index(edge)
                     remove.append((edge[0], edge[1]))
 
-            logger.debug('disconnect(): remove list %s', to_str(remove))
+            logger.debug('disconnect(): remove list %s', str(remove))
             for el in remove:
                 edge_data['connect'].remove(el)
-                logger.debug('disconnect(): removed connection %s', to_str(el))
+                logger.debug('disconnect(): removed connection %s', str(el))
 
             if not edge_data['connect']:
                 self._graph.remove_edge(srcnode, dstnode)
@@ -410,7 +410,7 @@ connected.
                     base_dir = op.join(base_dir, self.name)
             else:
                 base_dir = os.getcwd()
-        base_dir = makedirs(base_dir, exist_ok=True)
+        base_dir = os.makedirs(base_dir, exist_ok=True)
         if graph2use in ['hierarchical', 'colored']:
             if self.name[:1].isdigit():  # these graphs break if int
                 raise ValueError('{} graph failed, workflow name cannot begin '
@@ -576,7 +576,7 @@ connected.
         flatgraph = self._create_flat_graph()
         self.config = merge_dict(deepcopy(config._sections), self.config)
         logger.info('Workflow %s settings: %s', self.name,
-                    to_str(sorted(self.config)))
+                    str(sorted(self.config)))
         self._set_needed_outputs(flatgraph)
         execgraph = generate_expanded_graph(deepcopy(flatgraph))
         for index, node in enumerate(execgraph.nodes()):
@@ -609,7 +609,7 @@ connected.
         if workingdir is None:
             workingdir = os.getcwd()
         report_dir = op.join(workingdir, name)
-        makedirs(report_dir, exist_ok=True)
+        os.makedirs(report_dir, exist_ok=True)
         shutil.copyfile(
             op.join(op.dirname(__file__), 'report_template.html'),
             op.join(report_dir, 'index.html'))
@@ -821,7 +821,7 @@ connected.
             newval = dict(val)
         if isinstance(val, TraitListObject):
             newval = val[:]
-        logger.debug('setting node input: %s->%s', param, to_str(newval))
+        logger.debug('setting node input: %s->%s', param, str(newval))
         node.set_input(param, deepcopy(newval))
 
     def _get_all_nodes(self):
@@ -881,9 +881,9 @@ connected.
                 # dj: added list() for networkx ver.2
                 for u, _, d in list(
                         self._graph.in_edges(nbunch=node, data=True)):
-                    logger.debug('in: connections-> %s', to_str(d['connect']))
+                    logger.debug('in: connections-> %s', str(d['connect']))
                     for cd in deepcopy(d['connect']):
-                        logger.debug("in: %s", to_str(cd))
+                        logger.debug("in: %s", str(cd))
                         dstnode = node._get_parameter_node(cd[1], subtype='in')
                         srcnode = u
                         srcout = cd[0]
@@ -896,9 +896,9 @@ connected.
                 # dj: for ver 2 use list(out_edges)
                 for _, v, d in list(
                         self._graph.out_edges(nbunch=node, data=True)):
-                    logger.debug('out: connections-> %s', to_str(d['connect']))
+                    logger.debug('out: connections-> %s', str(d['connect']))
                     for cd in deepcopy(d['connect']):
-                        logger.debug("out: %s", to_str(cd))
+                        logger.debug("out: %s", str(cd))
                         dstnode = v
                         if isinstance(cd[0], tuple):
                             parameter = cd[0][0]

--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -12,7 +12,7 @@ from time import strftime
 from traceback import format_exception
 
 from ... import logging
-from ...utils.filemanip import savepkl, crash2txt, makedirs
+from ...utils.filemanip import savepkl, crash2txt
 
 logger = logging.getLogger('nipype.workflow')
 
@@ -42,7 +42,7 @@ def report_crash(node, traceback=None, hostname=None):
                                        str(uuid.uuid4()))
     crashdir = node.config['execution'].get('crashdump_dir', os.getcwd())
 
-    makedirs(crashdir, exist_ok=True)
+    os.makedirs(crashdir, exist_ok=True)
     crashfile = os.path.join(crashdir, crashfile)
 
     if node.config['execution']['crashfile_format'].lower() in ['text', 'txt']:

--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -115,8 +115,7 @@ pklfile = '%s'
 batchdir = '%s'
 from nipype.utils.filemanip import loadpkl, savepkl
 try:
-    if not sys.version_info < (2, 7):
-        from collections import OrderedDict
+    from collections import OrderedDict
     config_dict=%s
     config.update_config(config_dict)
     ## Only configure matplotlib if it was successfully imported,

--- a/nipype/sphinxext/plot_workflow.py
+++ b/nipype/sphinxext/plot_workflow.py
@@ -144,23 +144,6 @@ except ImportError as e:
 
 
 
-def _mkdirp(folder):
-    """
-    Equivalent to bash's mkdir -p
-    """
-    if sys.version_info > (3, 4, 1):
-        os.makedirs(folder, exist_ok=True)
-        return folder
-
-    try:
-        os.makedirs(folder)
-    except OSError as exc:
-        if exc.errno != EEXIST or not os.path.isdir(folder):
-            raise
-
-    return folder
-
-
 def wf_directive(name, arguments, options, content, lineno, content_offset,
                  block_text, state, state_machine):
     if len(missing_imports) == 0:
@@ -737,7 +720,7 @@ def run(arguments, content, options, state_machine, state, lineno):
         state_machine.insert_input(total_lines, source=source_file_name)
 
     # copy image files to builder's output directory, if necessary
-    _mkdirp(dest_dir)
+    os.makedirs(dest_dir, exist_ok=True)
     for code_piece, images in results:
         for img in images:
             for fn in img.filenames():

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -91,56 +91,7 @@ def to_str(value):
     Manipulates ordered dicts before they are hashed (Py2/3 compat.)
 
     """
-    if sys.version_info[0] > 2:
-        retval = str(value)
-    else:
-        retval = to_str_py27(value)
-    return retval
-
-
-def to_str_py27(value):
-    """
-    Encode dictionary for python 2
-    """
-
-    if isinstance(value, dict):
-        entry = '{}: {}'.format
-        retval = '{'
-        for key, val in list(value.items()):
-            if len(retval) > 1:
-                retval += ', '
-            kenc = repr(key)
-            if kenc.startswith(("u'", 'u"')):
-                kenc = kenc[1:]
-            venc = to_str_py27(val)
-            if venc.startswith(("u'", 'u"')):
-                venc = venc[1:]
-            retval += entry(kenc, venc)
-        retval += '}'
-        return retval
-
-    istuple = isinstance(value, tuple)
-    if isinstance(value, (tuple, list)):
-        retval = '(' if istuple else '['
-        nels = len(value)
-        for i, v in enumerate(value):
-            venc = to_str_py27(v)
-            if venc.startswith(("u'", 'u"')):
-                venc = venc[1:]
-            retval += venc
-
-            if i < nels - 1:
-                retval += ', '
-
-        if istuple and nels == 1:
-            retval += ','
-        retval += ')' if istuple else ']'
-        return retval
-
-    retval = repr(value).decode()
-    if retval.startswith(("u'", 'u"')):
-        retval = retval[1:]
-    return retval
+    return str(value)
 
 
 def fname_presuffix(fname, prefix='', suffix='', newpath=None, use_ext=True):
@@ -593,8 +544,6 @@ def save_json(filename, data):
 
     """
     mode = 'w'
-    if sys.version_info[0] < 3:
-        mode = 'wb'
     with open(filename, mode) as fp:
         json.dump(data, fp, sort_keys=True, indent=4)
 
@@ -841,27 +790,10 @@ def which(cmd, env=None, pathext=None):
     if env and 'PATH' in env:
         path = env.get("PATH")
 
-    if sys.version_info >= (3, 3):
-        for ext in pathext:
-            filename = shutil.which(cmd + ext, path=path)
-            if filename:
-                return filename
-        return None
-
-    def isexec(path):
-        return os.path.isfile(path) and os.access(path, os.X_OK)
-
     for ext in pathext:
-        extcmd = cmd + ext
-        fpath, fname = os.path.split(extcmd)
-        if fpath:
-            if isexec(extcmd):
-                return extcmd
-        else:
-            for directory in path.split(os.pathsep):
-                filename = op.join(directory, extcmd)
-                if isexec(filename):
-                    return filename
+        filename = shutil.which(cmd + ext, path=path)
+        if filename:
+            return filename
     return None
 
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -86,14 +86,6 @@ def split_filename(fname):
     return pth, fname, ext
 
 
-def to_str(value):
-    """
-    Manipulates ordered dicts before they are hashed (Py2/3 compat.)
-
-    """
-    return str(value)
-
-
 def fname_presuffix(fname, prefix='', suffix='', newpath=None, use_ext=True):
     """Manipulates path and name of input filename
 
@@ -711,31 +703,6 @@ def dist_is_editable(dist):
     return False
 
 
-def makedirs(path, exist_ok=False):
-    """
-    Create path, if it doesn't exist.
-
-    Parameters
-    ----------
-    path : output directory to create
-
-    """
-    if not exist_ok:  # The old makedirs
-        os.makedirs(path)
-        return path
-
-    # this odd approach deals with concurrent directory cureation
-    if not op.exists(op.abspath(path)):
-        fmlogger.debug("Creating directory %s", path)
-        try:
-            os.makedirs(path)
-        except OSError:
-            fmlogger.debug("Problem creating directory %s", path)
-            if not op.exists(path):
-                raise OSError('Could not create directory %s' % path)
-    return path
-
-
 def emptydirs(path, noexist_ok=False):
     """
     Empty an existing directory, without deleting it. Do not
@@ -769,7 +736,7 @@ def emptydirs(path, noexist_ok=False):
         else:
             raise ex
 
-    makedirs(path)
+    os.makedirs(path)
 
 
 def which(cmd, env=None, pathext=None):

--- a/nipype/utils/profiler.py
+++ b/nipype/utils/profiler.py
@@ -4,6 +4,7 @@
 """
 Utilities to keep track of performance
 """
+import os
 import threading
 from time import time
 try:

--- a/nipype/utils/tests/test_functions.py
+++ b/nipype/utils/tests/test_functions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 import pytest
 from nipype.utils.functions import (getsource, create_function_from_source)
 
@@ -27,7 +26,7 @@ def test_func_to_str_err():
 
 def _print_statement():
     try:
-        exec('print ""')
+        exec('print("")')
         return True
     except SyntaxError:
         return False
@@ -41,7 +40,6 @@ def test_func_string():
     assert is_string() == wrapped_func()
 
 
-@pytest.mark.skipif(sys.version_info[0] > 2, reason="breaks python 3")
-def test_func_print_py2():
+def test_func_print():
     wrapped_func = create_function_from_source(getsource(_print_statement))
     assert wrapped_func()


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

In merging `master` into `dev/2.0`, I saw a Python >= 3.2 check, indicating a less-than-thorough purge of all obsolete version checks. Here I grepped for `sys.version` and removed any checks that no longer apply for Python < 3.5. (I think < 3.4.1 is the actual highest check, so we're not in the range of distinguishing 3.5 and 3.6.)

The main thing to-do is to change `to_str()` to `str()` everywhere, and remove that function fully, but I want to get tests running to make sure I'm not breaking anything.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
