### PR TITLE
DOC: Hyperlink DOIs to preferred resolver

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -215,7 +215,7 @@ this way you can use the initial paper published in 2011 (see below).
 	month            = "08",
 	doi              = "10.3389/fninf.2011.00013",
 	pubmed           = "21897815",
-	url              = "http://dx.doi.org/10.3389/fninf.2011.00013",
+	url              = "https://doi.org/10.3389/fninf.2011.00013",
 	issn             = "1662-5196"}
 
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -271,7 +271,7 @@ class FramewiseDisplacement(BaseInterface):
     .. [Power2012] Power et al., Spurious but systematic correlations in functional
          connectivity MRI networks arise from subject motion, NeuroImage 59(3),
          2012. doi:`10.1016/j.neuroimage.2011.10.018
-         <http://dx.doi.org/10.1016/j.neuroimage.2011.10.018>`_.
+         <https://doi.org/10.1016/j.neuroimage.2011.10.018>`_.
 
 
     """

--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -1587,7 +1587,7 @@ class KellyKapowski(ANTSCommand):
             "year={2009},"
             "issn={1053-8119},"
             "url={http://www.sciencedirect.com/science/article/pii/S1053811908012780},"
-            "doi={http://dx.doi.org/10.1016/j.neuroimage.2008.12.016}"
+            "doi={https://doi.org/10.1016/j.neuroimage.2008.12.016}"
             "}"),
         'description':
         'The details on the implementation of DiReCT.',

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -123,7 +123,7 @@ class Denoise(DipyBaseInterface):
 
     .. [Coupe2008] Coupe P et al., `An Optimized Blockwise Non Local Means
       Denoising Filter for 3D Magnetic Resonance Images
-      <http://dx.doi.org/10.1109%2FTMI.2007.906087>`_,
+      <https://doi.org/10.1109%2FTMI.2007.906087>`_,
       IEEE Transactions on Medical Imaging, 27(4):425-441, 2008.
 
 

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -288,7 +288,7 @@ def _compute_voxel(args):
     .. [Alexander2002] Alexander et al., Detection and modeling of non-Gaussian
       apparent diffusion coefficient profiles in human brain data, MRM
       48(2):331-340, 2002, doi: `10.1002/mrm.10209
-      <http://dx.doi.org/10.1002/mrm.10209>`_.
+      <https://doi.org/10.1002/mrm.10209>`_.
     .. [Pierpaoli1996] Pierpaoli et al., Diffusion tensor MR imaging
       of the human brain, Radiology 201:637-648. 1996.
     """

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -139,7 +139,7 @@ class SpaceTimeRealigner(NipyBaseInterface):
        application to joint correction of motion and slice timing \
        in fMRI. IEEE Trans Med Imaging. 2011 Aug;30(8):1546-54. DOI_.
 
-    .. _DOI: http://dx.doi.org/10.1109/TMI.2011.2131152
+    .. _DOI: https://doi.org/10.1109/TMI.2011.2131152
 
     """
 

--- a/nipype/interfaces/petpvc.py
+++ b/nipype/interfaces/petpvc.py
@@ -164,7 +164,7 @@ class PETPVC(CommandLine):
             "number={22},"
             "pages={7975},"
             "url={http://stacks.iop.org/0031-9155/61/i=22/a=7975},"
-            "doi={http://dx.doi.org/10.1088/0031-9155/61/22/7975},"
+            "doi={https://doi.org/10.1088/0031-9155/61/22/7975},"
             "year={2016},"
             "}"),
         'description':

--- a/nipype/workflows/dmri/fsl/artifacts.py
+++ b/nipype/workflows/dmri/fsl/artifacts.py
@@ -388,12 +388,12 @@ def hmc_pipeline(name='motion_correct'):
 
       .. [Leemans09] Leemans A, and Jones DK, `The B-matrix must be rotated
         when correcting for subject motion in DTI data
-        <http://dx.doi.org/10.1002/mrm.21890>`_,
+        <https://doi.org/10.1002/mrm.21890>`_,
         Magn Reson Med. 61(6):1336-49. 2009. doi: 10.1002/mrm.21890.
 
       .. [Yendiki13] Yendiki A et al., `Spurious group differences due to head
         motion in a diffusion MRI study
-        <http://dx.doi.org/10.1016/j.neuroimage.2013.11.027>`_.
+        <https://doi.org/10.1016/j.neuroimage.2013.11.027>`_.
         Neuroimage. 21(88C):79-90. 2013. doi: 10.1016/j.neuroimage.2013.11.027
 
     Example
@@ -656,11 +656,11 @@ def sdc_fmb(name='fmb_correction',
 
       .. [Jezzard95] Jezzard P, and Balaban RS, `Correction for geometric
         distortion in echo planar images from B0 field variations
-        <http://dx.doi.org/10.1002/mrm.1910340111>`_,
+        <https://doi.org/10.1002/mrm.1910340111>`_,
         MRM 34(1):65-73. (1995). doi: 10.1002/mrm.1910340111.
 
       .. [Jenkinson03] Jenkinson M., `Fast, automated, N-dimensional
-        phase-unwrapping algorithm <http://dx.doi.org/10.1002/mrm.10354>`_,
+        phase-unwrapping algorithm <https://doi.org/10.1002/mrm.10354>`_,
         MRM 49(1):193-197, 2003, doi: 10.1002/mrm.10354.
 
     """
@@ -873,7 +873,7 @@ def sdc_peb(name='peb_correction',
 
       .. [Andersson2003] Andersson JL et al., `How to correct susceptibility
         distortions in spin-echo echo-planar images: application to diffusion
-        tensor imaging <http://dx.doi.org/10.1016/S1053-8119(03)00336-7>`_.
+        tensor imaging <https://doi.org/10.1016/S1053-8119(03)00336-7>`_.
         Neuroimage. 2003 Oct;20(2):870-88. doi: 10.1016/S1053-8119(03)00336-7
 
       .. [Cordes2000] Cordes D et al., Geometric distortion correction in EPI
@@ -951,7 +951,7 @@ def remove_bias(name='bias_correct'):
 
       .. [Jeurissen2014] Jeurissen B. et al., `Multi-tissue constrained
         spherical deconvolution for improved analysis of multi-shell diffusion
-        MRI data <http://dx.doi.org/10.1016/j.neuroimage.2014.07.061>`_.
+        MRI data <https://doi.org/10.1016/j.neuroimage.2014.07.061>`_.
         NeuroImage (2014). doi: 10.1016/j.neuroimage.2014.07.061
 
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

## List of changes proposed in this PR (pull-request)

- updates all static DOI links

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
