### PR TITLE
ENH/FIX: Resolve LinAlgError during SVD

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -14,7 +14,6 @@ import os.path as op
 import nibabel as nb
 import numpy as np
 from numpy.polynomial import Legendre
-from scipy import linalg
 
 from .. import config, logging
 from ..external.due import BibTeX

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -14,6 +14,7 @@ import os.path as op
 import nibabel as nb
 import numpy as np
 from numpy.polynomial import Legendre
+from scipy import linalg
 
 from .. import config, logging
 from ..external.due import BibTeX
@@ -1193,9 +1194,12 @@ def compute_noise_components(imgseries, mask_images, num_components,
         try:
             u, _, _ = np.linalg.svd(M, full_matrices=False)
         except np.linalg.LinAlgError:
-            if self.inputs.failure_mode == 'error':
-                raise
-            u = np.ones((M.shape[0], num_components), dtype=np.float32) * np.nan
+            try:
+                u, _, _ = linalg.svd(M, full_matrices=False, lapack_driver='gesvd')
+            except linalg.LinAlgError:
+                if self.inputs.failure_mode == 'error':
+                    raise
+                u = np.ones((M.shape[0], num_components), dtype=np.float32) * np.nan
         if components is None:
             components = u[:, :num_components]
         else:

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -27,6 +27,16 @@ from ..utils.misc import normalize_mc_params
 IFLOGGER = logging.getLogger('nipype.interface')
 
 
+def fallback_svd(a, full_matrices=True, compute_uv=True):
+    try:
+        return np.linalg.svd(a, full_matrices=full_matrices, compute_uv=compute_uv)
+    except np.linalg.LinAlgError:
+        pass
+
+    from scipy.linalg import svd
+    return svd(a, full_matrices=full_matrices, compute_uv=compute_uv, lapack_driver='gesvd')
+
+
 class ComputeDVARSInputSpec(BaseInterfaceInputSpec):
     in_file = File(
         exists=True, mandatory=True, desc='functional data, after HMC')
@@ -1192,14 +1202,11 @@ def compute_noise_components(imgseries, mask_images, num_components,
         # "The covariance matrix C = MMT was constructed and decomposed into its
         # principal components using a singular value decomposition."
         try:
-            u, _, _ = np.linalg.svd(M, full_matrices=False)
+            u, _, _ = fallback_svd(M, full_matrices=False)
         except np.linalg.LinAlgError:
-            try:
-                u, _, _ = linalg.svd(M, full_matrices=False, lapack_driver='gesvd')
-            except linalg.LinAlgError:
-                if self.inputs.failure_mode == 'error':
-                    raise
-                u = np.ones((M.shape[0], num_components), dtype=np.float32) * np.nan
+            if self.inputs.failure_mode == 'error':
+                raise
+            u = np.ones((M.shape[0], num_components), dtype=np.float32) * np.nan
         if components is None:
             components = u[:, :num_components]
         else:
@@ -1277,7 +1284,7 @@ def _full_rank(X, cmax=1e15):
     X: array of shape(nrows, ncols) after regularization
     cmax=1.e-15, float tolerance for condition number
     """
-    U, s, V = np.linalg.svd(X, 0)
+    U, s, V = fallback_svd(X, full_matrices=False)
     smax, smin = s.max(), s.min()
     c = smax / smin
     if c < cmax:


### PR DESCRIPTION
The default `lapack_driver` uses divide and conquer SVD (`gesdd`), which occasionally will cause `LinAlgError` even if the data are completely fine. Switching `lapack_driver` to `gesvd` when it fails can solve this issue.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
