### PR TITLE
BF: ANTS LaplacianThickness cmdline opts fixed up

### DIFF
--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -207,13 +207,27 @@ class LaplacianThicknessInputSpec(ANTSCommandInputSpec):
         name_template='%s_thickness',
         keep_extension=True,
         hash_files=False)
-    smooth_param = traits.Float(argstr='smoothparam=%d', desc='', position=4)
+    smooth_param = traits.Float(
+        argstr='%f',
+        desc='Sigma of the Laplacian Recursive Image Filter (defaults to 1)',
+        position=4)
     prior_thickness = traits.Float(
-        argstr='priorthickval=%d', desc='', position=5)
-    dT = traits.Float(argstr='dT=%d', desc='', position=6)
-    sulcus_prior = traits.Bool(argstr='use-sulcus-prior', desc='', position=7)
-    opt_tolerance = traits.Float(
-        argstr='optional-laplacian-tolerance=%d', desc='', position=8)
+        argstr='%f',
+        desc='Prior thickness (defaults to 500)',
+        position=5)
+    dT = traits.Float(
+        argstr='%f',
+        desc='Time delta used during integration (defaults to 0.01)',
+        position=6)
+    sulcus_prior = traits.Float(
+        argstr='%f',
+        desc='Positive floating point number for sulcus prior. '
+             'Authors said that 0.15 might be a reasonable value',
+        position=7)
+    tolerance = traits.Float(
+        argstr='%f',
+        desc='Tolerance to reach during optimization (defaults to 0.001)',
+        position=8)
 
 
 class LaplacianThicknessOutputSpec(TraitedSpec):

--- a/nipype/interfaces/ants/tests/test_auto_LaplacianThickness.py
+++ b/nipype/interfaces/ants/tests/test_auto_LaplacianThickness.py
@@ -7,7 +7,7 @@ def test_LaplacianThickness_inputs():
     input_map = dict(
         args=dict(argstr='%s', ),
         dT=dict(
-            argstr='dT=%d',
+            argstr='%f',
             position=6,
         ),
         environ=dict(
@@ -30,10 +30,6 @@ def test_LaplacianThickness_inputs():
             nohash=True,
             usedefault=True,
         ),
-        opt_tolerance=dict(
-            argstr='optional-laplacian-tolerance=%d',
-            position=8,
-        ),
         output_image=dict(
             argstr='%s',
             hash_files=False,
@@ -43,16 +39,20 @@ def test_LaplacianThickness_inputs():
             position=3,
         ),
         prior_thickness=dict(
-            argstr='priorthickval=%d',
+            argstr='%f',
             position=5,
         ),
         smooth_param=dict(
-            argstr='smoothparam=%d',
+            argstr='%f',
             position=4,
         ),
         sulcus_prior=dict(
-            argstr='use-sulcus-prior',
+            argstr='%f',
             position=7,
+        ),
+        tolerance=dict(
+            argstr='%f',
+            position=8,
         ),
     )
     inputs = LaplacianThickness.input_spec()


### PR DESCRIPTION
That interface had a chance to work only when no any optional options specified since cmdline specs.
I also stripped  opt_ prefix from tollerance since they are all optional.

Some related discussions/changes on ANTs:
- https://github.com/ANTsX/ANTs/issues/688
- https://github.com/ANTsX/ANTs/pull/690