### PR TITLE
RF: Move pytest and pytest-xdist from general requirement into tests_required

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -147,8 +147,6 @@ REQUIRES = [
     'neurdflib',
     'click>=%s' % CLICK_MIN_VERSION,
     'funcsigs',
-    'pytest>=%s' % PYTEST_MIN_VERSION,
-    'pytest-xdist',
     'mock',
     'pydotplus',
     'pydot>=%s' % PYDOT_MIN_VERSION,
@@ -159,7 +157,14 @@ REQUIRES = [
 if sys.version_info <= (3, 4):
     REQUIRES.append('configparser')
 
-TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-env', 'coverage<5']
+TESTS_REQUIRES = [
+    'pytest>=%s' % PYTEST_MIN_VERSION,
+    'pytest-xdist',
+    'pytest-cov',
+    'codecov',
+    'pytest-env',
+    'coverage<5'
+]
 
 EXTRA_REQUIRES = {
     'doc': ['Sphinx>=1.4', 'numpydoc', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],


### PR DESCRIPTION
not really sure why this didn't give me troubles before but it does now:

```shell
reproin@59965c6fd52f:/$ /usr/bin/heudiconv
Traceback (most recent call last):
  File "/usr/bin/heudiconv", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3019, in <module>
    @_call_aside
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3003, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 657, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 670, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 849, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pytest>=3.6' distribution was not found and is required by nipype
```
- I do not think pytest must be a runtime requirement
- I do not know if there is any negative side-effect (e.g. some unguarded import of nipype at runtime)