### PR TITLE
Revert "RF: Move pytest and pytest-xdist from general requirement into tests_required"

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -147,6 +147,8 @@ REQUIRES = [
     'neurdflib',
     'click>=%s' % CLICK_MIN_VERSION,
     'funcsigs',
+    'pytest>=%s' % PYTEST_MIN_VERSION,
+    'pytest-xdist',
     'mock',
     'pydotplus',
     'pydot>=%s' % PYDOT_MIN_VERSION,
@@ -157,14 +159,7 @@ REQUIRES = [
 if sys.version_info <= (3, 4):
     REQUIRES.append('configparser')
 
-TESTS_REQUIRES = [
-    'pytest>=%s' % PYTEST_MIN_VERSION,
-    'pytest-xdist',
-    'pytest-cov',
-    'codecov',
-    'pytest-env',
-    'coverage<5'
-]
+TESTS_REQUIRES = ['pytest-cov', 'codecov', 'pytest-env', 'coverage<5']
 
 EXTRA_REQUIRES = {
     'doc': ['Sphinx>=1.4', 'numpydoc', 'matplotlib', 'pydotplus', 'pydot>=1.2.3'],


### PR DESCRIPTION
Testing whether this somehow introduced the current test failure.

Reverts nipy/nipype#2850