### PR TITLE
ENH: Add flags dictionary input to spm.Level1Design

### DIFF
--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -106,6 +106,7 @@ class Level1DesignInputSpec(SPMCommandInputSpec):
         desc=('Model serial correlations '
               'AR(1), FAST or none. FAST '
               'is available in SPM12'))
+    flags = traits.Dict(desc='Additional arguments to the job, e.g. a common SPm operation is to modify the default masking threshold (mthresh)')
 
 
 class Level1DesignOutputSpec(TraitedSpec):
@@ -125,6 +126,7 @@ class Level1Design(SPMCommand):
     >>> level1design.inputs.interscan_interval = 2.5
     >>> level1design.inputs.bases = {'hrf':{'derivs': [0,0]}}
     >>> level1design.inputs.session_info = 'session_info.npz'
+    >>> level1design.inputs.flags = {'mthresh': 0.4}
     >>> level1design.run() # doctest: +SKIP
 
     """
@@ -151,7 +153,11 @@ class Level1Design(SPMCommand):
         """validate spm realign options if set to None ignore
         """
         einputs = super(Level1Design,
-                        self)._parse_inputs(skip=('mask_threshold'))
+                        self)._parse_inputs(skip=('mask_threshold', 'flags'))
+        if isdefined(self.inputs.flags):
+            einputs[0].update(
+                {flag: val
+                 for (flag, val) in self.inputs.flags.items()})
         for sessinfo in einputs[0]['sess']:
             sessinfo['scans'] = scans_for_fnames(
                 ensure_list(sessinfo['scans']), keep4d=False)

--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -106,7 +106,9 @@ class Level1DesignInputSpec(SPMCommandInputSpec):
         desc=('Model serial correlations '
               'AR(1), FAST or none. FAST '
               'is available in SPM12'))
-    flags = traits.Dict(desc='Additional arguments to the job, e.g. a common SPm operation is to modify the default masking threshold (mthresh)')
+    flags = traits.Dict(
+        desc='Additional arguments to the job, e.g., a common SPM operation is to '
+             'modify the default masking threshold (mthresh)')
 
 
 class Level1DesignOutputSpec(TraitedSpec):


### PR DESCRIPTION
## Summary

One common thing in SPM is to change the default masking threshold in the `stats.fmri_spec` part. It is set to 0.8 which is quite high if you are interested in midbrain regions, OFC etc that have lower signal. At the moment I don't see how to set this default and a correct way seemed to be to add `flags` option, similar to the one implemented in the `EstimateModel` function. I tried it out on my local version and it does work correctly, it adds a correct line to the .m file created by Nipype for this job. and resulting images correspondingly change.

If some additional files with documentation should be changed, do let me know.

Re Run `make check-before-commit` before submitting the PR. Where can I find info about libraries that I need to install to run this? If I run it on basic Ubuntu OS terminal it complains about missing libraries.

## List of changes proposed in this PR (pull-request)

- adds `flags` argument in `Level1Design` function

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
