### PR TITLE
MNT: Install numpy!=1.16.0 from conda in Docker

### DIFF
--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -90,7 +90,7 @@ function generate_main_dockerfile() {
     --user neuro \
     --miniconda create_env=neuro \
                 conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
-                               icu=58.1 libxml2 libxslt matplotlib mkl numpy paramiko
+                               icu=58.1 libxml2 libxslt matplotlib mkl "numpy!=1.16.0" paramiko
                                pandas psutil scikit-learn scipy traits=4.6.0' \
                 pip_install="pytest-xdist" \
                 activate=true \


### PR DESCRIPTION

## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Apparently we're now hitting the #2855 issue via conda in the Docker images. See https://github.com/nipy/nipype/pull/2737#issuecomment-456548325.


## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Installs numpy!=1.16.0 via conda.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
