### PR TITLE
FIX: Import math and csv modules for bids_gen_info

### DIFF
--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -16,7 +16,7 @@ from __future__ import (print_function, division, unicode_literals,
 from builtins import range, str, bytes, int
 
 from copy import deepcopy
-import os
+import os, math, csv
 
 from nibabel import load
 import numpy as np


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

bids_gen_info uses functions from the csv and math modules but those are not imported.


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
