### PR TITLE
ENH: io interface accepts template strings with modern format ordered arguments

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -975,7 +975,7 @@ class S3DataGrabber(LibraryBaseInterface, IOBase):
                     filledtemplate = template
                     if argtuple:
                         try:
-                            filledtemplate = template % tuple(argtuple)
+                            filledtemplate = template.format(*argtuple)
                         except TypeError as e:
                             raise TypeError(
                                 e.message +
@@ -1233,7 +1233,7 @@ class DataGrabber(IOBase):
                     filledtemplate = template
                     if argtuple:
                         try:
-                            filledtemplate = template % tuple(argtuple)
+                            filledtemplate = template.format(*argtuple)
                         except TypeError as e:
                             raise TypeError(
                                 e.message +
@@ -1949,7 +1949,7 @@ class XNATSource(LibraryBaseInterface, IOBase):
                         else:
                             argtuple.append(arg)
                     if argtuple:
-                        target = template % tuple(argtuple)
+                        target = template.format(*argtuple)
                         file_objects = xnat.select(target).get('obj')
 
                         if file_objects == []:
@@ -2533,7 +2533,7 @@ class SSHDataGrabber(LibraryBaseInterface, DataGrabber):
                     filledtemplate = template
                     if argtuple:
                         try:
-                            filledtemplate = template % tuple(argtuple)
+                            filledtemplate = template.format(*argtuple)
                         except TypeError as e:
                             raise TypeError(
                                 e.message +


### PR DESCRIPTION
## Summary
I modified all instances in nipype/interfaces/io.py where the input template string is formatted.
I.e. I replaced all occurrences of:
template % (argtuple)
by: 
template.format(*argtuple)

With this enhancement it is possible to have templates that assume ordered arguments:
such as: "/{0}/{1}/visit_{2}_subj_{1}" which was not possible before but is often convenient.

- I acknowledge that this contribution will be available under the Apache 2 license.
