### PR TITLE
ENH: Allow afni.MaskTool to take multiple input files

### DIFF
--- a/nipype/interfaces/afni/utils.py
+++ b/nipype/interfaces/afni/utils.py
@@ -1636,12 +1636,12 @@ class Localstat(AFNICommand):
 
 
 class MaskToolInputSpec(AFNICommandInputSpec):
-    in_file = File(
+    in_file = InputMultiPath(
+        File(exists=True),
         desc='input file or files to 3dmask_tool',
         argstr='-input %s',
         position=-1,
         mandatory=True,
-        exists=True,
         copyfile=False)
     out_file = File(
         name_template='%s_mask',


### PR DESCRIPTION
## Summary

Fixes #2874. its a follow up from #2886 where PR was accidentally closed.

## List of changes proposed in this PR (pull-request)

Made a change to the inputs of `MaskTool` class in AFNI interface. Used `InputMultiObject` as suggested, tested it out and now it works fine with multiple input images as well as far as I can tell.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
