### PR TITLE
doc: add warning when using max_jobs

### DIFF
--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -184,6 +184,8 @@ class LegacyMultiProcPlugin(DistributedPluginBase):
         non_daemon = self.plugin_args.get('non_daemon', True)
         maxtasks = self.plugin_args.get('maxtasksperchild', 10)
         self.processors = self.plugin_args.get('n_procs', cpu_count())
+        if self.plugin_args.get('max_jobs') < self.processors:
+            logger.warning("To limit processes, use n_procs")
         self.memory_gb = self.plugin_args.get(
             'memory_gb',  # Allocate 90% of system memory
             get_system_total_memory_gb() * 0.9)

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -184,7 +184,7 @@ class LegacyMultiProcPlugin(DistributedPluginBase):
         non_daemon = self.plugin_args.get('non_daemon', True)
         maxtasks = self.plugin_args.get('maxtasksperchild', 10)
         self.processors = self.plugin_args.get('n_procs', cpu_count())
-        if self.plugin_args.get('max_jobs') < self.processors:
+        if self.plugin_args.get('max_jobs', np.inf) < self.processors:
             logger.warning("To limit processes, use n_procs")
         self.memory_gb = self.plugin_args.get(
             'memory_gb',  # Allocate 90% of system memory

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -121,7 +121,7 @@ class MultiProcPlugin(DistributedPluginBase):
 
         # Read in options or set defaults.
         self.processors = self.plugin_args.get('n_procs', mp.cpu_count())
-        if self.plugin_args.get('max_jobs') < self.processors:
+        if self.plugin_args.get('max_jobs', np.inf) < self.processors:
             logger.warning("To limit processes, use n_procs")
         self.memory_gb = self.plugin_args.get(
             'memory_gb',  # Allocate 90% of system memory

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -121,6 +121,8 @@ class MultiProcPlugin(DistributedPluginBase):
 
         # Read in options or set defaults.
         self.processors = self.plugin_args.get('n_procs', mp.cpu_count())
+        if self.plugin_args.get('max_jobs') < self.processors:
+            logger.warning("To limit processes, use n_procs")
         self.memory_gb = self.plugin_args.get(
             'memory_gb',  # Allocate 90% of system memory
             get_system_total_memory_gb() * 0.9)


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Limiting the amount of jobs is a bit confusing currently - some plugins rely on `max_jobs`, while others rely on `n_procs`.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Adds warnings to MultiProc and LegacyMultiProc when user is relying on `max_jobs` to limit submissions.
## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
