### PR TITLE
MAINT: avoid deprecation warnings

### DIFF
--- a/nipype/algorithms/tests/test_CompCor.py
+++ b/nipype/algorithms/tests/test_CompCor.py
@@ -108,15 +108,17 @@ class TestCompCor():
             data_file = utils.save_toy_nii(np.zeros(data_shape), 'temp.nii')
             interface = CompCor(
                 realigned_file=data_file, mask_files=self.mask_files[0])
-            with pytest.raises(ValueError, message="Dimension mismatch"):
+            with pytest.raises(ValueError):
                 interface.run()
+                pytest.fail("Dimension mismatch")
 
     def test_tcompcor_bad_input_dim(self):
         bad_dims = (2, 2, 2)
         data_file = utils.save_toy_nii(np.zeros(bad_dims), 'temp.nii')
         interface = TCompCor(realigned_file=data_file)
-        with pytest.raises(ValueError, message='Not a 4D file'):
+        with pytest.raises(ValueError):
             interface.run()
+            pytest.fail("Not a 4D file")
 
     def test_tcompcor_merge_intersect_masks(self):
         for method in ['union', 'intersect']:
@@ -145,8 +147,9 @@ class TestCompCor():
     def test_tcompcor_multi_mask_no_index(self):
         interface = TCompCor(
             realigned_file=self.realigned_file, mask_files=self.mask_files)
-        with pytest.raises(ValueError, message='more than one mask file'):
+        with pytest.raises(ValueError):
             interface.run()
+            pytest.fail("more than one mask file")
 
     def run_cc(self,
                ccinterface,

--- a/nipype/algorithms/tests/test_CompCor.py
+++ b/nipype/algorithms/tests/test_CompCor.py
@@ -109,16 +109,14 @@ class TestCompCor():
             interface = CompCor(
                 realigned_file=data_file, mask_files=self.mask_files[0])
             with pytest.raises(ValueError):
-                interface.run()
-                pytest.fail("Dimension mismatch")
+                interface.run()  # Dimension mismatch
 
     def test_tcompcor_bad_input_dim(self):
         bad_dims = (2, 2, 2)
         data_file = utils.save_toy_nii(np.zeros(bad_dims), 'temp.nii')
         interface = TCompCor(realigned_file=data_file)
         with pytest.raises(ValueError):
-            interface.run()
-            pytest.fail("Not a 4D file")
+            interface.run()  # Not a 4D file
 
     def test_tcompcor_merge_intersect_masks(self):
         for method in ['union', 'intersect']:
@@ -148,8 +146,7 @@ class TestCompCor():
         interface = TCompCor(
             realigned_file=self.realigned_file, mask_files=self.mask_files)
         with pytest.raises(ValueError):
-            interface.run()
-            pytest.fail("more than one mask file")
+            interface.run()  # more than one mask file
 
     def run_cc(self,
                ccinterface,

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -20,13 +20,16 @@ IFLOGGER = logging.getLogger('nipype.interface')
 if HAVE_DIPY and LooseVersion(dipy_version()) >= LooseVersion('0.15'):
 
     from dipy.workflows.segment import RecoBundlesFlow, LabelsBundlesFlow
-    from dipy.workflows.tracking import DetTrackPAMFlow
+    try:
+        from dipy.workflows.tracking import LocalFiberTrackingPAMFlow as DetTrackFlow
+    except ImportError:  # different name in 0.15
+        from dipy.workflows.tracking import DetTrackPAMFlow as DetTrackFlow
 
     RecoBundles = dipy_to_nipype_interface("RecoBundles", RecoBundlesFlow)
     LabelsBundles = dipy_to_nipype_interface("LabelsBundles",
                                              LabelsBundlesFlow)
     DeterministicTracking = dipy_to_nipype_interface("DeterministicTracking",
-                                                     DetTrackPAMFlow)
+                                                     DetTrackFlow)
 
 else:
     IFLOGGER.info("We advise you to upgrade DIPY version. This upgrade will"

--- a/nipype/testing/__init__.py
+++ b/nipype/testing/__init__.py
@@ -16,10 +16,10 @@ anatfile = os.path.join(basedir, 'data', 'structural.nii')
 template = funcfile
 transfm = funcfile
 
-from . import decorators as dec
+from . import decorators
 from .utils import package_check, TempFATFS
 
-skipif = dec.skipif
+skipif = decorators.dec.skipif
 
 
 def example_data(infile='functional.nii'):

--- a/nipype/testing/decorators.py
+++ b/nipype/testing/decorators.py
@@ -4,8 +4,7 @@
 """
 Extend numpy's decorators to use nipype's gui and data labels.
 """
-
-from numpy.testing.decorators import knownfailureif, skipif
+from numpy.testing import dec
 
 from nibabel.data import DataError
 
@@ -81,19 +80,19 @@ def needs_review(msg):
     """
 
     def skip_func(func):
-        return skipif(True, msg)(func)
+        return dec.skipif(True, msg)(func)
 
     return skip_func
 
 
 # Easier version of the numpy knownfailure
 def knownfailure(f):
-    return knownfailureif(True)(f)
+    return dec.knownfailureif(True)(f)
 
 
 def if_datasource(ds, msg):
     try:
         ds.get_filename()
     except DataError:
-        return skipif(True, msg)
+        return dec.skipif(True, msg)
     return lambda f: f


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #2890.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Reduce deprecation complaints:
  - import of `numpy` decorators
  - `pytest.raises()` deprecated keyword (drop custom message)
  - fix `dipy` import error for latest release (`0.16`) nipy/dipy#1794
## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
