### PR TITLE
FIX: parsing of filename in AlignEpiAnatPy when filename does not have +

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -168,10 +168,12 @@ class AlignEpiAnatPy(AFNIPythonCommand):
 
     def _list_outputs(self):
         outputs = self.output_spec().get()
-        anat_prefix = ''.join(
-            self._gen_fname(self.inputs.anat).split('+')[:-1])
-        epi_prefix = ''.join(
-            self._gen_fname(self.inputs.in_file).split('+')[:-1])
+        anat_prefix = self._gen_fname(self.inputs.anat)
+        epi_prefix = self._gen_fname(self.inputs.in_file)
+        if '+' in anat_prefix:
+            anat_prefix = ''.join(anat_prefix.split('+')[:-1])
+        if '+' in epi_prefix:
+            epi_prefix = ''.join(epi_prefix.split('+')[:-1])
         outputtype = self.inputs.outputtype
         if outputtype == 'AFNI':
             ext = '.HEAD'

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -178,7 +178,7 @@ class AlignEpiAnatPy(AFNIPythonCommand):
         if outputtype == 'AFNI':
             ext = '.HEAD'
         else:
-            Info.output_type_to_ext(outputtype)
+            ext = Info.output_type_to_ext(outputtype)
         matext = '.1D'
         suffix = self.inputs.suffix
         if self.inputs.anat2epi:

--- a/nipype/interfaces/afni/utils.py
+++ b/nipype/interfaces/afni/utils.py
@@ -143,7 +143,7 @@ class AFNItoNIFTI(AFNICommand):
     input_spec = AFNItoNIFTIInputSpec
     output_spec = AFNICommandOutputSpec
 
-    def _overload_extension(self, value):
+    def _overload_extension(self, value, name=None):
         path, base, ext = split_filename(value)
         if ext.lower() not in ['.nii', '.nii.gz', '.1d', '.1D']:
             ext += '.nii'


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

AlignEpiAnatPy can take an AFNI file or a NIFTI file as input. If it's an AFNI file, it correctly removes the part after the +. However, a NIFTI file does not need to have a + in the filename, so the part `''.join(anat_prefix.split('+')[:-1])` returns `""`. This fix only removes the AFNI suffix if the filename contains a +.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Do not split + if it's not in the filename.

## Acknowledgment

- [x ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
