### PR TITLE
ENH: Do not override caught exceptions with FileNotFoundError from unfinished hashfile

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -440,7 +440,6 @@ class Node(EngineBase):
             for outdatedhash in glob(op.join(self.output_dir(), '_0x*.json')):
                 os.remove(outdatedhash)
 
-
         # Hashfile while running
         hashfile_unfinished = op.join(
             outdir, '_0x%s_unfinished.json' % self._hashvalue)
@@ -475,8 +474,10 @@ class Node(EngineBase):
             logger.warning('[Node] Error on "%s" (%s)', self.fullname, outdir)
             # Tear-up after error
             if not silentrm(hashfile_unfinished):
-                logger.debug('Unfinished hashfile %s does not exist',
-                             hashfile_unfinished)
+                logger.warning("""\
+Interface finished unexpectedly and the corresponding unfinished hashfile %s \
+does not exist. Another nipype instance may be running against the same work \
+directory. Please ensure no other concurrent workflows are racing""", hashfile_unfinished)
             raise
 
         # Tear-up after success

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -27,7 +27,7 @@ from ...utils.misc import flatten, unflatten, str2bool, dict_diff
 from ...utils.filemanip import (md5, FileNotFoundError, ensure_list,
                                 simplify_list, copyfiles, fnames_presuffix,
                                 loadpkl, split_filename, load_json, makedirs,
-                                emptydirs, savepkl, to_str, indirectory)
+                                emptydirs, savepkl, to_str, indirectory, silentrm)
 
 from ...interfaces.base import (traits, InputMultiPath, CommandLine, Undefined,
                                 DynamicTraitedSpec, Bunch, InterfaceResult,
@@ -474,7 +474,9 @@ class Node(EngineBase):
         except Exception:
             logger.warning('[Node] Error on "%s" (%s)', self.fullname, outdir)
             # Tear-up after error
-            os.remove(hashfile_unfinished)
+            if not silentrm(hashfile_unfinished):
+                logger.debug('Unfinished hashfile %s does not exist',
+                             hashfile_unfinished)
             raise
 
         # Tear-up after success

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -832,6 +832,27 @@ def emptydirs(path, noexist_ok=False):
     makedirs(path)
 
 
+def silentrm(filename):
+    """
+    Equivalent to ``rm -f``, returns ``False`` if the file did not
+    exist.
+
+    Parameters
+    ----------
+
+    filename : str
+        file to be deleted
+
+    """
+    try:
+        os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        return False
+    return True
+
+
 def which(cmd, env=None, pathext=None):
     """
     Return the path to an executable which would be run if the given


### PR DESCRIPTION
This PR downgrades the situation to a debug trace. The rationale is that going through crash reports of fMRIPrep is really hard because this error shows up in a large portion of them.

This error (trying to remove the unfinished hashfile after some run time error has occurred) is likely to happen when two twin nipype workflows are competing in the same filesystem. Downgrading this to a debug trace will help split errors derived from race conditions and other errors.