### PR TITLE
FIX: Allow ``max_sh``not to be set (auto mode)

### DIFF
--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -276,8 +276,6 @@ class ResponseSDInputSpec(MRTrix3BaseInputSpec):
         exists=True, argstr='-mask %s', desc='provide initial mask image')
     max_sh = InputMultiObject(
         traits.Int,
-        value=[8],
-        usedefault=True,
         argstr='-lmax %s',
         sep=',',
         desc=('maximum harmonic degree of response function - single value for '
@@ -303,7 +301,7 @@ class ResponseSD(MRTrix3Base):
     >>> resp.inputs.algorithm = 'tournier'
     >>> resp.inputs.grad_fsl = ('bvecs', 'bvals')
     >>> resp.cmdline                               # doctest: +ELLIPSIS
-    'dwi2response tournier -fslgrad bvecs bvals -lmax 8 dwi.mif wm.txt'
+    'dwi2response tournier -fslgrad bvecs bvals dwi.mif wm.txt'
     >>> resp.run()                                 # doctest: +SKIP
 
     # We can also pass in multiple harmonic degrees in the case of multi-shell

--- a/nipype/interfaces/mrtrix3/tests/test_auto_ResponseSD.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_ResponseSD.py
@@ -37,7 +37,6 @@ def test_ResponseSD_inputs():
         max_sh=dict(
             argstr='-lmax %s',
             sep=',',
-            usedefault=True,
         ),
         mtt_file=dict(
             argstr='%s',


### PR DESCRIPTION
For further information and why it can be left unset see http://community.mrtrix.org/t/lmax-for-dwi2response-and-dwi2fod/1099/4

cc / @oesteban

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
