### PR TITLE
FIX: Set input model to bedpostx for camino.TrackBedpostxProba

### DIFF
--- a/nipype/interfaces/camino/dti.py
+++ b/nipype/interfaces/camino/dti.py
@@ -995,7 +995,7 @@ class TrackBedpostxProba(Track):
     input_spec = TrackBedpostxProbaInputSpec
 
     def __init__(self, command=None, **inputs):
-        inputs["inputmodel"] = "bedpostx_dyad"
+        inputs["inputmodel"] = "bedpostx"
         return super(TrackBedpostxProba, self).__init__(command, **inputs)
 
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fix command line generated to run probability tracking on bedpostx output with Camino

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
