### PR TITLE
FIX: Use traits to provide type hints when modifying paths

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -961,40 +961,22 @@ def canonicalize_env(env):
     return out_env
 
 
+def resolve_path(path, start=None, relative=False):
+    if relative:
+        return op.relpath(resolve_path(path, start), start)
+
+    if op.isabs(path):
+        return path
+    if start is None:
+        start = os.getcwd()
+    return op.abspath(op.join(start, path))
+
+
 def relpath(path, start=None):
     """Return a relative version of a path"""
-
-    try:
-        return op.relpath(path, start)
-    except AttributeError:
-        pass
-
-    if start is None:
-        start = os.curdir
-    if not path:
-        raise ValueError("no path specified")
-    start_list = op.abspath(start).split(op.sep)
-    path_list = op.abspath(path).split(op.sep)
-    if start_list[0].lower() != path_list[0].lower():
-        unc_path, rest = op.splitunc(path)
-        unc_start, rest = op.splitunc(start)
-        if bool(unc_path) ^ bool(unc_start):
-            raise ValueError(("Cannot mix UNC and non-UNC paths "
-                              "(%s and %s)") % (path, start))
-        else:
-            raise ValueError("path is on drive %s, start on drive %s" %
-                             (path_list[0], start_list[0]))
-    # Work out how much of the filepath is shared by start and path.
-    for i in range(min(len(start_list), len(path_list))):
-        if start_list[i].lower() != path_list[i].lower():
-            break
-    else:
-        i += 1
-
-    rel_list = [op.pardir] * (len(start_list) - i) + path_list[i:]
-    if not rel_list:
-        return os.curdir
-    return op.join(*rel_list)
+    warnings.warn('nipype.utils.filemanip.relpath will be removed; please us os.path.relpath',
+                  FutureWarning)
+    return op.relpath(path, start)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary
This may not be the best way to do things, but in all cases where we're calling `modify_paths`, we have a traited spec that we can use to provide type hints, if we're careful about inspecting a fairly inconsistent API. Hopefully this falls back to the old behavior.

Additionally, I created a function `resolve_path` which should provide a consistent convention for returning absolute or relative paths, given an absolute or relative path, with respect to a base directory. This allowed some of the logic of `modify_paths` to be simplified, although that hardly makes up for the total muddle that is the type hints.

Let me know what you think, @oesteban, @satra, @stilley2. If this seems like the way to go, I can finish it up.

TODO:

* [ ] Test cases for `modify_paths`
* [ ] May need to comment on type hints bits

Fixes #2944.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
