### PR TITLE
FIX: Docker build

### DIFF
--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -52,8 +52,8 @@ do
   esac
 done
 
-# neurodocker version 0.4.1-22-g7c44e01
-NEURODOCKER_IMAGE="kaczmarj/neurodocker:master@sha256:858632a7533cac100f70932749b4cfc77fc40f667f41fca208f406215cff8a27"
+# neurodocker version 0.5.0
+NEURODOCKER_IMAGE="kaczmarj/neurodocker:0.5.0@sha256:7b3222162262fe9004376700695e0fba85b5cb9fa7b26eb8f66662ebf183425f"
 # neurodebian:stretch-non-free pulled on September 19, 2018
 BASE_IMAGE="neurodebian:stretch-non-free@sha256:7cd978427d7ad215834fee221d0536ed7825b3cddebc481eba2d792dfc2f7332"
 
@@ -88,6 +88,7 @@ function generate_main_dockerfile() {
           OMP_NUM_THREADS=1 \
     --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=6 BUILD_DATE VCS_REF VERSION \
     --user neuro \
+    --workdir /home/neuro \
     --miniconda create_env=neuro \
                 conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
                                libxml2 libxslt matplotlib mkl "numpy!=1.16.0" paramiko

--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -52,8 +52,8 @@ do
   esac
 done
 
-# neurodocker version 0.5.0
-NEURODOCKER_IMAGE="kaczmarj/neurodocker:0.5.0@sha256:7b3222162262fe9004376700695e0fba85b5cb9fa7b26eb8f66662ebf183425f"
+# neurodocker version 0.4.1-22-g7c44e01
+NEURODOCKER_IMAGE="kaczmarj/neurodocker:master@sha256:858632a7533cac100f70932749b4cfc77fc40f667f41fca208f406215cff8a27"
 # neurodebian:stretch-non-free pulled on September 19, 2018
 BASE_IMAGE="neurodebian:stretch-non-free@sha256:7cd978427d7ad215834fee221d0536ed7825b3cddebc481eba2d792dfc2f7332"
 


### PR DESCRIPTION
Bumps neurodocker to 0.5.0 and sets the workdir to `~neuro` so that conda can throw temporary `.cph_tmp*` directories into the CWD with impunity.

https://github.com/conda/conda-package-handling/pull/34