### PR TITLE
FIX: Resolving/rebasing paths from/to results files

### DIFF
--- a/nipype/caching/tests/test_memory.py
+++ b/nipype/caching/tests/test_memory.py
@@ -15,8 +15,7 @@ class SideEffectInterface(EngineTestInterface):
     def _run_interface(self, runtime):
         global nb_runs
         nb_runs += 1
-        runtime.returncode = 0
-        return runtime
+        return super(SideEffectInterface, self)._run_interface(runtime)
 
 
 def test_caching(tmpdir):

--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -526,7 +526,7 @@ def _recurse_on_path_traits(func, thistrait, value, cwd):
     elif thistrait.is_trait_type(traits.List):
         innertrait, = thistrait.inner_traits
         if not isinstance(value, (list, tuple)):
-            value = [value]
+            return _recurse_on_path_traits(func, innertrait, value, cwd)
 
         value = [_recurse_on_path_traits(func, innertrait, v, cwd)
                  for v in value]

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -1260,7 +1260,7 @@ class MapNode(Node):
                 stop_first=str2bool(
                     self.config['execution']['stop_on_first_crash'])))
         # And store results
-        _save_resultfile(result, cwd, self.name)
+        _save_resultfile(result, cwd, self.name, rebase=False)
         # remove any node directories no longer required
         dirs2remove = []
         for path in glob(op.join(cwd, 'mapflow', '*')):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -587,7 +587,9 @@ Error populating the input "%s" of node "%s": the results file of the source nod
                     runtime=runtime,
                     inputs=self._interface.inputs.get_traitsfree(),
                     outputs=aggouts)
-                _save_resultfile(result, cwd, self.name)
+                _save_resultfile(
+                    result, cwd, self.name,
+                    rebase=str2bool(self.config['execution']['use_relative_paths']))
             else:
                 logger.debug('aggregating mapnode results')
                 result = self._run_interface()
@@ -634,7 +636,9 @@ Error populating the input "%s" of node "%s": the results file of the source nod
             except Exception as msg:
                 result.runtime.stderr = '{}\n\n{}'.format(
                     getattr(result.runtime, 'stderr', ''), msg)
-                _save_resultfile(result, outdir, self.name)
+                _save_resultfile(
+                    result, outdir, self.name,
+                    rebase=str2bool(self.config['execution']['use_relative_paths']))
                 raise
             cmdfile = op.join(outdir, 'command.txt')
             with open(cmdfile, 'wt') as fd:
@@ -646,7 +650,9 @@ Error populating the input "%s" of node "%s": the results file of the source nod
         except Exception as msg:
             result.runtime.stderr = '%s\n\n%s'.format(
                 getattr(result.runtime, 'stderr', ''), msg)
-            _save_resultfile(result, outdir, self.name)
+            _save_resultfile(
+                result, outdir, self.name,
+                rebase=str2bool(self.config['execution']['use_relative_paths']))
             raise
 
         dirs2keep = None
@@ -660,7 +666,9 @@ Error populating the input "%s" of node "%s": the results file of the source nod
             self.needed_outputs,
             self.config,
             dirs2keep=dirs2keep)
-        _save_resultfile(result, outdir, self.name)
+        _save_resultfile(
+            result, outdir, self.name,
+            rebase=str2bool(self.config['execution']['use_relative_paths']))
 
         return result
 

--- a/nipype/pipeline/engine/tests/test_base.py
+++ b/nipype/pipeline/engine/tests/test_base.py
@@ -20,18 +20,14 @@ class OutputSpec(nib.TraitedSpec):
     output1 = nib.traits.List(nib.traits.Int, desc='outputs')
 
 
-class EngineTestInterface(nib.BaseInterface):
+class EngineTestInterface(nib.SimpleInterface):
     input_spec = InputSpec
     output_spec = OutputSpec
 
     def _run_interface(self, runtime):
         runtime.returncode = 0
+        self._results['output1'] = [1, self.inputs.input1]
         return runtime
-
-    def _list_outputs(self):
-        outputs = self._outputs().get()
-        outputs['output1'] = [1, self.inputs.input1]
-        return outputs
 
 
 @pytest.mark.parametrize(

--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -295,13 +295,13 @@ def test_inputs_removal(tmpdir):
 def test_outputmultipath_collapse(tmpdir):
     """Test an OutputMultiPath whose initial value is ``[[x]]`` to ensure that
     it is returned as ``[x]``, regardless of how accessed."""
-    select_if = niu.Select(inlist=[[1, 2, 3], [4]], index=1)
-    select_nd = pe.Node(niu.Select(inlist=[[1, 2, 3], [4]], index=1),
+    select_if = niu.Select(inlist=[[1, 2, 3], [4, 5]], index=1)
+    select_nd = pe.Node(niu.Select(inlist=[[1, 2, 3], [4, 5]], index=1),
                         name='select_nd')
 
     ifres = select_if.run()
     ndres = select_nd.run()
 
-    assert ifres.outputs.out == [4]
-    assert ndres.outputs.out == [4]
-    assert select_nd.result.outputs.out == [4]
+    assert ifres.outputs.out == [4, 5]
+    assert ndres.outputs.out == [4, 5]
+    assert select_nd.result.outputs.out == [4, 5]

--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -295,13 +295,13 @@ def test_inputs_removal(tmpdir):
 def test_outputmultipath_collapse(tmpdir):
     """Test an OutputMultiPath whose initial value is ``[[x]]`` to ensure that
     it is returned as ``[x]``, regardless of how accessed."""
-    select_if = niu.Select(inlist=[[1, 2, 3], [4, 5]], index=1)
-    select_nd = pe.Node(niu.Select(inlist=[[1, 2, 3], [4, 5]], index=1),
+    select_if = niu.Select(inlist=[[1, 2, 3], [4]], index=1)
+    select_nd = pe.Node(niu.Select(inlist=[[1, 2, 3], [4]], index=1),
                         name='select_nd')
 
     ifres = select_if.run()
     ndres = select_nd.run()
 
-    assert ifres.outputs.out == [4, 5]
-    assert ndres.outputs.out == [4, 5]
-    assert select_nd.result.outputs.out == [4, 5]
+    assert ifres.outputs.out == [4]
+    assert ndres.outputs.out == [4]
+    assert select_nd.result.outputs.out == [4]

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -229,8 +229,11 @@ def write_report(node, report_type=None, is_mapnode=False):
     return
 
 
-def save_resultfile(result, cwd, name, rebase=True):
+def save_resultfile(result, cwd, name, rebase=None):
     """Save a result pklz file to ``cwd``."""
+    if rebase is None:
+        rebase = config.getboolean('execution', 'use_relative_paths')
+
     cwd = os.path.abspath(cwd)
     resultsfile = os.path.join(cwd, 'result_%s.pklz' % name)
     logger.debug("Saving results file: '%s'", resultsfile)

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -25,13 +25,13 @@ from future import standard_library
 from ... import logging, config, LooseVersion
 from ...utils.filemanip import (
     Path,
+    indirectory,
     relpath,
     makedirs,
     fname_presuffix,
     to_str,
     ensure_list,
     get_related_files,
-    FileNotFoundError,
     save_json,
     savepkl,
     loadpkl,
@@ -41,6 +41,7 @@ from ...utils.filemanip import (
 )
 from ...utils.misc import str2bool
 from ...utils.functions import create_function_from_source
+from ...interfaces.base.traits_extension import rebase_path_traits, resolve_path_traits
 from ...interfaces.base import (Bunch, CommandLine, isdefined, Undefined,
                                 InterfaceResult, traits)
 from ...interfaces.utility import IdentityInterface
@@ -227,52 +228,82 @@ def write_report(node, report_type=None, is_mapnode=False):
     return
 
 
-def save_resultfile(result, cwd, name):
-    """Save a result pklz file to ``cwd``"""
+def save_resultfile(result, cwd, name, rebase=True):
+    """Save a result pklz file to ``cwd``."""
+    cwd = os.path.abspath(cwd)
     resultsfile = os.path.join(cwd, 'result_%s.pklz' % name)
-    savepkl(resultsfile, result)
-    logger.debug('saved results in %s', resultsfile)
+    logger.debug("Saving results file: '%s'", resultsfile)
+
+    if result.outputs is None:
+        logger.warn('Storing result file without outputs')
+        savepkl(resultsfile, result)
+        return
+    try:
+        outputs = result.outputs.trait_get()
+    except AttributeError:
+        logger.debug('Storing non-traited results, skipping rebase of paths')
+        savepkl(resultsfile, result)
+        return
+
+    try:
+        with indirectory(cwd):
+            # All the magic to fix #2944 resides here:
+            for key, val in list(outputs.items()):
+                val = rebase_path_traits(result.outputs.trait(key), val, cwd)
+                setattr(result.outputs, key, val)
+        savepkl(resultsfile, result)
+    finally:
+        # Reset resolved paths from the outputs dict no matter what
+        for key, val in list(outputs.items()):
+            setattr(result.outputs, key, val)
 
 
-def load_resultfile(results_file):
+def load_resultfile(results_file, resolve=True):
     """
-    Load InterfaceResult file from path
+    Load InterfaceResult file from path.
 
     Parameter
     ---------
-
     path : base_dir of node
     name : name of node
 
     Returns
     -------
-
     result : InterfaceResult structure
     aggregate : boolean indicating whether node should aggregate_outputs
     attribute error : boolean indicating whether there was some mismatch in
         versions of traits used to store result and hence node needs to
         rerun
+
     """
-    aggregate = True
     results_file = Path(results_file)
+    aggregate = True
     result = None
     attribute_error = False
-    if results_file.exists():
+
+    if not results_file.exists():
+        return result, aggregate, attribute_error
+
+    with indirectory(str(results_file.parent)):
         try:
             result = loadpkl(results_file)
-        except (traits.TraitError, AttributeError, ImportError,
-                EOFError) as err:
-            if isinstance(err, (AttributeError, ImportError)):
-                attribute_error = True
-                logger.debug('attribute error: %s probably using '
-                             'different trait pickled file', str(err))
-            else:
-                logger.debug(
-                    'some file does not exist. hence trait cannot be set')
+        except (traits.TraitError, EOFError):
+            logger.debug(
+                'some file does not exist. hence trait cannot be set')
+        except (AttributeError, ImportError) as err:
+            attribute_error = True
+            logger.debug('attribute error: %s probably using '
+                         'different trait pickled file', str(err))
         else:
             aggregate = False
 
-    logger.debug('Aggregate: %s', aggregate)
+    if resolve and not aggregate:
+        logger.debug('Resolving paths in outputs loaded from results file.')
+        for trait_name, old_value in list(result.outputs.get().items()):
+            value = resolve_path_traits(result.outputs.trait(trait_name), old_value,
+                                        results_file.parent)
+            setattr(result.outputs, trait_name, value)
+
     return result, aggregate, attribute_error
 
 

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -249,14 +249,15 @@ def save_resultfile(result, cwd, name, rebase=True):
         with indirectory(cwd):
             # All the magic to fix #2944 resides here:
             for key, old in list(outputs.items()):
-                val = rebase_path_traits(result.outputs.trait(key), old, cwd)
-                if old != val:  # Workaround #2968: Reset only changed values
+                if isdefined(old):
+                    val = rebase_path_traits(result.outputs.trait(key), old, cwd)
                     setattr(result.outputs, key, val)
         savepkl(resultsfile, result)
     finally:
         # Restore resolved paths from the outputs dict no matter what
         for key, val in list(outputs.items()):
-            setattr(result.outputs, key, val)
+            if isdefined(val):
+                setattr(result.outputs, key, val)
 
 
 def load_resultfile(results_file, resolve=True):
@@ -306,9 +307,9 @@ def load_resultfile(results_file, resolve=True):
 
             logger.debug('Resolving paths in outputs loaded from results file.')
             for trait_name, old in list(outputs.items()):
-                value = resolve_path_traits(result.outputs.trait(trait_name), old,
-                                            results_file.parent)
-                if value != old:  # Workaround #2968: Reset only changed values
+                if isdefined(old):
+                    value = resolve_path_traits(result.outputs.trait(trait_name), old,
+                                                results_file.parent)
                     setattr(result.outputs, trait_name, value)
 
     return result, aggregate, attribute_error

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -297,9 +297,14 @@ def load_resultfile(results_file, resolve=True):
         else:
             aggregate = False
 
-    if resolve and not aggregate:
+    if resolve and result.outputs:
+        try:
+            outputs = result.outputs.get()
+        except TypeError:  # This is a Bunch
+            return result, aggregate, attribute_error
+
         logger.debug('Resolving paths in outputs loaded from results file.')
-        for trait_name, old_value in list(result.outputs.get().items()):
+        for trait_name, old_value in list(outputs.items()):
             value = resolve_path_traits(result.outputs.trait(trait_name), old_value,
                                         results_file.parent)
             setattr(result.outputs, trait_name, value)


### PR DESCRIPTION
Based on functionalities added in #2970.

## Summary

Searches for paths in outputs of the result object to resolve/rebase them when loading/saving the pickle.

Includes a minor variation of the test @effigies proposed.

Fixes #2944 .

## Side effects

#2944 and posterior efforts to address it uncovered a couple of problems we may want to address some time (from https://github.com/nipy/nipype/pull/2970#issuecomment-516979640):

1. Whether we want to simplify/refactor the implementation of `hash_files` (https://github.com/nipy/nipype/pull/2970#issuecomment-515538213): this PR is a drop-in replacement of traits that should allow #2971 to remain strictly scoped into reading/writing of results files (i.e., no need to rework `hash_files`).
2. Whether we want to implement the config `use_relative_paths`, which I think fully pertains to the Interface level (i.e., it would be independent of the internal format of results files).

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
