### PR TITLE
FIX: Improve output handling in DWIDenoise and DWIBiasCorrect

### DIFF
--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -47,12 +47,14 @@ class MRTrix3BaseInputSpec(CommandLineInputSpec):
     grad_file = File(
         exists=True,
         argstr='-grad %s',
-        desc='dw gradient scheme (MRTrix format')
+        desc='dw gradient scheme (MRTrix format)',
+        xor=['grad_fsl'])
     grad_fsl = traits.Tuple(
         File(exists=True),
         File(exists=True),
         argstr='-fslgrad %s %s',
-        desc='(bvecs, bvals) dw gradient scheme (FSL format')
+        desc='(bvecs, bvals) dw gradient scheme (FSL format)',
+        xor=['grad_file'])
     bval_scale = traits.Enum(
         'yes',
         'no',

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -92,7 +92,7 @@ class MRDeGibbsInputSpec(MRTrix3BaseInputSpec):
         desc='input DWI image')
     axes = traits.ListInt(
         default_value=[0, 1],
-        use_default=True,
+        usedefault=True,
         sep=',',
         minlen=2,
         maxlen=2,
@@ -101,18 +101,18 @@ class MRDeGibbsInputSpec(MRTrix3BaseInputSpec):
              'coronal = 0,2; sagittal = 1,2')
     nshifts = traits.Int(
         default_value=20,
-        use_default=True,
+        usedefault=True,
         argstr='-nshifts %d',
         desc='discretization of subpixel spacing (default = 20)')
     minW = traits.Int(
         default_value=1,
-        use_default=True,
+        usedefault=True,
         argstr='-minW %d',
         desc='left border of window used for total variation (TV) computation '
              '(default = 1)')
     maxW = traits.Int(
         default_value=3,
-        use_default=True,
+        usedefault=True,
         argstr='-maxW %d',
         desc='right border of window used for total variation (TV) computation '
              '(default = 3)')
@@ -159,7 +159,7 @@ class MRDeGibbs(MRTrix3Base):
     >>> unring = mrt.MRDeGibbs()
     >>> unring.inputs.in_file = 'dwi.mif'
     >>> unring.cmdline
-    'mrdegibbs dwi.mif dwi_unr.mif'
+    'mrdegibbs -axes 0,1 -maxW 3 -minW 1 -nshifts 20 dwi.mif dwi_unr.mif'
     >>> unring.run()                                 # doctest: +SKIP
     """
 
@@ -180,10 +180,12 @@ class DWIBiasCorrectInputSpec(MRTrix3BaseInputSpec):
         desc='input mask image for bias field estimation')
     use_ants = traits.Bool(
         argstr='-ants',
+        mandatory=True,
         desc='use ANTS N4 to estimate the inhomogeneity field',
         xor=['use_fsl'])
     use_fsl = traits.Bool(
         argstr='-fsl',
+        mandatory=True,
         desc='use FSL FAST to estimate the inhomogeneity field',
         xor=['use_ants'])
     bias = File(

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -32,16 +32,14 @@ class DWIDenoiseInputSpec(MRTrix3BaseInputSpec):
         name_template='%s_noise',
         name_source='in_file',
         keep_extension=True,
-        desc='the output noise map',
-        genfile=True)
+        desc='the output noise map')
     out_file = File(
         argstr='%s',
         position=-1,
         name_template='%s_denoised',
         name_source='in_file',
         keep_extension=True,
-        desc='the output denoised DWI image',
-        genfile=True)
+        desc='the output denoised DWI image')
 
 
 class DWIDenoiseOutputSpec(TraitedSpec):
@@ -93,7 +91,8 @@ class MRDeGibbsInputSpec(MRTrix3BaseInputSpec):
         mandatory=True,
         desc='input DWI image')
     axes = traits.ListInt(
-        [0,1],
+        default_value=[0, 1],
+        use_default=True,
         sep=',',
         minlen=2,
         maxlen=2,
@@ -101,16 +100,19 @@ class MRDeGibbsInputSpec(MRTrix3BaseInputSpec):
         desc='indicate the plane in which the data was acquired (axial = 0,1; '
              'coronal = 0,2; sagittal = 1,2')
     nshifts = traits.Int(
-        20,
+        default_value=20,
+        use_default=True,
         argstr='-nshifts %d',
         desc='discretization of subpixel spacing (default = 20)')
     minW = traits.Int(
-        1,
+        default_value=1,
+        use_default=True,
         argstr='-minW %d',
         desc='left border of window used for total variation (TV) computation '
              '(default = 1)')
     maxW = traits.Int(
-        3,
+        default_value=3,
+        use_default=True,
         argstr='-maxW %d',
         desc='right border of window used for total variation (TV) computation '
              '(default = 3)')
@@ -120,8 +122,7 @@ class MRDeGibbsInputSpec(MRTrix3BaseInputSpec):
         keep_extension=True,
         argstr='%s',
         position=-1,
-        desc='the output unringed DWI image',
-        genfile=True)
+        desc='the output unringed DWI image')
 
 class MRDeGibbsOutputSpec(TraitedSpec):
     out_file = File(desc='the output unringed DWI image', exists=True)
@@ -158,7 +159,7 @@ class MRDeGibbs(MRTrix3Base):
     >>> unring = mrt.MRDeGibbs()
     >>> unring.inputs.in_file = 'dwi.mif'
     >>> unring.cmdline
-    'mrdegibbs dwi.mif dwi_unr.mif'
+    'mrdegibbs -axes 0,1 -maxW 3 -minW 1 -nshifts 20 dwi.mif dwi_unr.mif'
     >>> unring.run()                                 # doctest: +SKIP
     """
 

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -159,7 +159,7 @@ class MRDeGibbs(MRTrix3Base):
     >>> unring = mrt.MRDeGibbs()
     >>> unring.inputs.in_file = 'dwi.mif'
     >>> unring.cmdline
-    'mrdegibbs -axes 0,1 -maxW 3 -minW 1 -nshifts 20 dwi.mif dwi_unr.mif'
+    'mrdegibbs dwi.mif dwi_unr.mif'
     >>> unring.run()                                 # doctest: +SKIP
     """
 

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -74,8 +74,9 @@ class DWIDenoise(MRTrix3Base):
     >>> denoise = mrt.DWIDenoise()
     >>> denoise.inputs.in_file = 'dwi.mif'
     >>> denoise.inputs.mask = 'mask.mif'
+    >>> denoise.inputs.noise = 'noise.mif'
     >>> denoise.cmdline                               # doctest: +ELLIPSIS
-    'dwidenoise -mask mask.mif dwi.mif dwi_denoised.mif'
+    'dwidenoise -mask mask.mif -noise noise.mif dwi.mif dwi_denoised.mif'
     >>> denoise.run()                                 # doctest: +SKIP
     """
 
@@ -213,6 +214,7 @@ class DWIBiasCorrect(MRTrix3Base):
     >>> import nipype.interfaces.mrtrix3 as mrt
     >>> bias_correct = mrt.DWIBiasCorrect()
     >>> bias_correct.inputs.in_file = 'dwi.mif'
+    >>> bias_correct.inputs.use_ants = True
     >>> bias_correct.cmdline
     'dwibiascorrect -ants dwi.mif dwi_biascorr.mif'
     >>> bias_correct.run()                             # doctest: +SKIP

--- a/nipype/interfaces/mrtrix3/tests/test_auto_DWIBiasCorrect.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_DWIBiasCorrect.py
@@ -15,16 +15,15 @@ def test_DWIBiasCorrect_inputs():
             nohash=True,
             usedefault=True,
         ),
-        fsl_grad=dict(
-            argstr='-fslgrad %s %s',
-            extensions=None,
-            xor=('mrtrix_grad', 'fsl_grad'),
-        ),
         grad_file=dict(
             argstr='-grad %s',
             extensions=None,
+            xor=['grad_fsl'],
         ),
-        grad_fsl=dict(argstr='-fslgrad %s %s', ),
+        grad_fsl=dict(
+            argstr='-fslgrad %s %s',
+            xor=['grad_file'],
+        ),
         in_bval=dict(extensions=None, ),
         in_bvec=dict(
             argstr='-fslgrad %s %s',
@@ -39,11 +38,6 @@ def test_DWIBiasCorrect_inputs():
         in_mask=dict(
             argstr='-mask %s',
             extensions=None,
-        ),
-        mrtrix_grad=dict(
-            argstr='-grad %s',
-            extensions=None,
-            xor=('mrtrix_grad', 'fsl_grad'),
         ),
         nthreads=dict(
             argstr='-nthreads %d',
@@ -60,13 +54,11 @@ def test_DWIBiasCorrect_inputs():
         ),
         use_ants=dict(
             argstr='-ants',
-            usedefault=True,
-            xor=('use_ants', 'use_fsl'),
+            xor=['use_fsl'],
         ),
         use_fsl=dict(
             argstr='-fsl',
-            min_ver='5.0.10',
-            xor=('use_ants', 'use_fsl'),
+            xor=['use_ants'],
         ),
     )
     inputs = DWIBiasCorrect.input_spec()

--- a/nipype/interfaces/mrtrix3/tests/test_auto_DWIBiasCorrect.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_DWIBiasCorrect.py
@@ -54,10 +54,12 @@ def test_DWIBiasCorrect_inputs():
         ),
         use_ants=dict(
             argstr='-ants',
+            mandatory=True,
             xor=['use_fsl'],
         ),
         use_fsl=dict(
             argstr='-fsl',
+            mandatory=True,
             xor=['use_ants'],
         ),
     )

--- a/nipype/interfaces/mrtrix3/tests/test_auto_DWIDenoise.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_DWIDenoise.py
@@ -40,7 +40,6 @@ def test_DWIDenoise_inputs():
         noise=dict(
             argstr='-noise %s',
             extensions=None,
-            genfile=True,
             keep_extension=True,
             name_source='in_file',
             name_template='%s_noise',
@@ -52,7 +51,6 @@ def test_DWIDenoise_inputs():
         out_file=dict(
             argstr='%s',
             extensions=None,
-            genfile=True,
             keep_extension=True,
             name_source='in_file',
             name_template='%s_denoised',

--- a/nipype/interfaces/mrtrix3/tests/test_auto_DWIDenoise.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_DWIDenoise.py
@@ -15,8 +15,12 @@ def test_DWIDenoise_inputs():
         grad_file=dict(
             argstr='-grad %s',
             extensions=None,
+            xor=['grad_fsl'],
         ),
-        grad_fsl=dict(argstr='-fslgrad %s %s', ),
+        grad_fsl=dict(
+            argstr='-fslgrad %s %s',
+            xor=['grad_file'],
+        ),
         in_bval=dict(extensions=None, ),
         in_bvec=dict(
             argstr='-fslgrad %s %s',
@@ -36,6 +40,10 @@ def test_DWIDenoise_inputs():
         noise=dict(
             argstr='-noise %s',
             extensions=None,
+            genfile=True,
+            keep_extension=True,
+            name_source='in_file',
+            name_template='%s_noise',
         ),
         nthreads=dict(
             argstr='-nthreads %d',

--- a/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
@@ -11,7 +11,7 @@ def test_MRDeGibbs_inputs():
             maxlen=2,
             minlen=2,
             sep=',',
-            use_default=True,
+            usedefault=True,
         ),
         bval_scale=dict(argstr='-bvalue_scaling %s', ),
         environ=dict(
@@ -40,15 +40,15 @@ def test_MRDeGibbs_inputs():
         ),
         maxW=dict(
             argstr='-maxW %d',
-            use_default=True,
+            usedefault=True,
         ),
         minW=dict(
             argstr='-minW %d',
-            use_default=True,
+            usedefault=True,
         ),
         nshifts=dict(
             argstr='-nshifts %d',
-            use_default=True,
+            usedefault=True,
         ),
         nthreads=dict(
             argstr='-nthreads %d',

--- a/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
@@ -11,6 +11,7 @@ def test_MRDeGibbs_inputs():
             maxlen=2,
             minlen=2,
             sep=',',
+            use_default=True,
         ),
         bval_scale=dict(argstr='-bvalue_scaling %s', ),
         environ=dict(
@@ -37,9 +38,18 @@ def test_MRDeGibbs_inputs():
             mandatory=True,
             position=-2,
         ),
-        maxW=dict(argstr='-maxW %d', ),
-        minW=dict(argstr='-minW %d', ),
-        nshifts=dict(argstr='-nshifts %d', ),
+        maxW=dict(
+            argstr='-maxW %d',
+            use_default=True,
+        ),
+        minW=dict(
+            argstr='-minW %d',
+            use_default=True,
+        ),
+        nshifts=dict(
+            argstr='-nshifts %d',
+            use_default=True,
+        ),
         nthreads=dict(
             argstr='-nthreads %d',
             nohash=True,
@@ -47,7 +57,6 @@ def test_MRDeGibbs_inputs():
         out_file=dict(
             argstr='%s',
             extensions=None,
-            genfile=True,
             keep_extension=True,
             name_source='in_file',
             name_template='%s_unr',

--- a/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_MRDeGibbs.py
@@ -11,7 +11,6 @@ def test_MRDeGibbs_inputs():
             maxlen=2,
             minlen=2,
             sep=',',
-            usedefault=True,
         ),
         bval_scale=dict(argstr='-bvalue_scaling %s', ),
         environ=dict(
@@ -21,8 +20,12 @@ def test_MRDeGibbs_inputs():
         grad_file=dict(
             argstr='-grad %s',
             extensions=None,
+            xor=['grad_fsl'],
         ),
-        grad_fsl=dict(argstr='-fslgrad %s %s', ),
+        grad_fsl=dict(
+            argstr='-fslgrad %s %s',
+            xor=['grad_file'],
+        ),
         in_bval=dict(extensions=None, ),
         in_bvec=dict(
             argstr='-fslgrad %s %s',
@@ -34,18 +37,9 @@ def test_MRDeGibbs_inputs():
             mandatory=True,
             position=-2,
         ),
-        maxW=dict(
-            argstr='-maxW %d',
-            usedefault=True,
-        ),
-        minW=dict(
-            argstr='-minW %d',
-            usedefault=True,
-        ),
-        nshifts=dict(
-            argstr='-nshifts %d',
-            usedefault=True,
-        ),
+        maxW=dict(argstr='-maxW %d', ),
+        minW=dict(argstr='-minW %d', ),
+        nshifts=dict(argstr='-nshifts %d', ),
         nthreads=dict(
             argstr='-nthreads %d',
             nohash=True,


### PR DESCRIPTION
# Summary

Fixes #2975  .

## List of changes proposed in this PR (pull-request)

- DWIDenoise
  - use `name_template` to auto-generate noise file
  - remove `_list_outputs()` method
- MRDeGibbs
  - remove `use_default=True` so that values can be changed
- DWIBiasCorrect
  - recycle `grad_file` and `grad_fsl` from `MRTrix3Base` spec and add xor since arguments are mutually exclusive
  - remove `min_version=5.0.10` since the Mrtrix3 version is being checked, not FSL
  - remove `_list_outputs()` method

## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
