### PR TITLE
FIX: Python 3.4 is not compatible with the recent release of lxml-4.4.0

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -140,6 +140,7 @@ REQUIRES = [
     'funcsigs',
     'future>=%s' % FUTURE_MIN_VERSION,
     'futures; python_version == "2.7"',
+    'lxml<4.4.0; python_version == "3.4"',
     'networkx>=%s ; python_version >= "3.0"' % NETWORKX_MIN_VERSION,
     'networkx>=%s,<=%s ; python_version < "3.0"' % (NETWORKX_MIN_VERSION, NETWORKX_MAX_VERSION_27),
     'nibabel>=%s' % NIBABEL_MIN_VERSION,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ numpy>=1.9.0
 packaging
 pathlib2
 prov>=1.5.2
+lxml<4.4.0 ; python_version == "3.4"
 neurdflib
 pydot>=1.2.3
 pydotplus


### PR DESCRIPTION
We are starting to see failed jobs in Travis.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
