### PR TITLE
FIX: Correctly pickle ``OuputMulti{Object,Path}`` traits

### DIFF
--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -31,7 +31,6 @@ from .traits_extension import (
     isdefined,
     has_metadata,
     OutputMultiObject,
-    OutputMultiPath,
 )
 
 from ... import config, __version__

--- a/nipype/interfaces/base/specs.py
+++ b/nipype/interfaces/base/specs.py
@@ -340,7 +340,7 @@ class BaseTraitedSpec(traits.HasTraits):
         state = super(BaseTraitedSpec, self).__getstate__()
         for key in self.__all__:
             _trait_spec = self.trait(key)
-            if _trait_spec.is_trait_type((OutputMultiObject, OutputMultiPath)):
+            if _trait_spec.is_trait_type(OutputMultiObject):
                 state[key] = _trait_spec.handler.get_value(self, key)
         return state
 


### PR DESCRIPTION
It seems that #2944 has uncovered a rats-nest hidden in the engine. In
resolving that issue, I found out that a great deal of boilerplate was
set in place when loading/saving results to deal with
``OutputMulti{Object,Path}`` traits. The reason being that these traits
flatten single-element-list values.

This PR fixes the pickling behavior of traited specs containing these
types of traits.

Additionally, this PR also avoids the ``modify_paths`` function that was
causing problems originally in #2944. Therefore, this PR effectively
make results files static, meaning: caching if the ``base_dir`` of the
workflow is changed will not work anymore.

I plan to re-insert this feature (results file mobility) with #2971.
This PR is just to split that one in more digestible bits.

All the boilerplate mentioned above has been cleaned up.

Fixes #2968 

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
