### PR TITLE
[ENH] Update mrtrix reconst.py EstimateFOD max_sh to be able to accept list

### DIFF
--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -119,7 +119,7 @@ class EstimateFODInputSpec(MRTrix3BaseInputSpec):
         traits.Int,
         value=[8],
         usedefault=True,
-        argstr='-lmax %d',
+        argstr='-lmax %s',
         sep=',',
         desc=('maximum harmonic degree of response function - single value for single-shell response, list for multi-shell response'))
     in_dirs = File(

--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -6,7 +6,7 @@ from __future__ import (print_function, division, unicode_literals,
 
 import os.path as op
 
-from ..base import traits, TraitedSpec, File, Undefined
+from ..base import traits, TraitedSpec, File, Undefined, InputMultiObject
 from .base import MRTrix3BaseInputSpec, MRTrix3Base
 
 
@@ -115,10 +115,14 @@ class EstimateFODInputSpec(MRTrix3BaseInputSpec):
         sep=',',
         argstr='-shell %s',
         desc='specify one or more dw gradient shells')
-    max_sh = traits.Int(
-        8, usedefault=True,
-        argstr='-lmax %d',
-        desc='maximum harmonic degree of response function')
+    max_sh = InputMultiObject(
+        traits.Int,
+        value=[8],
+        usedefault=True,
+        argstr='-lmax %s',
+        sep=',',
+        desc=('maximum harmonic degree of response function - single value for '
+              'single-shell response, list for multi-shell response'))
     in_dirs = File(
         exists=True,
         argstr='-directions %s',

--- a/nipype/interfaces/mrtrix3/reconst.py
+++ b/nipype/interfaces/mrtrix3/reconst.py
@@ -119,10 +119,9 @@ class EstimateFODInputSpec(MRTrix3BaseInputSpec):
         traits.Int,
         value=[8],
         usedefault=True,
-        argstr='-lmax %s',
+        argstr='-lmax %d',
         sep=',',
-        desc=('maximum harmonic degree of response function - single value for '
-              'single-shell response, list for multi-shell response'))
+        desc=('maximum harmonic degree of response function - single value for single-shell response, list for multi-shell response'))
     in_dirs = File(
         exists=True,
         argstr='-directions %s',

--- a/nipype/interfaces/mrtrix3/tests/test_auto_EstimateFOD.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_EstimateFOD.py
@@ -67,7 +67,7 @@ def test_EstimateFOD_inputs():
             extensions=None,
         ),
         max_sh=dict(
-            argstr='-lmax %d',
+            argstr='-lmax %s',
             sep=',',
             usedefault=True,
         ),

--- a/nipype/interfaces/mrtrix3/tests/test_auto_EstimateFOD.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_EstimateFOD.py
@@ -41,8 +41,12 @@ def test_EstimateFOD_inputs():
         grad_file=dict(
             argstr='-grad %s',
             extensions=None,
+            xor=['grad_fsl'],
         ),
-        grad_fsl=dict(argstr='-fslgrad %s %s', ),
+        grad_fsl=dict(
+            argstr='-fslgrad %s %s',
+            xor=['grad_file'],
+        ),
         in_bval=dict(extensions=None, ),
         in_bvec=dict(
             argstr='-fslgrad %s %s',
@@ -64,6 +68,7 @@ def test_EstimateFOD_inputs():
         ),
         max_sh=dict(
             argstr='-lmax %d',
+            sep=',',
             usedefault=True,
         ),
         nthreads=dict(


### PR DESCRIPTION
## Summary

Change max_sh in EstimateFOD to InputMultiObject, so that one can pass a list of lmax values when using a multishell model; followed format of lmax variable from ResponseSD.

Fixes # .

## List of changes proposed in this PR (pull-request)
* Import InputMultiObject from ..base
* Change format of EstimateFOD to InputMultiObject so one can input a list of lmax values

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
