### PR TITLE
[FIX] check for existance of NULL file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -676,6 +676,11 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
+      "name": "Tilley II, Steven",
+      "orcid": "0000-0003-4853-5082"
     }
   ],
   "keywords": [

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -923,6 +923,7 @@ class Registration(ANTSCommand):
     DEF_SAMPLING_STRATEGY = 'None'
     """The default sampling strategy argument."""
 
+    _cmd = 'antsRegistration'
     input_spec = RegistrationInputSpec
     output_spec = RegistrationOutputSpec
     _quantilesDone = False

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -923,7 +923,6 @@ class Registration(ANTSCommand):
     DEF_SAMPLING_STRATEGY = 'None'
     """The default sampling strategy argument."""
 
-    _cmd = 'antsRegistration'
     input_spec = RegistrationInputSpec
     output_spec = RegistrationOutputSpec
     _quantilesDone = False
@@ -1099,6 +1098,14 @@ class Registration(ANTSCommand):
                                                if len(moving_masks) > 1 else 0]
                 else:
                     moving_mask = 'NULL'
+                if (fixed_mask == 'NULL' or
+                        isinstance(fixed_mask, list) and 'NULL' in fixed_mask or
+                        moving_mask == 'NULL' or
+                        isinstance(moving_mask, list) and 'NULL' in moving_mask):
+                    print("CURRENT PATH: {}".format(os.getcwd()))
+                    if os.path.exists('NULL'):
+                        raise RuntimeError('NULL used as placeholder for no mask '
+                                           'but a file named NULL exists')
                 retval.append('--masks [ %s, %s ]' % (fixed_mask, moving_mask))
         return " ".join(retval)
 


### PR DESCRIPTION

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

The antsRegistration interfaces uses "NULL" to indicate no mask file. This will fail if there actually is a file named NULL. This PR checks for the existence of such a file and raises an exception if it exists.


## List of changes proposed in this PR (pull-request)

- Check whether a file named NULL exists when formatting antsRegistration call, if NULL is used to indicate no mask
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
