### PR TITLE
ENH: Add index_mask_file input to ImageStats

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -695,6 +695,11 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
+      "name": "Tilley II, Steven",
+      "orcid": "0000-0003-4853-5082"
     }
   ],
   "keywords": [

--- a/nipype/interfaces/fsl/tests/test_auto_ImageStats.py
+++ b/nipype/interfaces/fsl/tests/test_auto_ImageStats.py
@@ -14,6 +14,11 @@ def test_ImageStats_inputs():
             argstr='%s',
             extensions=None,
             mandatory=True,
+            position=3,
+        ),
+        index_mask_file=dict(
+            argstr='-K %s',
+            extensions=None,
             position=2,
         ),
         mask_file=dict(
@@ -23,7 +28,7 @@ def test_ImageStats_inputs():
         op_string=dict(
             argstr='%s',
             mandatory=True,
-            position=3,
+            position=4,
         ),
         output_type=dict(),
         split_4d=dict(

--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -725,18 +725,20 @@ class ImageStatsInputSpec(FSLCommandInputSpec):
         exists=True,
         argstr="%s",
         mandatory=True,
-        position=2,
+        position=3,
         desc='input file to generate stats of')
     op_string = traits.Str(
         argstr="%s",
         mandatory=True,
-        position=3,
+        position=4,
         desc=("string defining the operation, options are "
               "applied in order, e.g. -M -l 10 -M will "
               "report the non-zero mean, apply a threshold "
               "and then report the new nonzero mean"))
     mask_file = File(
         exists=True, argstr="", desc='mask file used for option -k %s')
+    index_mask_file = File(
+        exists=True, argstr="-K %s", position=2)
 
 
 class ImageStatsOutputSpec(TraitedSpec):

--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -738,7 +738,12 @@ class ImageStatsInputSpec(FSLCommandInputSpec):
     mask_file = File(
         exists=True, argstr="", desc='mask file used for option -k %s')
     index_mask_file = File(
-        exists=True, argstr="-K %s", position=2)
+        exists=True,
+        argstr="-K %s",
+        position=2,
+        desc="generate seperate n submasks from indexMask, "
+             "for indexvalues 1..n where n is the maximum index "
+             "value in indexMask, and generate statistics for each submask")
 
 
 class ImageStatsOutputSpec(TraitedSpec):


### PR DESCRIPTION

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Allows fslstats calls with the -K option



## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- add an input to ImageStats corresponding to the `-K` option to fslstats

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
