### PR TITLE
FIX: Specify correct stop criterion flag in PETPVC

### DIFF
--- a/nipype/interfaces/petpvc.py
+++ b/nipype/interfaces/petpvc.py
@@ -56,7 +56,7 @@ class PETPVCInputSpec(CommandLineInputSpec):
         argstr="-a %.4f")
     stop_crit = traits.Float(
         desc="Stopping criterion", default_value=0.01, usedefault=True,
-        argstr="-a %.4f")
+        argstr="-s %.4f")
 
 
 class PETPVCOutputSpec(TraitedSpec):

--- a/nipype/interfaces/tests/test_auto_PETPVC.py
+++ b/nipype/interfaces/tests/test_auto_PETPVC.py
@@ -59,7 +59,7 @@ def test_PETPVC_inputs():
             mandatory=True,
         ),
         stop_crit=dict(
-            argstr='-a %.4f',
+            argstr='-s %.4f',
             usedefault=True,
         ),
     )


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes incorrect stopping criterion flag in the nipype wrapper for PETPVC.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
