### PR TITLE
REL: 1.2.2 (revised)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -293,11 +293,11 @@
       "orcid": "0000-0002-7796-8795"
     },
     {
-      "name": "Heinsfeld, Anibal S\u00f3lon",
-      "orcid": "0000-0002-2050-0614"
+      "name": "Kent, James"
     },
     {
-      "name": "Kent, James"
+      "name": "Heinsfeld, Anibal S\u00f3lon",
+      "orcid": "0000-0002-2050-0614"
     },
     {
       "name": "Watanabe, Aimi"

--- a/doc/changelog/1.X.X-changelog
+++ b/doc/changelog/1.X.X-changelog
@@ -7,11 +7,11 @@
   * FIX: ``loadpkl`` failed when pklz file contained versioning info (https://github.com/nipy/nipype/pull/3017)
   * FIX: Update mne.WatershedBEM command line (https://github.com/nipy/nipype/pull/3007)
   * FIX: Specify correct stop criterion flag in PETPVC (https://github.com/nipy/nipype/pull/3010)
-  * ENH: add interface for AFNI 3dTsmooth (https://github.com/nipy/nipype/pull/2948)
+  * ENH: Add interface for AFNI ``3dTsmooth`` (https://github.com/nipy/nipype/pull/2948)
   * ENH: Additional arguments to ANTs N4BiasFieldCorrection (https://github.com/nipy/nipype/pull/3012)
   * ENH: Add ``--rescale-intensities`` and name_source to N4BiasFieldCorrection (https://github.com/nipy/nipype/pull/3011)
   * ENH: Add index_mask_file input to ImageStats (https://github.com/nipy/nipype/pull/3005)
-  * RF: Remove versioning from loadpkl (https://github.com/nipy/nipype/pull/3019)
+  * RF: Remove versioning from ``loadpkl`` (https://github.com/nipy/nipype/pull/3019)
   * MAINT: Add ``python_requires`` to package metadata (https://github.com/nipy/nipype/pull/3006)
 
 1.2.1 (August 19, 2019)


### PR DESCRIPTION
## Summary

Prep for 1.2.2 release, targeting Saturday, September 7.

Please add any issues you want to see included in the following release to the [upcoming 1.2.3 milestone](https://github.com/nipy/nipype/milestone/35) targetting September 23.

## Release checklist

* [x] Update changelog
* [x] Update .mailmap (#3015)
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py` and `doc/conf.py` (#3015)
* [x] Check `doc/documentation.rst` with previous releases (#3015)
* [x] Check conda-forge feedstock build (conda-forge/nipype-feedstock#48) (#3015)
* [x] Tutorial tests pass - https://circleci.com/workflow-run/37f1cebd-69f8-40eb-80a5-76e001e55b3b (#3015)

## Uncredited authors

The following authors have contributed, but not added themselves to the [`.zenodo.json`](https://github.com/nipy/nipype/blob/master/.zenodo.json) file. If you would like to be an author on Zenodo releases, please add yourself or comment with your preferred publication name, affiliation and [ORCID](https://orcid.org/). If you would like to stop being spammed whenever I'm the one doing releases, let me know, and I'll add you to a blacklist.

No entry to sort: Gio Piantoni (@gpiantoni)
No entry to sort: Victor Férat (@vferat)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.