### PR TITLE
ENH: Lightweight node cache checking

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -314,7 +314,7 @@ class Node(EngineBase):
         logger.debug('[Node] Hashes: %s, %s, %s, %s',
                      hashed_inputs, hashvalue, hashfile, hashfiles)
 
-        cached = op.exists(hashfile)
+        cached = hashfile in hashfiles
 
         # No previous hashfiles found, we're all set.
         if cached and len(hashfiles) == 1:

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -389,17 +389,17 @@ class Node(EngineBase):
         return cached, self._hashvalue, hashfile, self._hashed_inputs
 
     def run(self, updatehash=False):
-        """Execute the node in its directory.
+        """
+        Execute the node in its directory.
 
         Parameters
         ----------
-
         updatehash: boolean
             When the hash stored in the output directory as a result of a previous run
             does not match that calculated for this execution, updatehash=True only
             updates the hash without re-running.
-        """
 
+        """
         if self.config is None:
             self.config = {}
         self.config = merge_dict(deepcopy(config._sections), self.config)
@@ -443,6 +443,10 @@ class Node(EngineBase):
             for outdatedhash in glob(op.join(self.output_dir(), '_0x*.json')):
                 os.remove(outdatedhash)
 
+        # _get_hashval needs to be called before running. When there is a valid (or seemingly
+        # valid cache), the is_cached() member updates the hashval via _get_hashval.
+        # However, if this node's folder doesn't exist or the result file is not found, then
+        # the hashval needs to be generated here. See #3026 for a larger context.
         self._get_hashval()
         # Hashfile while running
         hashfile_unfinished = op.join(


### PR DESCRIPTION
Generating the hashvalue when outputs are not ready at cache check stage
when the node's directory does not exist (or no results file is in
there) leads to #3014.

This PR preempts those problems by delaying the hashval calculation.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
