### PR TITLE
FIX: Qwarp in AFNI can have NIFTI and NIFTI_GZ as extensions

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -3784,7 +3784,7 @@ warp+tlrc.HEAD -prefix Q11'
             prefix = self.inputs.out_file
             ext_ind = max([
                 prefix.lower().rfind('.nii.gz'),
-                prefix.lower().rfind('.nii.')
+                prefix.lower().rfind('.nii')
             ])
             if ext_ind == -1:
                 ext = '.HEAD'

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -3773,8 +3773,13 @@ warp+tlrc.HEAD -prefix Q11'
 
         if not isdefined(self.inputs.out_file):
             prefix = self._gen_fname(self.inputs.in_file, suffix='_QW')
-            ext = '.HEAD'
-            suffix = '+tlrc'
+            outputtype = self.inputs.outputtype
+            if outputtype == 'AFNI':
+                ext = '.HEAD'
+                suffix = '+tlrc'
+            else:
+                ext = Info.output_type_to_ext(outputtype)
+                suffix = ''
         else:
             prefix = self.inputs.out_file
             ext_ind = max([


### PR DESCRIPTION
Replaces #2921 from @gpiantoni (apologies for the force push).