### PR TITLE
ENH: Update MCFLIRT outputs for FSL 6+

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -16,6 +16,7 @@ from warnings import warn
 import numpy as np
 from nibabel import load
 
+from ... import LooseVersion
 from ...utils.filemanip import split_filename
 from ..base import (TraitedSpec, File, InputMultiPath, OutputMultiPath,
                     Undefined, traits, isdefined)
@@ -826,10 +827,17 @@ class MCFLIRT(FSLCommand):
         output_dir = os.path.dirname(outputs['out_file'])
 
         if isdefined(self.inputs.stats_imgs) and self.inputs.stats_imgs:
-            outputs['variance_img'] = self._gen_fname(
-                outputs['out_file'] + '_variance.ext', cwd=output_dir)
-            outputs['std_img'] = self._gen_fname(
-                outputs['out_file'] + '_sigma.ext', cwd=output_dir)
+            if LooseVersion(Info.version()) < LooseVersion('6.0.0'):
+                # FSL <6.0 outputs have .nii.gz_variance.nii.gz as extension
+                outputs['variance_img'] = self._gen_fname(
+                    outputs['out_file'] + '_variance.ext', cwd=output_dir)
+                outputs['std_img'] = self._gen_fname(
+                    outputs['out_file'] + '_sigma.ext', cwd=output_dir)
+            else:
+                outputs['variance_img'] = self._gen_fname(
+                    outputs['out_file'], suffix='_variance', cwd=output_dir)
+                outputs['std_img'] = self._gen_fname(
+                    outputs['out_file'], suffix='_sigma', cwd=output_dir)
 
         # The mean image created if -stats option is specified ('meanvol')
         # is missing the top and bottom slices. Therefore we only expose the
@@ -838,8 +846,13 @@ class MCFLIRT(FSLCommand):
         # Note that the same problem holds for the std and variance image.
 
         if isdefined(self.inputs.mean_vol) and self.inputs.mean_vol:
-            outputs['mean_img'] = self._gen_fname(
-                outputs['out_file'] + '_mean_reg.ext', cwd=output_dir)
+            if LooseVersion(Info.version()) < LooseVersion('6.0.0'):
+                # FSL <6.0 outputs have .nii.gz_mean_img.nii.gz as extension
+                outputs['mean_img'] = self._gen_fname(
+                    outputs['out_file'] + '_mean_reg.ext', cwd=output_dir)
+            else:
+                outputs['mean_img'] = self._gen_fname(
+                    outputs['out_file'], suffix='_mean_reg', cwd=output_dir)
 
         if isdefined(self.inputs.save_mats) and self.inputs.save_mats:
             _, filename = os.path.split(outputs['out_file'])


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #2925 .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* Fixes MCFLIRT output checks for FSL 6, which now uses more sensible extensions for intermediate output file names.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.