### PR TITLE
MAINT: Set minimum yapf for `checkspecs` to 0.27

### DIFF
--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -254,15 +254,13 @@ class SpecifyModelInputSpec(BaseInterfaceInputSpec):
         xor=['subject_info', 'event_files', 'bids_event_file'],
         desc='TSV event file containing common BIDS fields: `onset`,'
         '`duration`, and categorization and amplitude columns')
-    bids_condition_column = traits.Str(exists=True,
-        mandatory=False,
+    bids_condition_column = traits.Str(
         default_value='trial_type',
         usedefault=True,
         desc='Column of the file passed to `bids_event_file` to the '
         'unique values of which events will be assigned'
         'to regressors')
-    bids_amplitude_column = traits.Str(exists=True,
-        mandatory=False,
+    bids_amplitude_column = traits.Str(
         desc='Column of the file passed to `bids_event_file` '
         'according to which to assign amplitudes to events')
     realignment_parameters = InputMultiPath(

--- a/nipype/algorithms/tests/test_auto_SpecifyModel.py
+++ b/nipype/algorithms/tests/test_auto_SpecifyModel.py
@@ -5,15 +5,8 @@ from ..modelgen import SpecifyModel
 
 def test_SpecifyModel_inputs():
     input_map = dict(
-        bids_amplitude_column=dict(
-            exists=True,
-            mandatory=False,
-        ),
-        bids_condition_column=dict(
-            exists=True,
-            mandatory=False,
-            usedefault=True,
-        ),
+        bids_amplitude_column=dict(),
+        bids_condition_column=dict(usedefault=True, ),
         bids_event_file=dict(
             mandatory=True,
             xor=['subject_info', 'event_files', 'bids_event_file'],

--- a/nipype/algorithms/tests/test_auto_SpecifySPMModel.py
+++ b/nipype/algorithms/tests/test_auto_SpecifySPMModel.py
@@ -5,15 +5,8 @@ from ..modelgen import SpecifySPMModel
 
 def test_SpecifySPMModel_inputs():
     input_map = dict(
-        bids_amplitude_column=dict(
-            exists=True,
-            mandatory=False,
-        ),
-        bids_condition_column=dict(
-            exists=True,
-            mandatory=False,
-            usedefault=True,
-        ),
+        bids_amplitude_column=dict(),
+        bids_condition_column=dict(usedefault=True, ),
         bids_event_file=dict(
             mandatory=True,
             xor=['subject_info', 'event_files', 'bids_event_file'],

--- a/nipype/algorithms/tests/test_auto_SpecifySparseModel.py
+++ b/nipype/algorithms/tests/test_auto_SpecifySparseModel.py
@@ -5,15 +5,8 @@ from ..modelgen import SpecifySparseModel
 
 def test_SpecifySparseModel_inputs():
     input_map = dict(
-        bids_amplitude_column=dict(
-            exists=True,
-            mandatory=False,
-        ),
-        bids_condition_column=dict(
-            exists=True,
-            mandatory=False,
-            usedefault=True,
-        ),
+        bids_amplitude_column=dict(),
+        bids_condition_column=dict(usedefault=True, ),
         bids_event_file=dict(
             mandatory=True,
             xor=['subject_info', 'event_files', 'bids_event_file'],

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -186,7 +186,7 @@ EXTRA_REQUIRES = {
     'nipy': ['nitime', 'nilearn<0.5.0', 'dipy', 'nipy', 'matplotlib'],
     'profiler': ['psutil>=5.0'],
     'pybids': ['pybids>=0.7.0'],
-    'specs': ['yapf'],
+    'specs': ['yapf>=0.27'],
     'ssh': ['paramiko'],
     'tests': TESTS_REQUIRES,
     'xvfbwrapper': ['xvfbwrapper'],

--- a/tools/checkspecs.py
+++ b/tools/checkspecs.py
@@ -10,8 +10,14 @@ import os
 import re
 import sys
 import warnings
+from distutils.version import LooseVersion
 
 from nipype.interfaces.base import BaseInterface
+
+import yapf
+if LooseVersion(yapf.__version__) < '0.27':
+    raise ImportError("Please upgrade yapf to version 0.27 or newer for stable formatting")
+
 from yapf.yapflib.yapf_api import FormatCode
 
 

--- a/tools/checkspecs.py
+++ b/tools/checkspecs.py
@@ -31,7 +31,7 @@ class InterfaceChecker(object):
                  package_skip_patterns=None,
                  module_skip_patterns=None,
                  class_skip_patterns=None):
-        ''' Initialize package for parsing
+        r''' Initialize package for parsing
 
         Parameters
         ----------
@@ -200,7 +200,7 @@ class InterfaceChecker(object):
             'position', 'mandatory', 'copyfile', 'usedefault', 'sep',
             'hash_files', 'deprecated', 'new_name', 'min_ver', 'max_ver',
             'name_source', 'name_template', 'keep_extension', 'units',
-            'output_name'
+            'output_name', 'extensions'
         ]
         in_built = [
             'type', 'copy', 'parent', 'instance_handler', 'comparison_mode',


### PR DESCRIPTION
## Summary

`make specs` currently flails a bit from user to user, apparently because `yapf` has changed its formatting rules.

Additionally, we've been ignoring errors reported by `make specs`, probably because they weren't really clearly errors.

## List of changes proposed in this PR (pull-request)

* Set a new minimum version of `yapf >=0.27`. I've verified that 0.27 and 0.28 both give the same result, while 0.26 gives the old result.
* Add `extensions` metadata to list of accepted metadata to reduce noise
* Remove `exists` metadata from non-file traits as well as `mandatory=False` metadata

## Acknowledgment

- [x] (Mandatory) I acknowledge that this contribution will be available under the Apache 2 license.
