### PR TITLE
FIX: Drop deprecated message argument to FileNotFoundError

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -476,9 +476,9 @@ Output trait(s) %s not available in version %s of interface %s.\
                 setattr(outputs, key, val)
             except TraitError as error:
                 if 'an existing' in getattr(error, 'info', 'default'):
-                    msg = "No such file or directory for output '%s' of a %s interface" % \
-                        (key, self.__class__.__name__)
-                    raise FileNotFoundError(val, message=msg)
+                    msg = "No such file or directory '%s' for output '%s' of a %s interface" % \
+                        (val, key, self.__class__.__name__)
+                    raise FileNotFoundError(msg)
                 raise error
         return outputs
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -40,14 +40,16 @@ related_filetype_sets = [
 
 PY3 = sys.version_info[0] >= 3
 
+try:
+    from builtins import FileNotFoundError
+except ImportError:  # PY27
+    class FileNotFoundError(OSError):  # noqa
+        """Defines the exception for Python 2."""
 
-class FileNotFoundError(OSError):  # noqa
-    """Defines the exception for Python 2."""
-
-    def __init__(self, path):
-        """Initialize the exception."""
-        super(FileNotFoundError, self).__init__(
-            2, 'No such file or directory', '%s' % path)
+        def __init__(self, path):
+            """Initialize the exception."""
+            super(FileNotFoundError, self).__init__(
+                2, 'No such file or directory', '%s' % path)
 
 
 USING_PATHLIB2 = False


### PR DESCRIPTION
## Summary

Exceptions do not take a `message` argument. This restores the `FileNotFoundError` to Python 3 compatibility.

Fixes issue introduced in #2969.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
