### PR TITLE
RF: Provide functions to augment old Path.mkdir, Path.resolve methods

### DIFF
--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -33,7 +33,7 @@ from traits.trait_base import _Undefined
 
 from traits.api import Unicode
 from future import standard_library
-from ...utils.filemanip import Path, USING_PATHLIB2
+from ...utils.filemanip import Path, USING_PATHLIB2, path_resolve
 
 if USING_PATHLIB2:
     from future.types.newstr import newstr
@@ -147,7 +147,7 @@ class BasePath(TraitType):
                 self.error(objekt, name, str(value))
 
         if self.resolve:
-            value = value.resolve(strict=self.exists)
+            value = path_resolve(value, strict=self.exists)
 
         if not return_pathlike:
             value = str(value)

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -25,6 +25,7 @@ from future import standard_library
 from ... import logging, config, LooseVersion
 from ...utils.filemanip import (
     Path,
+    path_mkdir,
     indirectory,
     relpath,
     makedirs,
@@ -123,7 +124,7 @@ def write_node_report(node, result=None, is_mapnode=False):
 
     cwd = node.output_dir()
     report_file = Path(cwd) / '_report' / 'report.rst'
-    report_file.parent.mkdir(exist_ok=True, parents=True)
+    path_mkdir(report_file.parent, exist_ok=True, parents=True)
 
     lines = [
         write_rst_header('Node: %s' % get_print_name(node), level=0),

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -59,34 +59,26 @@ except ImportError:
     from pathlib2 import Path
     USING_PATHLIB2 = True
 
-try: # PY35 - strict mode was added in 3.6
-    Path('/invented/file/path').resolve(strict=True)
-except TypeError:
-    def _patch_resolve(self, strict=False):
-        """Add the argument strict to signature in Python>3,<3.6."""
-        resolved = Path().old_resolve() / self
 
+def path_resolve(path, strict=False):
+    try:
+        return path.resolve(strict=strict)
+    except TypeError:  # PY35
+        resolved = path.resolve()
         if strict and not resolved.exists():
             raise FileNotFoundError(resolved)
         return resolved
 
-    Path.old_resolve = Path.resolve
-    Path.resolve = _patch_resolve
-except FileNotFoundError:
-    pass
-except OSError:
-    # PY2
-    def _patch_resolve(self, strict=False):
-        """Raise FileNotFoundError instead of OSError with pathlib2."""
-        try:
-            resolved = self.old_resolve(strict=strict)
-        except OSError:
-            raise FileNotFoundError(self.old_resolve())
 
-        return resolved
+def path_mkdir(path, mode=0o777, parents=False, exist_ok=False):
+    try:
+        return path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
+    except TypeError:  # PY27/PY34
+        if parents:
+            return makedirs(str(path), mode=mode, exist_ok=exist_ok)
+        elif not exist_ok or not path.exists():
+            return os.mkdir(str(path), mode=mode)
 
-    Path.old_resolve = Path.resolve
-    Path.resolve = _patch_resolve
 
 if not hasattr(Path, 'write_text'):
     # PY34 - Path does not have write_text
@@ -94,19 +86,6 @@ if not hasattr(Path, 'write_text'):
         with open(str(self), 'w') as f:
             f.write(text)
     Path.write_text = _write_text
-
-try:  # PY27/PY34 - mkdir does not have exist_ok
-    from .tmpdirs import TemporaryDirectory
-    with TemporaryDirectory() as tmpdir:
-        (Path(tmpdir) / 'exist_ok_test').mkdir(exist_ok=True)
-except TypeError:
-    def _mkdir(self, mode=0o777, parents=False, exist_ok=False):
-        if parents:
-            makedirs(str(self), mode=mode, exist_ok=exist_ok)
-        elif not exist_ok or not self.exists():
-            os.mkdir(str(self), mode=mode)
-
-    Path.mkdir = _mkdir
 
 
 def split_filename(fname):

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -580,8 +580,6 @@ def test_path_strict_resolve(tmpdir):
     # Default strict=False should work out out of the box
     testfile = Path('somefile.txt')
     resolved = '%s/somefile.txt' % tmpdir
-    assert str(testfile.resolve()) == resolved
-    # path_resolve() is equivalent to Path.resolve()
     assert str(path_resolve(testfile)) == resolved
     # Strict keyword is always allowed
     assert str(path_resolve(testfile, strict=False)) == resolved

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -16,7 +16,8 @@ from ...utils.filemanip import (
     check_forhash, _parse_mount_table, _cifs_table, on_cifs, copyfile,
     copyfiles, ensure_list, simplify_list, check_depends,
     split_filename, get_related_files, indirectory,
-    loadpkl, loadcrash, savepkl, FileNotFoundError, Path)
+    loadpkl, loadcrash, savepkl, FileNotFoundError, Path,
+    path_mkdir, path_resolve)
 
 
 def _ignore_atime(stat):
@@ -572,21 +573,26 @@ def test_unversioned_pklization(tmpdir):
             loadpkl('./pickled.pkz')
 
 
-def test_Path_strict_resolve(tmpdir):
+def test_path_strict_resolve(tmpdir):
     """Check the monkeypatch to test strict resolution of Path."""
     tmpdir.chdir()
 
     # Default strict=False should work out out of the box
     testfile = Path('somefile.txt')
-    assert '%s/somefile.txt' % tmpdir == '%s' % testfile.resolve()
+    resolved = '%s/somefile.txt' % tmpdir
+    assert str(testfile.resolve()) == resolved
+    # path_resolve() is equivalent to Path.resolve()
+    assert str(path_resolve(testfile)) == resolved
+    # Strict keyword is always allowed
+    assert str(path_resolve(testfile, strict=False)) == resolved
 
     # Switching to strict=True must raise FileNotFoundError (also in Python2)
     with pytest.raises(FileNotFoundError):
-        testfile.resolve(strict=True)
+        path_resolve(testfile, strict=True)
 
     # If the file is created, it should not raise
     open('somefile.txt', 'w').close()
-    assert '%s/somefile.txt' % tmpdir == '%s' % testfile.resolve(strict=True)
+    assert str(path_resolve(testfile, strict=True)) == resolved
 
 
 @pytest.mark.parametrize("save_versioning", [True, False])
@@ -598,17 +604,18 @@ def test_pickle(tmp_path, save_versioning):
     assert outobj == testobj
 
 
-def test_Path(tmpdir):
+def test_path_mkdir(tmpdir):
     tmp_path = Path(tmpdir.strpath)
 
-    (tmp_path / 'textfile').write_text('some text')
+    # PY34: Leave as monkey-patch
+    Path.write_text(tmp_path / 'textfile', 'some text')
 
     with pytest.raises(OSError):
-        (tmp_path / 'no' / 'parents').mkdir(parents=False)
+        path_mkdir(tmp_path / 'no' / 'parents', parents=False)
 
-    (tmp_path / 'no' / 'parents').mkdir(parents=True)
+    path_mkdir(tmp_path / 'no' / 'parents', parents=True)
 
     with pytest.raises(OSError):
-        (tmp_path / 'no' / 'parents').mkdir(parents=False)
+        path_mkdir(tmp_path / 'no' / 'parents', parents=False)
 
-    (tmp_path / 'no' / 'parents').mkdir(parents=True, exist_ok=True)
+    path_mkdir(tmp_path / 'no' / 'parents', parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

In #3046, we see that pytest using our monkey-patched `Path` objects. This seems generally unsafe, and evidently possible for us to screw up, so I've switched to functions that try to use the original methods, with fallback implementations when they fail. These are marked with `#PY*` tags so we can drop them when we drop support for those versions.

I've left the `Path.write_text` method for now, just because the logic there is simpler and we'll be dropping Python 3.4 very soon.

Alternative to #3048.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Replace `Path.mkdir` monkeypatch with `nipype.utils.filemanip.path_mkdir`
* Replace `Path.resolve` monkeypatch with `nipype.utils.filemanip.path_resolve`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
