### PR TITLE
FIX: Remove asynchronous chdir callback

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -146,8 +146,6 @@ class MultiProcPlugin(DistributedPluginBase):
         self._stats = None
 
     def _async_callback(self, args):
-        # Make sure runtime is not left at a dubious working directory
-        os.chdir(self._cwd)
         result = args.result()
         self._taskresult[result['taskid']] = result
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

Remove the asynchronous chdir callback in the multiproc plugin

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
