### PR TITLE
MNT: Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,36 +31,6 @@ env:
       EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
       CI_SKIP_TEST=1
 
-# Python 3.4 is only available on Trusty, so we need to duplicate the
-# env matrix specifically for it.
-matrix:
-  include:
-    - python: 3.4
-      dist: trusty
-      env:
-        - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,nipy,profiler"
-          CI_SKIP_TEST=1
-    - python: 3.4
-      dist: trusty
-      env:
-        - INSTALL_DEB_DEPENDECIES=false
-          NIPYPE_EXTRAS="doc,tests,profiler"
-          CI_SKIP_TEST=1
-    - python: 3.4
-      dist: trusty
-      env:
-        - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,nipy,profiler,duecredit,ssh"
-          CI_SKIP_TEST=1
-    - python: 3.4
-      dist: trusty
-      env:
-        - INSTALL_DEB_DEPENDECIES=true
-          NIPYPE_EXTRAS="doc,tests,nipy,profiler"
-          EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
-          CI_SKIP_TEST=1
-
 addons:
   apt:
     packages:

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -55,13 +55,12 @@ CLASSIFIERS = [
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: POSIX :: Linux',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Topic :: Scientific/Engineering'
 ]
-PYTHON_REQUIRES = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*"
+PYTHON_REQUIRES = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"
 
 description = 'Neuroimaging in Python: Pipelines and Interfaces'
 
@@ -145,7 +144,6 @@ REQUIRES = [
     'funcsigs',
     'future>=%s' % FUTURE_MIN_VERSION,
     'futures; python_version == "2.7"',
-    'lxml<4.4.0; python_version == "3.4"',
     'networkx>=%s ; python_version >= "3.0"' % NETWORKX_MIN_VERSION,
     'networkx>=%s,<=%s ; python_version < "3.0"' % (NETWORKX_MIN_VERSION, NETWORKX_MAX_VERSION_27),
     'nibabel>=%s' % NIBABEL_MIN_VERSION,


### PR DESCRIPTION
## Summary
This PR does not attempt to hunt down Python 3.4-isms and purge them. Just removes the test battery and updates the package metadata.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
