### PR TITLE
FIX: Restore ``AFNICommand._get_fname``, required by some interfaces

### DIFF
--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -11,7 +11,7 @@ from sys import platform
 from distutils import spawn
 
 from ... import logging, LooseVersion
-from ...utils.filemanip import split_filename
+from ...utils.filemanip import split_filename, fname_presuffix
 from ..base import (CommandLine, traits, CommandLineInputSpec, isdefined, File,
                     TraitedSpec, PackageInfo)
 from ...external.due import BibTeX
@@ -236,6 +236,55 @@ class AFNICommand(AFNICommandBase):
                     if ext == "":
                         outputs[name] = outputs[name] + "+orig.BRIK"
         return outputs
+
+    def _gen_fname(self,
+                   basename,
+                   cwd=None,
+                   suffix=None,
+                   change_ext=True,
+                   ext=None):
+        """
+        Generate a filename based on the given parameters.
+
+        The filename will take the form: cwd/basename<suffix><ext>.
+        If change_ext is True, it will use the extentions specified in
+        <instance>intputs.output_type.
+
+        Parameters
+        ----------
+        basename : str
+            Filename to base the new filename on.
+        cwd : str
+            Path to prefix to the new filename. (default is os.getcwd())
+        suffix : str
+            Suffix to add to the `basename`.  (defaults is '' )
+        change_ext : bool
+            Flag to change the filename extension to the FSL output type.
+            (default True)
+
+        Returns
+        -------
+        fname : str
+            New filename based on given parameters.
+
+        """
+        if not basename:
+            msg = 'Unable to generate filename for command %s. ' % self.cmd
+            msg += 'basename is not set!'
+            raise ValueError(msg)
+
+        if cwd is None:
+            cwd = os.getcwd()
+        if ext is None:
+            ext = Info.output_type_to_ext(self.inputs.outputtype)
+        if change_ext:
+            suffix = ''.join((suffix, ext)) if suffix else ext
+
+        if suffix is None:
+            suffix = ''
+        fname = fname_presuffix(
+            basename, suffix=suffix, use_ext=False, newpath=cwd)
+        return fname
 
 
 def no_afni():

--- a/nipype/interfaces/afni/model.py
+++ b/nipype/interfaces/afni/model.py
@@ -309,58 +309,6 @@ class Deconvolve(AFNICommand):
         return outputs
 
 
-    def _gen_fname(self,
-                   basename,
-                   cwd=None,
-                   suffix=None,
-                   change_ext=True,
-                   ext=None):
-        """Generate a filename based on the given parameters.
-
-        The filename will take the form: cwd/basename<suffix><ext>.
-        If change_ext is True, it will use the extentions specified in
-        <instance>intputs.output_type.
-
-        Parameters
-        ----------
-        basename : str
-            Filename to base the new filename on.
-        cwd : str
-            Path to prefix to the new filename. (default is os.getcwd())
-        suffix : str
-            Suffix to add to the `basename`.  (defaults is '' )
-        change_ext : bool
-            Flag to change the filename extension to the FSL output type.
-            (default True)
-
-        Returns
-        -------
-        fname : str
-            New filename based on given parameters.
-
-        """
-        from nipype.utils.filemanip import fname_presuffix
-
-        if basename == '':
-            msg = 'Unable to generate filename for command %s. ' % self.cmd
-            msg += 'basename is not set!'
-            raise ValueError(msg)
-        if cwd is None:
-            cwd = os.getcwd()
-        if ext is None:
-            ext = Info.output_type_to_ext(self.inputs.outputtype)
-        if change_ext:
-            if suffix:
-                suffix = ''.join((suffix, ext))
-            else:
-                suffix = ext
-        if suffix is None:
-            suffix = ''
-        fname = fname_presuffix(
-            basename, suffix=suffix, use_ext=False, newpath=cwd)
-        return fname
-
-
 class RemlfitInputSpec(AFNICommandInputSpec):
     # mandatory files
     in_files = InputMultiPath(


### PR DESCRIPTION
In #2964 I broke some interfaces (@tsalo identified `Allineate` as one
of those) by removing the ``_get_fname`` function from the base
``AFNICommand``.

The intent was to migrate to a ``name_source``-based management of
automatically generated names, but in the case of ``Allineate``, the use
of `_get_fname` was a bit different (modifying the user-provide input
value under certain conditions to follow ANFI's ``3dAllineate``
behavior).

This PR restores the missing function. Closes #3070.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
