### PR TITLE
[FIX] Fixed typo in QwarpInputSpec Trait description

### DIFF
--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -24,7 +24,7 @@ iflogger = logging.getLogger('nipype.interface')
 
 
 class CentralityInputSpec(AFNICommandInputSpec):
-    """Common input spec class for all centrality-related commands 
+    """Common input spec class for all centrality-related commands
     """
 
     mask = File(

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -24,7 +24,7 @@ iflogger = logging.getLogger('nipype.interface')
 
 
 class CentralityInputSpec(AFNICommandInputSpec):
-    """Common input spec class for all centrality-related commands
+    """Common input spec class for all centrality-related commands 
     """
 
     mask = File(

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -3387,11 +3387,11 @@ or the inverse can be computed as needed in 3dNwarpApply, like
         exists=True,
         copyfile=False)
     noXdis = traits.Bool(
-        desc='Warp will not displace in x directoin', argstr='-noXdis')
+        desc='Warp will not displace in x direction', argstr='-noXdis')
     noYdis = traits.Bool(
-        desc='Warp will not displace in y directoin', argstr='-noYdis')
+        desc='Warp will not displace in y direction', argstr='-noYdis')
     noZdis = traits.Bool(
-        desc='Warp will not displace in z directoin', argstr='-noZdis')
+        desc='Warp will not displace in z direction', argstr='-noZdis')
     iniwarp = traits.List(
         File(exists=True, copyfile=False),
         desc='A dataset with an initial nonlinear warp to use.'


### PR DESCRIPTION
## Summary
Fixed a typo in QwarpInputSpecs trait description for 'noXdis', 'noYdis', and 'noZdis'.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
