### PR TITLE
ENH: Always fsync pickle files

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -236,17 +236,17 @@ def save_resultfile(result, cwd, name, rebase=None):
 
     if result.outputs is None:
         logger.warning('Storing result file without outputs')
-        savepkl(resultsfile, result)
+        savepkl(resultsfile, result, sync=True)
         return
     try:
         output_names = result.outputs.copyable_trait_names()
     except AttributeError:
         logger.debug('Storing non-traited results, skipping rebase of paths')
-        savepkl(resultsfile, result)
+        savepkl(resultsfile, result, sync=True)
         return
 
     if not rebase:
-        savepkl(resultsfile, result)
+        savepkl(resultsfile, result, sync=True)
         return
 
     backup_traits = {}
@@ -262,7 +262,7 @@ def save_resultfile(result, cwd, name, rebase=None):
                     backup_traits[key] = old
                     val = rebase_path_traits(result.outputs.trait(key), old, cwd)
                     setattr(result.outputs, key, val)
-        savepkl(resultsfile, result)
+        savepkl(resultsfile, result, sync=True)
     finally:
         # Restore resolved paths from the outputs dict no matter what
         for key, val in list(backup_traits.items()):

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -789,19 +789,18 @@ def read_stream(stream, logger=None, encoding=None):
     return out.splitlines()
 
 
-def savepkl(filename, record, versioning=False):
-    with SoftFileLock('%s.lock' % filename):
-        with open(filename, 'wb') as fobj:
-            pkl_file = gzip.GzipFile(fileobj=fobj) if filename.endswith('.pklz') else fobj
-            if versioning:
-                from nipype import __version__ as version
-                metadata = json.dumps({'version': version})
+def savepkl(filename, record, versioning=False, sync=False):
+    with open(filename, 'wb') as fobj:
+        pkl_file = gzip.GzipFile(fileobj=fobj) if filename.endswith('.pklz') else fobj
+        if versioning:
+            from nipype import __version__ as version
+            metadata = json.dumps({'version': version})
 
-                pkl_file.write(metadata.encode('utf-8'))
-                pkl_file.write('\n'.encode('utf-8'))
+            pkl_file.write(metadata.encode('utf-8'))
+            pkl_file.write('\n'.encode('utf-8'))
 
-            pickle.dump(record, pkl_file)
-            # Pickle files need to be available immediately, so force a sync
+        pickle.dump(record, pkl_file)
+        if sync:
             fobj.flush()
             os.fsync(fobj.fileno())
 


### PR DESCRIPTION
## Summary
Fully qualifying results file names does not seem to have resolved the issue with finding the files, making it more likely that this is a filesystem synchronization issue. This PR adds an `fsync` call for Pickle files, specifically.

This required a slight refactor for handling gzip (`pklz`) files.

Hopefully:

* Fixes #3014
* Fixes #3076 
* Fixes #3081

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
