### PR TITLE
REL: 1.3.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -74,10 +74,6 @@
       "name": "Wong, Jason"
     },
     {
-      "affiliation": "Concordia University",
-      "name": "Benderoff, Erin"
-    },
-    {
       "affiliation": "Developer",
       "name": "Clark, Daniel",
       "orcid": "0000-0002-8121-8954"
@@ -141,6 +137,10 @@
       "affiliation": "CNRS LTCI, Telecom ParisTech, Universit\u00e9 Paris-Saclay",
       "name": "Gramfort, Alexandre",
       "orcid": "0000-0001-9791-4404"
+    },
+    {
+      "affiliation": "Concordia University",
+      "name": "Benderoff, Erin"
     },
     {
       "affiliation": "Dartmouth College: Hanover, NH, United States",
@@ -275,6 +275,11 @@
       "name": "Dubois, Mathieu"
     },
     {
+      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
+      "name": "Tilley II, Steven",
+      "orcid": "0000-0003-4853-5082"
+    },
+    {
       "affiliation": "Child Mind Institute",
       "name": "Frohlich, Caroline"
     },
@@ -314,10 +319,6 @@
       "orcid": "0000-0002-6652-3512"
     },
     {
-      "name": "Heinsfeld, Anibal S\u00f3lon",
-      "orcid": "0000-0002-2050-0614"
-    },
-    {
       "name": "Ginsburg, Daniel"
     },
     {
@@ -329,6 +330,10 @@
       "affiliation": "Harvard University - Psychology",
       "name": "Kastman, Erik",
       "orcid": "0000-0001-7221-9042"
+    },
+    {
+      "name": "Heinsfeld, Anibal S\u00f3lon",
+      "orcid": "0000-0002-2050-0614"
     },
     {
       "affiliation": "Washington University in St Louis",
@@ -377,9 +382,6 @@
       "name": "Millman, Jarrod"
     },
     {
-      "name": "Lai, Jeff"
-    },
-    {
       "name": "Zhou, Dale"
     },
     {
@@ -387,11 +389,6 @@
     },
     {
       "name": "Haselgrove, Christian"
-    },
-    {
-      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
-      "name": "Tilley II, Steven",
-      "orcid": "0000-0003-4853-5082"
     },
     {
       "name": "Renfro, Mandy"
@@ -404,11 +401,6 @@
       "affiliation": "University of Pennsylvania",
       "name": "Kahn, Ari E.",
       "orcid": "0000-0002-2127-0507"
-    },
-    {
-      "affiliation": "Yale University; New Haven, CT, United States",
-      "name": "Sisk, Lucinda M.",
-      "orcid": "0000-0003-4900-9770"
     },
     {
       "affiliation": "Korea Advanced Institute of Science and Technology",
@@ -436,6 +428,11 @@
     },
     {
       "name": "Hallquist, Michael"
+    },
+    {
+      "affiliation": "Yale University; New Haven, CT, United States",
+      "name": "Sisk, Lucinda M.",
+      "orcid": "0000-0003-4900-9770"
     },
     {
       "affiliation": "Donders Institute for Brain, Cognition and Behavior, Center for Cognitive Neuroimaging",
@@ -485,11 +482,6 @@
       "name": "Hinds, Oliver"
     },
     {
-      "affiliation": "National Institute on Aging, Baltimore, MD, USA",
-      "name": "Bilgel, Murat",
-      "orcid": "0000-0001-5042-7422"
-    },
-    {
       "affiliation": "TIB \u2013 Leibniz Information Centre for Science and Technology and University Library, Hannover, Germany",
       "name": "Leinweber, Katrin",
       "orcid": "0000-0001-5135-5758"
@@ -500,15 +492,6 @@
     {
       "affiliation": "Boston University",
       "name": "Perkins, L. Nathan"
-    },
-    {
-      "affiliation": "University of Amsterdam",
-      "name": "Snoek, Lukas",
-      "orcid": "0000-0001-8972-204X"
-    },
-    {
-      "affiliation": "Institute of Imaging & Computer Vision, RWTH Aachen University, Germany",
-      "name": "Weninger, Leon"
     },
     {
       "affiliation": "University of Newcastle, Australia",
@@ -525,14 +508,18 @@
       "name": "Noel, Maxime"
     },
     {
+      "affiliation": "University of Amsterdam",
+      "name": "Snoek, Lukas",
+      "orcid": "0000-0001-8972-204X"
+    },
+    {
+      "affiliation": "Institute of Imaging & Computer Vision, RWTH Aachen University, Germany",
+      "name": "Weninger, Leon"
+    },
+    {
       "affiliation": "University of Pennsylvania",
       "name": "Junhao WEN",
       "orcid": "0000-0003-2077-3070"
-    },
-    {
-      "affiliation": "Leibniz Institute for Neurobiology",
-      "name": "Stadler, J\u00f6rg",
-      "orcid": "0000-0003-4313-129X"
     },
     {
       "name": "Cheung, Brian"
@@ -548,6 +535,11 @@
       "affiliation": "Department of Psychology, Stanford University; Parietal, INRIA",
       "name": "Durnez, Joke",
       "orcid": "0000-0001-9030-2202"
+    },
+    {
+      "affiliation": "Leibniz Institute for Neurobiology",
+      "name": "Stadler, J\u00f6rg",
+      "orcid": "0000-0003-4313-129X"
     },
     {
       "affiliation": "CNRS, UMS3552 IRMaGe",
@@ -600,10 +592,12 @@
       "name": "Khanuja, Ranjeet"
     },
     {
-      "name": "Schlamp, Kai"
+      "affiliation": "National Institute on Aging, Baltimore, MD, USA",
+      "name": "Bilgel, Murat",
+      "orcid": "0000-0001-5042-7422"
     },
     {
-      "name": "Arias, Jaime"
+      "name": "Schlamp, Kai"
     },
     {
       "affiliation": "CEA",
@@ -670,6 +664,12 @@
     },
     {
       "name": "Davison, Andrew"
+    },
+    {
+      "name": "Lai, Jeff"
+    },
+    {
+      "name": "Arias, Jaime"
     },
     {
       "name": "Bielievtsov, Dmytro",

--- a/doc/changelog/1.X.X-changelog
+++ b/doc/changelog/1.X.X-changelog
@@ -1,11 +1,16 @@
-1.3.0 (To Be Determined)
-========================
+1.3.0 (November 11, 2019)
+=========================
 
 ##### [Full changelog](https://github.com/nipy/nipype/milestone/34?closed=1)
 
+  * FIX: Fixed typo in QwarpInputSpec Trait description (https://github.com/nipy/nipype/pull/3079)
   * FIX: Restore ``AFNICommand._get_fname``, required by some interfaces (https://github.com/nipy/nipype/pull/3071)
   * FIX: Remove asynchronous chdir callback (https://github.com/nipy/nipype/pull/3060)
   * FIX: Minimize scope for directory changes while loading results file (https://github.com/nipy/nipype/pull/3061)
+  * ENH: Minimize the number of calls to ``_load_results`` when populating inputs (https://github.com/nipy/nipype/pull/3075)
+  * ENH: Refactor savepkl/loadpkl - add a window for loadpkl to wait for the file (https://github.com/nipy/nipype/pull/3089)
+  * ENH: Add "ExportFile" interface as simple alternative to "DataSink" (https://github.com/nipy/nipype/pull/3054)
+  * ENH: Allow nipype.cfg in cwd to be read even if ~/.nipype does not exist (https://github.com/nipy/nipype/pull/3072)
   * ENH: Add precommit information for contributors and pre-commit style (https://github.com/nipy/nipype/pull/3063)
   * ENH: Delay etelemetry for non-interactive sessions, report bad versions (https://github.com/nipy/nipype/pull/3049)
   * ENH: Run memoized check_version at REPL import, Node/Workflow/Interface init (https://github.com/nipy/nipype/pull/30)

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -9,7 +9,7 @@ import sys
 
 # nipype version information
 # Remove -dev for release
-__version__ = '1.3.0-rc1.post-dev'
+__version__ = '1.3.0'
 
 
 def get_nipype_gitversion():


### PR DESCRIPTION
## Summary

Prep for 1.3.0, for immediate release.

This is delayed from the originally planned release on Monday, October 28 for the sake of testing.

Emergency fixes only to be accepted between now and release.

## Release checklist

* [x] Update changelog
* [x] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py` and `doc/conf.py`
* [x] Update `doc/documentation.rst` with previous releases
* [x] Check conda-forge feedstock build (conda-forge/nipype-feedstock#56)
* [x] Tutorial tests (https://circleci.com/workflow-run/b6b19962-143a-4d25-b49f-ffd9037c9c13)

## Uncredited authors

The following authors have contributed, but not added themselves to the [`.zenodo.json`](https://github.com/nipy/nipype/blob/master/.zenodo.json) file. If you would like to be an author on Zenodo releases, please add yourself or comment with your preferred publication name, affiliation and [ORCID](https://orcid.org/). If you would like to stop being spammed whenever I'm the one doing releases, let me know, and I'll add you to a blacklist.

No entry to sort: Gio Piantoni (@gpiantoni)
No entry to sort: Victor Férat (@vferat)
No entry to sort: Isaiah Norton (@ihnorton)
No entry to sort: Niklas Förster (@niklasfoe)
No entry to sort: daniel glen (@afni-dglen) 
No entry to sort: Kirstie Whitaker (@KirstieJane)
No entry to sort: hstojic (@hstojic)
No entry to sort: Jonathan R. Williford (@williford)
No entry to sort: Adam Kimbler (@adamkimbler)
No entry to sort: Kevin Sitek (@sitek)
No entry to sort: Ami Tsuchida
No entry to sort: Abel González (@abelalez)
No entry to sort: Michiel Cottaar (@MichielCottaar)
No entry to sort: Daniel Brenner (@brennerd11)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.