### PR TITLE
ENH: Pacify DeprecationWarnings caused by nibabel 3 pre-release

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -1280,9 +1280,10 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
         mask = None
         for filename in mask_files:
             img = nb.load(filename)
+            img_as_mask = np.asanyarray(img.dataobj).astype("int32") > 0
             if mask is None:
-                mask = img.get_fdata() > 0
-            np.logical_or(mask, img.get_fdata() > 0, mask)
+                mask = img_as_mask
+            np.logical_or(mask, img_as_mask, mask)
         img = nb.Nifti1Image(mask, img.affine, header=img.header)
         return [img]
 
@@ -1290,9 +1291,10 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
         mask = None
         for filename in mask_files:
             img = nb.load(filename)
+            img_as_mask = np.asanyarray(img.dataobj).astype("int32") > 0
             if mask is None:
-                mask = img.get_fdata() > 0
-            np.logical_and(mask, img.get_fdata() > 0, mask)
+                mask = img_as_mask
+            np.logical_and(mask, img_as_mask, mask)
         img = nb.Nifti1Image(mask, img.affine, header=img.header)
         return [img]
 

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -919,9 +919,7 @@ class TSNR(BaseInterface):
     def _run_interface(self, runtime):
         img = nb.load(self.inputs.in_file[0], mmap=NUMPY_MMAP)
         header = img.header.copy()
-        vollist = [
-            nb.load(filename) for filename in self.inputs.in_file
-        ]
+        vollist = [nb.load(filename) for filename in self.inputs.in_file]
         data = np.concatenate(
             [
                 vol.get_fdata(dtype=np.float32).reshape(vol.shape[:3] + (-1,))

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -623,12 +623,10 @@ class CompCor(SimpleInterface):
         skip_vols = self.inputs.ignore_initial_volumes
         if skip_vols:
             imgseries = imgseries.__class__(
-                imgseries.get_data()[..., skip_vols:],
-                imgseries.affine,
-                imgseries.header,
+                imgseries.dataobj[..., skip_vols:], imgseries.affine, imgseries.header
             )
 
-        mask_images = self._process_masks(mask_images, imgseries.get_data())
+        mask_images = self._process_masks(mask_images, imgseries.dataobj)
 
         TR = 0
         if self.inputs.pre_filter == "cosine":
@@ -664,7 +662,7 @@ class CompCor(SimpleInterface):
             )
 
         components, filter_basis, metadata = compute_noise_components(
-            imgseries.get_data(),
+            imgseries.get_fdata(dtype=np.float32),
             mask_images,
             components_criterion,
             self.inputs.pre_filter,
@@ -837,8 +835,9 @@ class TCompCor(CompCor):
     def _process_masks(self, mask_images, timeseries=None):
         out_images = []
         self._mask_files = []
+        timeseries = np.asanyarray(timeseries)
         for i, img in enumerate(mask_images):
-            mask = img.get_data().astype(np.bool)
+            mask = np.asanyarray(img.dataobj).astype(np.bool)
             imgseries = timeseries[mask, :]
             imgseries = regress_poly(2, imgseries)[0]
             tSTD = _compute_tSTD(imgseries, 0, axis=-1)
@@ -924,7 +923,11 @@ class TSNR(BaseInterface):
             nb.load(filename, mmap=NUMPY_MMAP) for filename in self.inputs.in_file
         ]
         data = np.concatenate(
-            [vol.get_data().reshape(vol.shape[:3] + (-1,)) for vol in vollist], axis=3
+            [
+                vol.get_fdata(dtype=np.float32).reshape(vol.shape[:3] + (-1,))
+                for vol in vollist
+            ],
+            axis=3,
         )
         data = np.nan_to_num(data)
 
@@ -985,7 +988,7 @@ class NonSteadyStateDetector(BaseInterface):
     def _run_interface(self, runtime):
         in_nii = nb.load(self.inputs.in_file)
         global_signal = (
-            in_nii.get_data()[:, :, :, :50].mean(axis=0).mean(axis=0).mean(axis=0)
+            in_nii.dataobj[:, :, :, :50].mean(axis=0).mean(axis=0).mean(axis=0)
         )
 
         self._results = {"n_volumes_to_discard": is_outlier(global_signal)}
@@ -1032,8 +1035,8 @@ research/nichols/scripts/fsl/standardizeddvars.pdf>`_, 2013.
     from nitime.algorithms import AR_est_YW
     import warnings
 
-    func = nb.load(in_file, mmap=NUMPY_MMAP).get_data().astype(np.float32)
-    mask = nb.load(in_mask, mmap=NUMPY_MMAP).get_data().astype(np.uint8)
+    func = nb.load(in_file, mmap=NUMPY_MMAP).get_fdata(dtype=np.float32)
+    mask = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj).astype(np.uint8)
 
     if len(func.shape) != 4:
         raise RuntimeError("Input fMRI dataset should be 4-dimensional")
@@ -1280,8 +1283,8 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
         for filename in mask_files:
             img = nb.load(filename, mmap=NUMPY_MMAP)
             if mask is None:
-                mask = img.get_data() > 0
-            np.logical_or(mask, img.get_data() > 0, mask)
+                mask = img.get_fdata() > 0
+            np.logical_or(mask, img.get_fdata() > 0, mask)
         img = nb.Nifti1Image(mask, img.affine, header=img.header)
         return [img]
 
@@ -1290,8 +1293,8 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
         for filename in mask_files:
             img = nb.load(filename, mmap=NUMPY_MMAP)
             if mask is None:
-                mask = img.get_data() > 0
-            np.logical_and(mask, img.get_data() > 0, mask)
+                mask = img.get_fdata() > 0
+            np.logical_and(mask, img.get_fdata() > 0, mask)
         img = nb.Nifti1Image(mask, img.affine, header=img.header)
         return [img]
 
@@ -1374,7 +1377,7 @@ def compute_noise_components(
     md_retained = []
 
     for name, img in zip(mask_names, mask_images):
-        mask = nb.squeeze_image(img).get_data().astype(np.bool)
+        mask = np.asanyarray(nb.squeeze_image(img).dataobj).astype(np.bool)
         if imgseries.shape[:3] != mask.shape:
             raise ValueError(
                 "Inputs for CompCor, timeseries and mask, do not have "

--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -920,7 +920,7 @@ class TSNR(BaseInterface):
         img = nb.load(self.inputs.in_file[0], mmap=NUMPY_MMAP)
         header = img.header.copy()
         vollist = [
-            nb.load(filename, mmap=NUMPY_MMAP) for filename in self.inputs.in_file
+            nb.load(filename) for filename in self.inputs.in_file
         ]
         data = np.concatenate(
             [
@@ -1035,8 +1035,8 @@ research/nichols/scripts/fsl/standardizeddvars.pdf>`_, 2013.
     from nitime.algorithms import AR_est_YW
     import warnings
 
-    func = nb.load(in_file, mmap=NUMPY_MMAP).get_fdata(dtype=np.float32)
-    mask = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj).astype(np.uint8)
+    func = nb.load(in_file).get_fdata(dtype=np.float32)
+    mask = np.asanyarray(nb.load(in_mask).dataobj).astype(np.uint8)
 
     if len(func.shape) != 4:
         raise RuntimeError("Input fMRI dataset should be 4-dimensional")
@@ -1281,7 +1281,7 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
     if mask_method == "union":
         mask = None
         for filename in mask_files:
-            img = nb.load(filename, mmap=NUMPY_MMAP)
+            img = nb.load(filename)
             if mask is None:
                 mask = img.get_fdata() > 0
             np.logical_or(mask, img.get_fdata() > 0, mask)
@@ -1291,7 +1291,7 @@ def combine_mask_files(mask_files, mask_method=None, mask_index=None):
     if mask_method == "intersect":
         mask = None
         for filename in mask_files:
-            img = nb.load(filename, mmap=NUMPY_MMAP)
+            img = nb.load(filename)
             if mask is None:
                 mask = img.get_fdata() > 0
             np.logical_and(mask, img.get_fdata() > 0, mask)

--- a/nipype/algorithms/icc.py
+++ b/nipype/algorithms/icc.py
@@ -41,12 +41,12 @@ class ICC(BaseInterface):
     output_spec = ICCOutputSpec
 
     def _run_interface(self, runtime):
-        maskdata = nb.load(self.inputs.mask).get_data()
+        maskdata = nb.load(self.inputs.mask).get_fdata()
         maskdata = np.logical_not(np.logical_or(maskdata == 0, np.isnan(maskdata)))
 
         session_datas = [
             [
-                nb.load(fname, mmap=NUMPY_MMAP).get_data()[maskdata].reshape(-1, 1)
+                nb.load(fname, mmap=NUMPY_MMAP).get_fdata()[maskdata].reshape(-1, 1)
                 for fname in sessions
             ]
             for sessions in self.inputs.subjects_sessions
@@ -66,17 +66,17 @@ class ICC(BaseInterface):
 
         nim = nb.load(self.inputs.subjects_sessions[0][0])
         new_data = np.zeros(nim.shape)
-        new_data[maskdata] = icc.reshape(-1,)
+        new_data[maskdata] = icc.reshape(-1)
         new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, "icc_map.nii")
 
         new_data = np.zeros(nim.shape)
-        new_data[maskdata] = session_var.reshape(-1,)
+        new_data[maskdata] = session_var.reshape(-1)
         new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, "session_var_map.nii")
 
         new_data = np.zeros(nim.shape)
-        new_data[maskdata] = subject_var.reshape(-1,)
+        new_data[maskdata] = subject_var.reshape(-1)
         new_img = nb.Nifti1Image(new_data, nim.affine, nim.header)
         nb.save(new_img, "subject_var_map.nii")
 

--- a/nipype/algorithms/mesh.py
+++ b/nipype/algorithms/mesh.py
@@ -113,9 +113,8 @@ class WarpPoints(TVTKBaseInterface):
 
         warps = []
         for axis in warp_dims:
-            wdata = axis.get_data()
+            wdata = axis.dataobj  # four_to_three ensures this is an array
             if np.any(wdata != 0):
-
                 warp = ndimage.map_coordinates(wdata, voxpoints.transpose())
             else:
                 warp = np.zeros((points.shape[0],))

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -112,13 +112,13 @@ class Distance(BaseInterface):
         from scipy.ndimage.measurements import center_of_mass, label
 
         origdata1 = np.asanyarray(nii1.dataobj)
-        origdata1 = (origdata1 != 0) & ~np.isnan(origdata1)
-        cog_t = np.array(center_of_mass(origdata1.copy())).reshape(-1, 1)
+        origdata1 = (np.rint(origdata1) != 0) & ~np.isnan(origdata1)
+        cog_t = np.array(center_of_mass(origdata1)).reshape(-1, 1)
         cog_t = np.vstack((cog_t, np.array([1])))
         cog_t_coor = np.dot(nii1.affine, cog_t)[:3, :]
 
         origdata2 = np.asanyarray(nii2.dataobj)
-        origdata2 = (origdata2 != 0) & ~np.isnan(origdata2)
+        origdata2 = (np.rint(origdata2) != 0) & ~np.isnan(origdata2)
         (labeled_data, n_labels) = label(origdata2)
 
         cogs = np.ones((4, n_labels))
@@ -165,13 +165,13 @@ class Distance(BaseInterface):
         from scipy.spatial.distance import cdist
 
         origdata1 = np.asanyarray(nii1.dataobj)
-        origdata1 = np.logical_not(np.logical_or(origdata1 == 0, np.isnan(origdata1)))
+        origdata1 = (np.rint(origdata1) != 0) & ~np.isnan(origdata1)
         origdata2 = np.asanyarray(nii2.dataobj)
-        origdata2 = np.logical_not(np.logical_or(origdata2 == 0, np.isnan(origdata2)))
+        origdata2 = (np.rint(origdata2) != 0) & ~np.isnan(origdata2)
 
         if isdefined(self.inputs.mask_volume):
             maskdata = np.asanyarray(nb.load(self.inputs.mask_volume).dataobj)
-            maskdata = np.logical_not(np.logical_or(maskdata == 0, np.isnan(maskdata)))
+            maskdata = (np.rint(maskdata) != 0) & ~np.isnan(maskdata)
             origdata1 = np.logical_and(maskdata, origdata1)
             origdata2 = np.logical_and(maskdata, origdata2)
 

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -716,7 +716,7 @@ class Similarity(NipyBaseInterface):
             mask1 = None
 
         if isdefined(self.inputs.mask2):
-            mask2 = np.asanyarray(nb.load(self.inputs.mask2).dataobj) == 2
+            mask2 = np.asanyarray(nb.load(self.inputs.mask2).dataobj) == 1
         else:
             mask2 = None
 

--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -441,8 +441,8 @@ class FuzzyOverlap(SimpleInterface):
 
     def _run_interface(self, runtime):
         # Load data
-        refdata = np.asanyarray(nb.concat_images(self.inputs.in_ref).dataobj)
-        tstdata = np.asanyarray(nb.concat_images(self.inputs.in_tst).dataobj)
+        refdata = nb.concat_images(self.inputs.in_ref).dataobj
+        tstdata = nb.concat_images(self.inputs.in_tst).dataobj
 
         # Data must have same shape
         if not refdata.shape == tstdata.shape:

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -94,7 +94,7 @@ class PickAtlas(BaseInterface):
 
     def _get_brodmann_area(self):
         nii = nb.load(self.inputs.atlas)
-        origdata = nii.get_data()
+        origdata = np.asanyarray(nii.dataobj)
         newdata = np.zeros(origdata.shape)
 
         if not isinstance(self.inputs.labels, list):
@@ -153,7 +153,7 @@ class SimpleThreshold(BaseInterface):
     def _run_interface(self, runtime):
         for fname in self.inputs.volumes:
             img = nb.load(fname, mmap=NUMPY_MMAP)
-            data = np.array(img.get_data())
+            data = img.get_fdata()
 
             active_map = data > self.inputs.threshold
 
@@ -216,7 +216,7 @@ class ModifyAffine(BaseInterface):
             affine = np.dot(self.inputs.transformation_matrix, affine)
 
             nb.save(
-                nb.Nifti1Image(img.get_data(), affine, img.header),
+                nb.Nifti1Image(img.dataobj, affine, img.header),
                 self._gen_output_filename(fname),
             )
 
@@ -1014,11 +1014,11 @@ class AddNoise(BaseInterface):
 
     def _run_interface(self, runtime):
         in_image = nb.load(self.inputs.in_file)
-        in_data = in_image.get_data()
+        in_data = in_image.get_fdata()
         snr = self.inputs.snr
 
         if isdefined(self.inputs.in_mask):
-            in_mask = nb.load(self.inputs.in_mask).get_data()
+            in_mask = np.asanyarray(nb.load(self.inputs.in_mask).dataobj)
         else:
             in_mask = np.ones_like(in_data)
 
@@ -1272,27 +1272,25 @@ def normalize_tpms(in_files, in_mask=None, out_files=None):
     imgs = [nb.load(fim, mmap=NUMPY_MMAP) for fim in in_files]
 
     if len(in_files) == 1:
-        img_data = imgs[0].get_data()
+        img_data = imgs[0].get_fdata(dtype=np.float32)
         img_data[img_data > 0.0] = 1.0
         hdr = imgs[0].header.copy()
-        hdr["data_type"] = 16
         hdr.set_data_dtype(np.float32)
-        nb.save(
-            nb.Nifti1Image(img_data.astype(np.float32), imgs[0].affine, hdr),
-            out_files[0],
-        )
+        nb.save(nb.Nifti1Image(img_data, imgs[0].affine, hdr), out_files[0])
         return out_files[0]
 
-    img_data = np.array([im.get_data() for im in imgs]).astype(np.float32)
+    img_data = np.stack(
+        [im.get_fdata(caching="unchanged", dtype=np.float32) for im in imgs]
+    )
     # img_data[img_data>1.0] = 1.0
     img_data[img_data < 0.0] = 0.0
     weights = np.sum(img_data, axis=0)
 
-    msk = np.ones_like(imgs[0].get_data())
+    msk = np.ones(imgs[0].shape)
     msk[weights <= 0] = 0
 
     if in_mask is not None:
-        msk = nb.load(in_mask, mmap=NUMPY_MMAP).get_data()
+        msk = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj)
         msk[msk <= 0] = 0
         msk[msk > 0] = 1
 
@@ -1302,7 +1300,6 @@ def normalize_tpms(in_files, in_mask=None, out_files=None):
         data = np.ma.masked_equal(img_data[i], 0)
         probmap = data / weights
         hdr = imgs[i].header.copy()
-        hdr["data_type"] = 16
         hdr.set_data_dtype("float32")
         nb.save(
             nb.Nifti1Image(probmap.astype(np.float32), imgs[i].affine, hdr), out_file
@@ -1331,7 +1328,7 @@ def split_rois(in_file, mask=None, roishape=None):
     droishape = (roishape[0], roishape[1], roishape[2], nvols)
 
     if mask is not None:
-        mask = nb.load(mask, mmap=NUMPY_MMAP).get_data()
+        mask = np.asanyarray(nb.load(mask, mmap=NUMPY_MMAP).dataobj)
         mask[mask > 0] = 1
         mask[mask < 1] = 0
     else:
@@ -1342,7 +1339,7 @@ def split_rois(in_file, mask=None, roishape=None):
     els = np.sum(mask)
     nrois = int(ceil(els / float(roisize)))
 
-    data = im.get_data().reshape((mask.size, -1))
+    data = np.asanyarray(im.dataobj).reshape((mask.size, -1))
     data = np.squeeze(data.take(nzels, axis=0))
     nvols = data.shape[-1]
 
@@ -1420,10 +1417,10 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
     rsh = ref.shape
     del ref
     npix = rsh[0] * rsh[1] * rsh[2]
-    fcdata = nb.load(in_files[0]).get_data()
+    fcimg = nb.load(in_files[0])
 
-    if fcdata.ndim == 4:
-        ndirs = fcdata.shape[-1]
+    if len(fcimg.shape) == 4:
+        ndirs = fcimg.shape[-1]
     else:
         ndirs = 1
     newshape = (rsh[0], rsh[1], rsh[2], ndirs)
@@ -1431,11 +1428,13 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
     hdr.set_xyzt_units("mm", "sec")
 
     if ndirs < 300:
-        data = np.zeros((npix, ndirs))
+        data = np.zeros((npix, ndirs), dtype=dtype)
         for cname, iname in zip(in_files, in_idxs):
             f = np.load(iname)
             idxs = np.squeeze(f["arr_0"])
-            cdata = nb.load(cname, mmap=NUMPY_MMAP).get_data().reshape(-1, ndirs)
+            cdata = np.asanyarray(nb.load(cname, mmap=NUMPY_MMAP).dataobj).reshape(
+                -1, ndirs
+            )
             nels = len(idxs)
             idata = (idxs,)
             try:
@@ -1450,10 +1449,7 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
                 )
                 raise
 
-        hdr.set_data_shape(newshape)
-        nb.Nifti1Image(data.reshape(newshape).astype(dtype), aff, hdr).to_filename(
-            out_file
-        )
+        nb.Nifti1Image(data.reshape(newshape), aff, hdr).to_filename(out_file)
 
     else:
         hdr.set_data_shape(rsh[:3])
@@ -1468,10 +1464,10 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
             idxs = np.squeeze(f["arr_0"])
 
             for d, fname in enumerate(nii):
-                data = nb.load(fname, mmap=NUMPY_MMAP).get_data().reshape(-1)
-                cdata = (
-                    nb.load(cname, mmap=NUMPY_MMAP).get_data().reshape(-1, ndirs)[:, d]
+                data = np.asanyarray(nb.load(fname, mmap=NUMPY_MMAP).dataobj).reshape(
+                    -1
                 )
+                cdata = nb.load(cname, mmap=NUMPY_MMAP).dataobj[..., d].reshape(-1)
                 nels = len(idxs)
                 idata = (idxs,)
                 data[idata] = cdata[0:nels]
@@ -1552,7 +1548,7 @@ class CalculateMedian(BaseInterface):
         self._median_files = []
         for idx, fname in enumerate(ensure_list(self.inputs.in_files)):
             img = nb.load(fname, mmap=NUMPY_MMAP)
-            data = np.median(img.get_data(), axis=3)
+            data = np.median(img.get_fdata(), axis=3)
             if self.inputs.median_per_file:
                 self._median_files.append(self._write_nifti(img, data, idx))
             else:

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1432,9 +1432,7 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
         for cname, iname in zip(in_files, in_idxs):
             f = np.load(iname)
             idxs = np.squeeze(f["arr_0"])
-            cdata = np.asanyarray(nb.load(cname).dataobj).reshape(
-                -1, ndirs
-            )
+            cdata = np.asanyarray(nb.load(cname).dataobj).reshape(-1, ndirs)
             nels = len(idxs)
             idata = (idxs,)
             try:
@@ -1464,9 +1462,7 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
             idxs = np.squeeze(f["arr_0"])
 
             for d, fname in enumerate(nii):
-                data = np.asanyarray(nb.load(fname).dataobj).reshape(
-                    -1
-                )
+                data = np.asanyarray(nb.load(fname).dataobj).reshape(-1)
                 cdata = nb.load(cname).dataobj[..., d].reshape(-1)
                 nels = len(idxs)
                 idata = (idxs,)

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -152,7 +152,7 @@ class SimpleThreshold(BaseInterface):
 
     def _run_interface(self, runtime):
         for fname in self.inputs.volumes:
-            img = nb.load(fname, mmap=NUMPY_MMAP)
+            img = nb.load(fname)
             data = img.get_fdata()
 
             active_map = data > self.inputs.threshold
@@ -1269,7 +1269,7 @@ def normalize_tpms(in_files, in_mask=None, out_files=None):
             out_file = op.abspath("%s_norm_%02d%s" % (fname, i, fext))
             out_files += [out_file]
 
-    imgs = [nb.load(fim, mmap=NUMPY_MMAP) for fim in in_files]
+    imgs = [nb.load(fim) for fim in in_files]
 
     if len(in_files) == 1:
         img_data = imgs[0].get_fdata(dtype=np.float32)
@@ -1290,7 +1290,7 @@ def normalize_tpms(in_files, in_mask=None, out_files=None):
     msk[weights <= 0] = 0
 
     if in_mask is not None:
-        msk = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj)
+        msk = np.asanyarray(nb.load(in_mask).dataobj)
         msk[msk <= 0] = 0
         msk[msk > 0] = 1
 
@@ -1328,7 +1328,7 @@ def split_rois(in_file, mask=None, roishape=None):
     droishape = (roishape[0], roishape[1], roishape[2], nvols)
 
     if mask is not None:
-        mask = np.asanyarray(nb.load(mask, mmap=NUMPY_MMAP).dataobj)
+        mask = np.asanyarray(nb.load(mask).dataobj)
         mask[mask > 0] = 1
         mask[mask < 1] = 0
     else:
@@ -1432,7 +1432,7 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
         for cname, iname in zip(in_files, in_idxs):
             f = np.load(iname)
             idxs = np.squeeze(f["arr_0"])
-            cdata = np.asanyarray(nb.load(cname, mmap=NUMPY_MMAP).dataobj).reshape(
+            cdata = np.asanyarray(nb.load(cname).dataobj).reshape(
                 -1, ndirs
             )
             nels = len(idxs)
@@ -1464,10 +1464,10 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
             idxs = np.squeeze(f["arr_0"])
 
             for d, fname in enumerate(nii):
-                data = np.asanyarray(nb.load(fname, mmap=NUMPY_MMAP).dataobj).reshape(
+                data = np.asanyarray(nb.load(fname).dataobj).reshape(
                     -1
                 )
-                cdata = nb.load(cname, mmap=NUMPY_MMAP).dataobj[..., d].reshape(-1)
+                cdata = nb.load(cname).dataobj[..., d].reshape(-1)
                 nels = len(idxs)
                 idata = (idxs,)
                 data[idata] = cdata[0:nels]
@@ -1547,7 +1547,7 @@ class CalculateMedian(BaseInterface):
         total = None
         self._median_files = []
         for idx, fname in enumerate(ensure_list(self.inputs.in_files)):
-            img = nb.load(fname, mmap=NUMPY_MMAP)
+            img = nb.load(fname)
             data = np.median(img.get_fdata(), axis=3)
             if self.inputs.median_per_file:
                 self._median_files.append(self._write_nifti(img, data, idx))

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -525,7 +525,7 @@ class ArtifactDetect(BaseInterface):
                     mask[:, :, :, t0] = mask_tmp
                     g[t0] = np.nansum(vol * mask_tmp) / np.nansum(mask_tmp)
         elif masktype == "file":  # uses a mask image to determine intensity
-            maskimg = load(self.inputs.mask_file, mmap=NUMPY_MMAP)
+            maskimg = load(self.inputs.mask_file)
             mask = maskimg.get_fdata()
             affine = maskimg.affine
             mask = mask > 0.5

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -526,7 +526,7 @@ class ArtifactDetect(BaseInterface):
                     g[t0] = np.nansum(vol * mask_tmp) / np.nansum(mask_tmp)
         elif masktype == "file":  # uses a mask image to determine intensity
             maskimg = load(self.inputs.mask_file)
-            mask = maskimg.get_fdata()
+            mask = maskimg.get_fdata(dtype=np.float32)
             affine = maskimg.affine
             mask = mask > 0.5
             for t0 in range(timepoints):

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -496,7 +496,7 @@ class ArtifactDetect(BaseInterface):
         # compute global intensity signal
         (x, y, z, timepoints) = nim.shape
 
-        data = nim.get_data()
+        data = nim.get_fdata(dtype=np.float32)
         affine = nim.affine
         g = np.zeros((timepoints, 1))
         masktype = self.inputs.mask_type
@@ -526,7 +526,7 @@ class ArtifactDetect(BaseInterface):
                     g[t0] = np.nansum(vol * mask_tmp) / np.nansum(mask_tmp)
         elif masktype == "file":  # uses a mask image to determine intensity
             maskimg = load(self.inputs.mask_file, mmap=NUMPY_MMAP)
-            mask = maskimg.get_data()
+            mask = maskimg.get_fdata()
             affine = maskimg.affine
             mask = mask > 0.5
             for t0 in range(timepoints):

--- a/nipype/algorithms/stats.py
+++ b/nipype/algorithms/stats.py
@@ -50,7 +50,7 @@ class ActivationCount(SimpleInterface):
     output_spec = ActivationCountOutputSpec
 
     def _run_interface(self, runtime):
-        allmaps = nb.concat_images(self.inputs.in_files).get_data()
+        allmaps = nb.concat_images(self.inputs.in_files).dataobj
         acm_pos = np.mean(allmaps > self.inputs.threshold, axis=3, dtype=np.float32)
         acm_neg = np.mean(
             allmaps < -1.0 * self.inputs.threshold, axis=3, dtype=np.float32

--- a/nipype/algorithms/tests/test_CompCor.py
+++ b/nipype/algorithms/tests/test_CompCor.py
@@ -124,7 +124,7 @@ class TestCompCor:
         ccinterface = TCompCor(num_components=6, realigned_file=self.realigned_file)
         ccinterface.run()
 
-        mask = nb.load("mask_000.nii.gz").get_data()
+        mask = nb.load("mask_000.nii.gz").dataobj
         num_nonmasked_voxels = np.count_nonzero(mask)
         assert num_nonmasked_voxels == 1
 
@@ -153,7 +153,7 @@ class TestCompCor:
         )
 
         TCompCor(realigned_file=asymmetric_data).run()
-        assert nb.load("mask_000.nii.gz").get_data().shape == asymmetric_shape[:3]
+        assert nb.load("mask_000.nii.gz").shape == asymmetric_shape[:3]
 
     def test_compcor_bad_input_shapes(self):
         # dim 0 is < dim 0 of self.mask_files (2)
@@ -183,12 +183,12 @@ class TestCompCor:
             ).run()
             if method == "union":
                 assert np.array_equal(
-                    nb.load("mask_000.nii.gz").get_data(),
+                    nb.load("mask_000.nii.gz").dataobj,
                     ([[[0, 0], [0, 0]], [[0, 0], [1, 0]]]),
                 )
             if method == "intersect":
                 assert np.array_equal(
-                    nb.load("mask_000.nii.gz").get_data(),
+                    nb.load("mask_000.nii.gz").dataobj,
                     ([[[0, 0], [0, 0]], [[0, 1], [0, 0]]]),
                 )
 
@@ -197,8 +197,7 @@ class TestCompCor:
             realigned_file=self.realigned_file, mask_files=self.mask_files, mask_index=1
         ).run()
         assert np.array_equal(
-            nb.load("mask_000.nii.gz").get_data(),
-            ([[[0, 0], [0, 0]], [[0, 1], [0, 0]]]),
+            nb.load("mask_000.nii.gz").dataobj, ([[[0, 0], [0, 0]], [[0, 1], [0, 0]]])
         )
 
     def test_tcompcor_multi_mask_no_index(self):

--- a/nipype/algorithms/tests/test_normalize_tpms.py
+++ b/nipype/algorithms/tests/test_normalize_tpms.py
@@ -19,7 +19,7 @@ from nipype.utils import NUMPY_MMAP
 def test_normalize_tpms(tmpdir):
 
     in_mask = example_data("tpms_msk.nii.gz")
-    mskdata = nb.load(in_mask, mmap=NUMPY_MMAP).get_data()
+    mskdata = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj)
     mskdata[mskdata > 0.0] = 1.0
 
     mapdata = []
@@ -32,8 +32,8 @@ def test_normalize_tpms(tmpdir):
         out_files.append(tmpdir.join("normtpm_%02d.nii.gz" % i).strpath)
 
         im = nb.load(mapname, mmap=NUMPY_MMAP)
-        data = im.get_data()
-        mapdata.append(data.copy())
+        data = im.get_fdata()
+        mapdata.append(data)
 
         nb.Nifti1Image(2.0 * (data * mskdata), im.affine, im.header).to_filename(
             filename
@@ -45,7 +45,7 @@ def test_normalize_tpms(tmpdir):
     sumdata = np.zeros_like(mskdata)
 
     for i, tstfname in enumerate(out_files):
-        normdata = nb.load(tstfname, mmap=NUMPY_MMAP).get_data()
+        normdata = nb.load(tstfname, mmap=NUMPY_MMAP).get_fdata()
         sumdata += normdata
         assert np.all(normdata[mskdata == 0] == 0)
         assert np.allclose(normdata, mapdata[i])

--- a/nipype/algorithms/tests/test_normalize_tpms.py
+++ b/nipype/algorithms/tests/test_normalize_tpms.py
@@ -19,7 +19,7 @@ from nipype.utils import NUMPY_MMAP
 def test_normalize_tpms(tmpdir):
 
     in_mask = example_data("tpms_msk.nii.gz")
-    mskdata = np.asanyarray(nb.load(in_mask, mmap=NUMPY_MMAP).dataobj)
+    mskdata = np.asanyarray(nb.load(in_mask).dataobj)
     mskdata[mskdata > 0.0] = 1.0
 
     mapdata = []
@@ -31,7 +31,7 @@ def test_normalize_tpms(tmpdir):
         filename = tmpdir.join("modtpm_%02d.nii.gz" % i).strpath
         out_files.append(tmpdir.join("normtpm_%02d.nii.gz" % i).strpath)
 
-        im = nb.load(mapname, mmap=NUMPY_MMAP)
+        im = nb.load(mapname)
         data = im.get_fdata()
         mapdata.append(data)
 
@@ -45,7 +45,7 @@ def test_normalize_tpms(tmpdir):
     sumdata = np.zeros_like(mskdata)
 
     for i, tstfname in enumerate(out_files):
-        normdata = nb.load(tstfname, mmap=NUMPY_MMAP).get_fdata()
+        normdata = nb.load(tstfname).get_fdata()
         sumdata += normdata
         assert np.all(normdata[mskdata == 0] == 0)
         assert np.allclose(normdata, mapdata[i])

--- a/nipype/algorithms/tests/test_splitmerge.py
+++ b/nipype/algorithms/tests/test_splitmerge.py
@@ -15,8 +15,9 @@ def test_split_and_merge(tmpdir):
 
     in_mask = example_data("tpms_msk.nii.gz")
     dwfile = tmpdir.join("dwi.nii.gz").strpath
-    mskdata = nb.load(in_mask, mmap=NUMPY_MMAP).get_data()
-    aff = nb.load(in_mask, mmap=NUMPY_MMAP).affine
+    mask_img = nb.load(in_mask, mmap=NUMPY_MMAP)
+    mskdata = np.asanyarray(mask_img.dataobj)
+    aff = mask_img.affine
 
     dwshape = (mskdata.shape[0], mskdata.shape[1], mskdata.shape[2], 6)
     dwdata = np.random.normal(size=dwshape)
@@ -25,7 +26,7 @@ def test_split_and_merge(tmpdir):
 
     resdw, resmsk, resid = split_rois(dwfile, in_mask, roishape=(20, 20, 2))
     merged = merge_rois(resdw, resid, in_mask)
-    dwmerged = nb.load(merged, mmap=NUMPY_MMAP).get_data()
+    dwmerged = nb.load(merged, mmap=NUMPY_MMAP).get_fdata(dtype=np.float32)
 
     dwmasked = dwdata * mskdata[:, :, :, np.newaxis]
 

--- a/nipype/algorithms/tests/test_splitmerge.py
+++ b/nipype/algorithms/tests/test_splitmerge.py
@@ -15,7 +15,7 @@ def test_split_and_merge(tmpdir):
 
     in_mask = example_data("tpms_msk.nii.gz")
     dwfile = tmpdir.join("dwi.nii.gz").strpath
-    mask_img = nb.load(in_mask, mmap=NUMPY_MMAP)
+    mask_img = nb.load(in_mask)
     mskdata = np.asanyarray(mask_img.dataobj)
     aff = mask_img.affine
 
@@ -26,7 +26,7 @@ def test_split_and_merge(tmpdir):
 
     resdw, resmsk, resid = split_rois(dwfile, in_mask, roishape=(20, 20, 2))
     merged = merge_rois(resdw, resid, in_mask)
-    dwmerged = nb.load(merged, mmap=NUMPY_MMAP).get_fdata(dtype=np.float32)
+    dwmerged = nb.load(merged).get_fdata(dtype=np.float32)
 
     dwmasked = dwdata * mskdata[:, :, :, np.newaxis]
 

--- a/nipype/algorithms/tests/test_stats.py
+++ b/nipype/algorithms/tests/test_stats.py
@@ -19,7 +19,7 @@ def test_ActivationCount(tmpdir):
     diff = nb.load(res.outputs.out_file)
     pos = nb.load(res.outputs.acm_pos)
     neg = nb.load(res.outputs.acm_neg)
-    assert np.allclose(diff.get_data(), pos.get_data() - neg.get_data())
+    assert np.allclose(diff.get_fdata(), pos.get_fdata() - neg.get_fdata())
 
 
 @pytest.mark.parametrize(
@@ -43,8 +43,8 @@ def test_ActivationCount_normaldistr(tmpdir, threshold, above_thresh):
     pos = nb.load(res.outputs.acm_pos)
     neg = nb.load(res.outputs.acm_neg)
     assert np.isclose(
-        pos.get_data().mean(), above_thresh * 1.0e-2, rtol=0.1, atol=1.0e-4
+        pos.get_fdata().mean(), above_thresh * 1.0e-2, rtol=0.1, atol=1.0e-4
     )
     assert np.isclose(
-        neg.get_data().mean(), above_thresh * 1.0e-2, rtol=0.1, atol=1.0e-4
+        neg.get_fdata().mean(), above_thresh * 1.0e-2, rtol=0.1, atol=1.0e-4
     )

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -200,7 +200,7 @@ def cmat(
     fib, hdr = nb.trackvis.read(track_file, False)
     stats["orig_n_fib"] = len(fib)
 
-    roi = nb.load(roi_file, mmap=NUMPY_MMAP)
+    roi = nb.load(roi_file)
     # Preserve on-disk type unless scaled
     roiData = np.asanyarray(roi.dataobj)
     roiVoxelSize = roi.header.get_zooms()
@@ -838,7 +838,7 @@ class ROIGen(BaseInterface):
         aparc_aseg_file = self.inputs.aparc_aseg_file
         aparcpath, aparcname, aparcext = split_filename(aparc_aseg_file)
         iflogger.info("Using Aparc+Aseg file: %s", aparcname + aparcext)
-        niiAPARCimg = nb.load(aparc_aseg_file, mmap=NUMPY_MMAP)
+        niiAPARCimg = nb.load(aparc_aseg_file)
         # Preserve on-disk type
         niiAPARCdata = np.asanyarray(niiAPARCimg.dataobj)
         niiDataLabels = np.unique(niiAPARCdata)
@@ -1056,7 +1056,7 @@ class ROIGen(BaseInterface):
 def create_nodes(roi_file, resolution_network_file, out_filename):
     G = nx.Graph()
     gp = nx.read_graphml(resolution_network_file)
-    roi_image = nb.load(roi_file, mmap=NUMPY_MMAP)
+    roi_image = nb.load(roi_file)
     # Preserve on-disk type unless scaled
     roiData = np.asanyarray(roi_image.dataobj)
     for u, d in gp.nodes(data=True):

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -201,7 +201,8 @@ def cmat(
     stats["orig_n_fib"] = len(fib)
 
     roi = nb.load(roi_file, mmap=NUMPY_MMAP)
-    roiData = roi.get_data()
+    # Preserve on-disk type unless scaled
+    roiData = np.asanyarray(roi.dataobj)
     roiVoxelSize = roi.header.get_zooms()
     (endpoints, endpointsmm) = create_endpoints_array(fib, roiVoxelSize)
 
@@ -432,9 +433,7 @@ def cmat(
 
     fiberlabels_fname = op.abspath(endpoint_name + "_filtered_fiberslabel.npy")
     iflogger.info("Storing all fiber labels (with orphans) as %s", fiberlabels_fname)
-    np.save(
-        fiberlabels_fname, np.array(fiberlabels, dtype=np.int32),
-    )
+    np.save(fiberlabels_fname, np.array(fiberlabels, dtype=np.int32))
 
     fiberlabels_noorphans_fname = op.abspath(endpoint_name + "_final_fiberslabels.npy")
     iflogger.info(
@@ -840,7 +839,8 @@ class ROIGen(BaseInterface):
         aparcpath, aparcname, aparcext = split_filename(aparc_aseg_file)
         iflogger.info("Using Aparc+Aseg file: %s", aparcname + aparcext)
         niiAPARCimg = nb.load(aparc_aseg_file, mmap=NUMPY_MMAP)
-        niiAPARCdata = niiAPARCimg.get_data()
+        # Preserve on-disk type
+        niiAPARCdata = np.asanyarray(niiAPARCimg.dataobj)
         niiDataLabels = np.unique(niiAPARCdata)
         numDataLabels = np.size(niiDataLabels)
         iflogger.info("Number of labels in image: %s", numDataLabels)
@@ -1057,7 +1057,8 @@ def create_nodes(roi_file, resolution_network_file, out_filename):
     G = nx.Graph()
     gp = nx.read_graphml(resolution_network_file)
     roi_image = nb.load(roi_file, mmap=NUMPY_MMAP)
-    roiData = roi_image.get_data()
+    # Preserve on-disk type unless scaled
+    roiData = np.asanyarray(roi_image.dataobj)
     for u, d in gp.nodes(data=True):
         G.add_node(int(u), **d)
         xyz = tuple(

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -10,7 +10,6 @@ import networkx as nx
 
 from ... import logging
 from ...utils.filemanip import split_filename
-from ...utils import NUMPY_MMAP
 
 from ..base import (
     BaseInterface,

--- a/nipype/interfaces/cmtk/parcellation.py
+++ b/nipype/interfaces/cmtk/parcellation.py
@@ -345,7 +345,7 @@ def create_roi(subject_id, subjects_dir, fs_dir, parcellation_name, dilation):
     parval = cmp_config._get_lausanne_parcellation("Lausanne2008")[parcellation_name]
     pgpath = parval["node_information_graphml"]
     aseg = nb.load(op.join(fs_dir, "mri", "aseg.nii.gz"))
-    asegd = aseg.get_data()
+    asegd = np.asanyarray(aseg.dataobj)
 
     # identify cortical voxels, right (3) and left (42) hemispheres
     idxr = np.where(asegd == 3)
@@ -420,7 +420,7 @@ def create_roi(subject_id, subjects_dir, fs_dir, parcellation_name, dilation):
             runCmd(mri_cmd, log)
 
             tmp = nb.load(op.join(output_dir, "tmp.nii.gz"))
-            tmpd = tmp.get_data()
+            tmpd = np.asanyarray(tmp.dataobj)
 
             # find voxel and set them to intensityvalue in rois
             idx = np.where(tmpd == 1)
@@ -478,7 +478,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
     ]
     # load ribbon as basis for white matter mask
     fsmask = nb.load(op.join(fs_dir, "mri", "ribbon.nii.gz"))
-    fsmaskd = fsmask.get_data()
+    fsmaskd = np.asanyarray(fsmask.dataobj)
 
     wmmask = np.zeros(fsmaskd.shape)
     # extract right and left white matter
@@ -490,7 +490,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
 
     # remove subcortical nuclei from white matter mask
     aseg = nb.load(op.join(fs_dir, "mri", "aseg.nii.gz"))
-    asegd = aseg.get_data()
+    asegd = np.asanyarray(aseg.dataobj)
 
     # need binary erosion function
     imerode = nd.binary_erosion
@@ -583,7 +583,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
 
     # ADD voxels from 'cc_unknown.nii.gz' dataset
     ccun = nb.load(op.join(fs_dir, "label", "cc_unknown.nii.gz"))
-    ccund = ccun.get_data()
+    ccund = np.asanyarray(ccun.dataobj)
     idx = np.where(ccund != 0)
     iflogger.info("Add corpus callosum and unknown to wm mask")
     wmmask[idx] = 1
@@ -594,7 +594,7 @@ def create_wm_mask(subject_id, subjects_dir, fs_dir, parcellation_name):
         parcellation_name,
     )
     roi = nb.load(op.join(op.curdir, "ROI_%s.nii.gz" % parcellation_name))
-    roid = roi.get_data()
+    roid = np.asanyarray(roi.dataobj)
     assert roid.shape[0] == wmmask.shape[0]
     pg = nx.read_graphml(pgpath)
     for brk, brv in pg.nodes(data=True):

--- a/nipype/interfaces/dipy/anisotropic_power.py
+++ b/nipype/interfaces/dipy/anisotropic_power.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import nibabel as nb
 
 from ... import logging

--- a/nipype/interfaces/dipy/anisotropic_power.py
+++ b/nipype/interfaces/dipy/anisotropic_power.py
@@ -43,11 +43,11 @@ class APMQball(DipyDiffusionInterface):
         gtab = self._get_gradient_table()
 
         img = nb.load(self.inputs.in_file)
-        data = img.get_data()
+        data = np.asanyarray(img.dataobj)
         affine = img.affine
         mask = None
         if isdefined(self.inputs.mask_file):
-            mask = nb.load(self.inputs.mask_file).get_data()
+            mask = np.asanyarray(nb.load(self.inputs.mask_file).dataobj)
 
         # Fit it
         model = shm.QballModel(gtab, 8)

--- a/nipype/interfaces/dipy/preprocess.py
+++ b/nipype/interfaces/dipy/preprocess.py
@@ -166,7 +166,7 @@ class Denoise(DipyBaseInterface):
         settings = dict(mask=None, rician=(self.inputs.noise_model == "rician"))
 
         if isdefined(self.inputs.in_mask):
-            settings["mask"] = nb.load(self.inputs.in_mask).get_data()
+            settings["mask"] = np.asanyarray(nb.load(self.inputs.in_mask).dataobj)
 
         if isdefined(self.inputs.patch_radius):
             settings["patch_radius"] = self.inputs.patch_radius
@@ -180,10 +180,10 @@ class Denoise(DipyBaseInterface):
 
         signal_mask = None
         if isdefined(self.inputs.signal_mask):
-            signal_mask = nb.load(self.inputs.signal_mask).get_data()
+            signal_mask = np.asanyarray(nb.load(self.inputs.signal_mask).dataobj)
         noise_mask = None
         if isdefined(self.inputs.noise_mask):
-            noise_mask = nb.load(self.inputs.noise_mask).get_data()
+            noise_mask = np.asanyarray(nb.load(self.inputs.noise_mask).dataobj)
 
         _, s = nlmeans_proxy(
             self.inputs.in_file,
@@ -224,7 +224,7 @@ def resample_proxy(in_file, order=3, new_zooms=None, out_file=None):
 
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     hdr = img.header.copy()
-    data = img.get_data().astype(np.float32)
+    data = img.get_fdata(dtype=np.float32)
     affine = img.affine
     im_zooms = hdr.get_zooms()[:3]
 
@@ -264,7 +264,7 @@ def nlmeans_proxy(in_file, settings, snr=None, smask=None, nmask=None, out_file=
 
     img = nb.load(in_file, mmap=NUMPY_MMAP)
     hdr = img.header
-    data = img.get_data()
+    data = img.get_fdata()
     aff = img.affine
 
     if data.ndim < 4:

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -6,7 +6,6 @@ import numpy as np
 import nibabel as nb
 
 from ... import logging
-from ...utils import NUMPY_MMAP
 from ..base import (
     traits,
     TraitedSpec,

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -142,7 +142,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         nballs = len(self.inputs.in_vfms)
         vfs = np.squeeze(
             nb.concat_images(
-                [nb.load(f, mmap=NUMPY_MMAP) for f in self.inputs.in_vfms]
+                self.inputs.in_vfms
             ).dataobj
         )
         if nballs == 1:
@@ -163,7 +163,7 @@ class SimulateMultiTensor(DipyBaseInterface):
 
         # Fiber fractions
         ffsim = nb.concat_images(
-            [nb.load(f, mmap=NUMPY_MMAP) for f in self.inputs.in_frac]
+            self.inputs.in_frac
         )
         ffs = np.nan_to_num(np.squeeze(ffsim.dataobj))  # fiber fractions
         ffs = np.clip(ffs, 0.0, 1.0)
@@ -207,7 +207,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         dirs = None
         for i in range(nsticks):
             f = self.inputs.in_dirs[i]
-            fd = np.nan_to_num(nb.load(f, mmap=NUMPY_MMAP).dataobj)
+            fd = np.nan_to_num(nb.load(f).dataobj)
             w = np.linalg.norm(fd, axis=3)[..., np.newaxis]
             w[w < np.finfo(float).eps] = 1.0
             fd /= w

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -143,7 +143,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         vfs = np.squeeze(
             nb.concat_images(
                 [nb.load(f, mmap=NUMPY_MMAP) for f in self.inputs.in_vfms]
-            ).get_data()
+            ).dataobj
         )
         if nballs == 1:
             vfs = vfs[..., np.newaxis]
@@ -151,7 +151,7 @@ class SimulateMultiTensor(DipyBaseInterface):
 
         # Generate a mask
         if isdefined(self.inputs.in_mask):
-            msk = nb.load(self.inputs.in_mask).get_data()
+            msk = np.asanyarray(nb.load(self.inputs.in_mask).dataobj)
             msk[msk > 0.0] = 1.0
             msk[msk < 1.0] = 0.0
         else:
@@ -165,7 +165,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         ffsim = nb.concat_images(
             [nb.load(f, mmap=NUMPY_MMAP) for f in self.inputs.in_frac]
         )
-        ffs = np.nan_to_num(np.squeeze(ffsim.get_data()))  # fiber fractions
+        ffs = np.nan_to_num(np.squeeze(ffsim.dataobj))  # fiber fractions
         ffs = np.clip(ffs, 0.0, 1.0)
         if nsticks == 1:
             ffs = ffs[..., np.newaxis]
@@ -207,7 +207,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         dirs = None
         for i in range(nsticks):
             f = self.inputs.in_dirs[i]
-            fd = np.nan_to_num(nb.load(f, mmap=NUMPY_MMAP).get_data())
+            fd = np.nan_to_num(nb.load(f, mmap=NUMPY_MMAP).dataobj)
             w = np.linalg.norm(fd, axis=3)[..., np.newaxis]
             w[w < np.finfo(float).eps] = 1.0
             fd /= w
@@ -230,7 +230,7 @@ class SimulateMultiTensor(DipyBaseInterface):
 
         mevals = [sf_evals] * nsticks + [[ba_evals[d]] * 3 for d in range(nballs)]
 
-        b0 = b0_im.get_data()[msk > 0]
+        b0 = b0_im.get_fdata()[msk > 0]
         args = []
         for i in range(nvox):
             args.append(

--- a/nipype/interfaces/dipy/simulate.py
+++ b/nipype/interfaces/dipy/simulate.py
@@ -140,11 +140,7 @@ class SimulateMultiTensor(DipyBaseInterface):
 
         # Volume fractions of isotropic compartments
         nballs = len(self.inputs.in_vfms)
-        vfs = np.squeeze(
-            nb.concat_images(
-                self.inputs.in_vfms
-            ).dataobj
-        )
+        vfs = np.squeeze(nb.concat_images(self.inputs.in_vfms).dataobj)
         if nballs == 1:
             vfs = vfs[..., np.newaxis]
         total_vf = np.sum(vfs, axis=3)
@@ -162,9 +158,7 @@ class SimulateMultiTensor(DipyBaseInterface):
         nvox = len(msk[msk > 0])
 
         # Fiber fractions
-        ffsim = nb.concat_images(
-            self.inputs.in_frac
-        )
+        ffsim = nb.concat_images(self.inputs.in_frac)
         ffs = np.nan_to_num(np.squeeze(ffsim.dataobj))  # fiber fractions
         ffs = np.clip(ffs, 0.0, 1.0)
         if nsticks == 1:

--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -47,11 +47,11 @@ class DTI(DipyDiffusionInterface):
         gtab = self._get_gradient_table()
 
         img = nb.load(self.inputs.in_file)
-        data = img.get_data()
+        data = img.get_fdata()
         affine = img.affine
         mask = None
         if isdefined(self.inputs.mask_file):
-            mask = nb.load(self.inputs.mask_file).get_data()
+            mask = np.asanyarray(nb.load(self.inputs.mask_file).dataobj)
 
         # Fit it
         tenmodel = dti.TensorModel(gtab)
@@ -120,7 +120,7 @@ class TensorMode(DipyDiffusionInterface):
 
         # Load the 4D image files
         img = nb.load(self.inputs.in_file)
-        data = img.get_data()
+        data = img.get_fdata()
         affine = img.affine
 
         # Load the gradient strengths and directions

--- a/nipype/interfaces/dipy/tensors.py
+++ b/nipype/interfaces/dipy/tensors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import nibabel as nb
 
 from ... import logging

--- a/nipype/interfaces/dipy/tracks.py
+++ b/nipype/interfaces/dipy/tracks.py
@@ -233,7 +233,7 @@ class StreamlineTractography(DipyBaseInterface):
         imref = nb.four_to_three(img)[0]
         affine = img.affine
 
-        data = img.get_data().astype(np.float32)
+        data = img.get_fdata(dtype=np.float32)
         hdr = imref.header.copy()
         hdr.set_data_dtype(np.float32)
         hdr["data_type"] = 16
@@ -274,7 +274,7 @@ class StreamlineTractography(DipyBaseInterface):
         IFLOGGER.info("Performing tractography")
 
         if isdefined(self.inputs.tracking_mask):
-            msk = nb.load(self.inputs.tracking_mask).get_data()
+            msk = np.asanyarray(nb.load(self.inputs.tracking_mask).dataobj)
             msk[msk > 0] = 1
             msk[msk < 0] = 0
         else:
@@ -287,7 +287,7 @@ class StreamlineTractography(DipyBaseInterface):
             seeds = np.loadtxt(self.inputs.seed_coord)
 
         elif isdefined(self.inputs.seed_mask):
-            seedmsk = nb.load(self.inputs.seed_mask).get_data()
+            seedmsk = np.asanyarray(nb.load(self.inputs.seed_mask).dataobj)
             assert seedmsk.shape == data.shape[:3]
             seedmsk[seedmsk > 0] = 1
             seedmsk[seedmsk < 1] = 0

--- a/nipype/interfaces/freesurfer/tests/test_model.py
+++ b/nipype/interfaces/freesurfer/tests/test_model.py
@@ -37,7 +37,7 @@ def test_concatenate(tmpdir):
     # Test specified concatenated_file
     res = model.Concatenate(in_files=[in1, in2], concatenated_file=out).run()
     assert res.outputs.concatenated_file == tmpdir.join(out).strpath
-    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_fdata(), out_data)
+    assert np.allclose(nb.load(out).get_fdata(), out_data)
 
     # Test in workflow
     wf = pe.Workflow("test_concatenate", base_dir=tmpdir.strpath)
@@ -55,4 +55,4 @@ def test_concatenate(tmpdir):
     res = model.Concatenate(
         in_files=[in1, in2], concatenated_file=out, stats="mean"
     ).run()
-    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_fdata(), mean_data)
+    assert np.allclose(nb.load(out).get_fdata(), mean_data)

--- a/nipype/interfaces/freesurfer/tests/test_model.py
+++ b/nipype/interfaces/freesurfer/tests/test_model.py
@@ -32,12 +32,12 @@ def test_concatenate(tmpdir):
     # Test default behavior
     res = model.Concatenate(in_files=[in1, in2]).run()
     assert res.outputs.concatenated_file == tmpdir.join("concat_output.nii.gz").strpath
-    assert np.allclose(nb.load("concat_output.nii.gz").get_data(), out_data)
+    assert np.allclose(nb.load("concat_output.nii.gz").get_fdata(), out_data)
 
     # Test specified concatenated_file
     res = model.Concatenate(in_files=[in1, in2], concatenated_file=out).run()
     assert res.outputs.concatenated_file == tmpdir.join(out).strpath
-    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_data(), out_data)
+    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_fdata(), out_data)
 
     # Test in workflow
     wf = pe.Workflow("test_concatenate", base_dir=tmpdir.strpath)
@@ -47,7 +47,7 @@ def test_concatenate(tmpdir):
     wf.add_nodes([concat])
     wf.run()
     assert np.allclose(
-        nb.load(tmpdir.join("test_concatenate", "concat", out).strpath).get_data(),
+        nb.load(tmpdir.join("test_concatenate", "concat", out).strpath).get_fdata(),
         out_data,
     )
 
@@ -55,4 +55,4 @@ def test_concatenate(tmpdir):
     res = model.Concatenate(
         in_files=[in1, in2], concatenated_file=out, stats="mean"
     ).run()
-    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_data(), mean_data)
+    assert np.allclose(nb.load(out, mmap=NUMPY_MMAP).get_fdata(), mean_data)

--- a/nipype/interfaces/image.py
+++ b/nipype/interfaces/image.py
@@ -68,8 +68,8 @@ class Rescale(SimpleInterface):
         import nibabel as nb
 
         img = nb.load(self.inputs.in_file)
-        data = img.get_data()
-        ref_data = nb.load(self.inputs.ref_file).get_data()
+        data = img.get_fdata()
+        ref_data = nb.load(self.inputs.ref_file).get_fdata()
 
         in_mask = data > 0
         ref_mask = ref_data > 0
@@ -232,7 +232,7 @@ def _as_reoriented_backport(img, ornt):
     if np.array_equal(ornt, [[0, 1], [1, 1], [2, 1]]):
         return img
 
-    t_arr = nb.apply_orientation(img.get_data(), ornt)
+    t_arr = nb.apply_orientation(img.dataobj, ornt)
     new_aff = img.affine.dot(inv_ornt_aff(ornt, img.shape))
     reoriented = img.__class__(t_arr, new_aff, img.header)
 

--- a/nipype/interfaces/nilearn.py
+++ b/nipype/interfaces/nilearn.py
@@ -124,15 +124,15 @@ class SignalExtraction(NilearnBaseInterface, SimpleInterface):
         maskers = []
 
         # determine form of label files, choose appropriate nilearn masker
-        if np.amax(label_data.get_data()) > 1:  # 3d label file
-            n_labels = np.amax(label_data.get_data())
+        if np.amax(label_data.dataobj) > 1:  # 3d label file
+            n_labels = np.amax(label_data.dataobj)
             maskers.append(nl.NiftiLabelsMasker(label_data))
         else:  # 4d labels
-            n_labels = label_data.get_data().shape[3]
+            n_labels = label_data.shape[3]
             if self.inputs.incl_shared_variance:  # independent computation
                 for img in nli.iter_img(label_data):
                     maskers.append(
-                        nl.NiftiMapsMasker(self._4d(img.get_data(), img.affine))
+                        nl.NiftiMapsMasker(self._4d(img.dataobj, img.affine))
                     )
             else:  # one computation fitting all
                 maskers.append(nl.NiftiMapsMasker(label_data))
@@ -155,9 +155,7 @@ class SignalExtraction(NilearnBaseInterface, SimpleInterface):
             )
 
         if self.inputs.include_global:
-            global_label_data = label_data.get_data().sum(
-                axis=3
-            )  # sum across all regions
+            global_label_data = label_data.dataobj.sum(axis=3)  # sum across all regions
             global_label_data = (
                 np.rint(global_label_data).astype(int).clip(0, 1)
             )  # binarize

--- a/nipype/interfaces/nipy/model.py
+++ b/nipype/interfaces/nipy/model.py
@@ -115,7 +115,7 @@ class FitGLM(NipyBaseInterface):
         if isinstance(functional_runs, (str, bytes)):
             functional_runs = [functional_runs]
         nii = nb.load(functional_runs[0])
-        data = nii.get_fdata(caching='unchanged')
+        data = nii.get_fdata(caching="unchanged")
 
         if isdefined(self.inputs.mask):
             mask = np.asanyarray(nb.load(self.inputs.mask).dataobj) > 0

--- a/nipype/interfaces/nipy/model.py
+++ b/nipype/interfaces/nipy/model.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 
-from ...utils import NUMPY_MMAP
-
 from .base import NipyBaseInterface
 from ..base import (
     TraitedSpec,

--- a/nipype/interfaces/nipy/model.py
+++ b/nipype/interfaces/nipy/model.py
@@ -115,21 +115,19 @@ class FitGLM(NipyBaseInterface):
         if isinstance(functional_runs, (str, bytes)):
             functional_runs = [functional_runs]
         nii = nb.load(functional_runs[0])
-        data = nii.get_data()
+        data = nii.get_fdata(caching='unchanged')
 
         if isdefined(self.inputs.mask):
-            mask = nb.load(self.inputs.mask).get_data() > 0
+            mask = np.asanyarray(nb.load(self.inputs.mask).dataobj) > 0
         else:
             mask = np.ones(nii.shape[:3]) == 1
 
-        timeseries = data.copy()[mask, :]
+        timeseries = data[mask, :]
         del data
 
         for functional_run in functional_runs[1:]:
-            nii = nb.load(functional_run, mmap=NUMPY_MMAP)
-            data = nii.get_data()
-            npdata = data.copy()
-            del data
+            nii = nb.load(functional_run, mmap=False)
+            npdata = np.asarray(nii.dataobj)
             timeseries = np.concatenate((timeseries, npdata[mask, :]), axis=1)
             del npdata
 
@@ -326,15 +324,14 @@ class EstimateContrast(NipyBaseInterface):
 
         beta_nii = nb.load(self.inputs.beta)
         if isdefined(self.inputs.mask):
-            mask = nb.load(self.inputs.mask).get_data() > 0
+            mask = np.asanyarray(nb.load(self.inputs.mask).dataobj) > 0
         else:
             mask = np.ones(beta_nii.shape[:3]) == 1
 
         glm = GLM.GeneralLinearModel()
-        nii = nb.load(self.inputs.beta)
-        glm.beta = beta_nii.get_data().copy()[mask, :].T
+        glm.beta = np.array(beta_nii.dataobj)[mask, :].T
         glm.nvbeta = self.inputs.nvbeta
-        glm.s2 = nb.load(self.inputs.s2).get_data().copy()[mask]
+        glm.s2 = np.array(nb.load(self.inputs.s2).dataobj)[mask]
         glm.dof = self.inputs.dof
         glm._axis = self.inputs.axis
         glm._constants = self.inputs.constants
@@ -358,7 +355,7 @@ class EstimateContrast(NipyBaseInterface):
             stat_map = np.zeros(mask.shape)
             stat_map[mask] = est_contrast.stat().T
             stat_map_file = os.path.abspath(name + "_stat_map.nii")
-            nb.save(nb.Nifti1Image(stat_map, nii.affine), stat_map_file)
+            nb.save(nb.Nifti1Image(stat_map, beta_nii.affine), stat_map_file)
             self._stat_maps.append(stat_map_file)
 
             p_map = np.zeros(mask.shape)

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -4,7 +4,6 @@ import os
 import nibabel as nb
 import numpy as np
 
-from ...utils import NUMPY_MMAP
 from ...utils.filemanip import split_filename, fname_presuffix
 
 from .base import NipyBaseInterface, have_nipy

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -57,7 +57,7 @@ class ComputeMask(NipyBaseInterface):
             value = getattr(self.inputs, key)
             if isdefined(value):
                 if key in ["mean_volume", "reference_volume"]:
-                    value = np.asanyarray(nb.load(value, mmap=NUMPY_MMAP).dataobj)
+                    value = np.asanyarray(nb.load(value).dataobj)
                 args[key] = value
 
         brain_mask = compute_mask(**args)

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -57,8 +57,7 @@ class ComputeMask(NipyBaseInterface):
             value = getattr(self.inputs, key)
             if isdefined(value):
                 if key in ["mean_volume", "reference_volume"]:
-                    nii = nb.load(value, mmap=NUMPY_MMAP)
-                    value = nii.get_data()
+                    value = np.asanyarray(nb.load(value, mmap=NUMPY_MMAP).dataobj)
                 args[key] = value
 
         brain_mask = compute_mask(**args)
@@ -264,7 +263,7 @@ class Trim(NipyBaseInterface):
             s = slice(self.inputs.begin_index, nii.shape[3])
         else:
             s = slice(self.inputs.begin_index, self.inputs.end_index)
-        nii2 = nb.Nifti1Image(nii.get_data()[..., s], nii.affine, nii.header)
+        nii2 = nb.Nifti1Image(nii.dataobj[..., s], nii.affine, nii.header)
         nb.save(nii2, out_file)
         return runtime
 

--- a/nipype/interfaces/nipy/utils.py
+++ b/nipype/interfaces/nipy/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import warnings
+import numpy as np
 import nibabel as nb
 
 from .base import NipyBaseInterface, have_nipy

--- a/nipype/interfaces/nipy/utils.py
+++ b/nipype/interfaces/nipy/utils.py
@@ -79,7 +79,7 @@ class Similarity(NipyBaseInterface):
             mask1 = None
 
         if isdefined(self.inputs.mask2):
-            mask2 = np.asanyarray(nb.load(self.inputs.mask2).dataobj) == 2
+            mask2 = np.asanyarray(nb.load(self.inputs.mask2).dataobj) == 1
         else:
             mask2 = None
 

--- a/nipype/interfaces/nipy/utils.py
+++ b/nipype/interfaces/nipy/utils.py
@@ -74,12 +74,12 @@ class Similarity(NipyBaseInterface):
         vol2_nii = nb.load(self.inputs.volume2)
 
         if isdefined(self.inputs.mask1):
-            mask1 = nb.load(self.inputs.mask1).get_data() == 1
+            mask1 = np.asanyarray(nb.load(self.inputs.mask1).dataobj) == 1
         else:
             mask1 = None
 
         if isdefined(self.inputs.mask2):
-            mask2 = nb.load(self.inputs.mask2).get_data() == 1
+            mask2 = np.asanyarray(nb.load(self.inputs.mask2).dataobj) == 2
         else:
             mask2 = None
 

--- a/nipype/interfaces/tests/test_image.py
+++ b/nipype/interfaces/tests/test_image.py
@@ -50,7 +50,9 @@ def test_reorientation_backport():
 
         # Reorientation changes affine and data array
         assert not np.allclose(img.affine, reoriented_a.affine)
-        assert not (flips_only and np.allclose(img.get_data(), reoriented_a.get_data()))
+        assert not (
+            flips_only and np.allclose(img.get_fdata(), reoriented_a.get_fdata())
+        )
         # Dimension info changes iff axes are reordered
         assert flips_only == np.array_equal(
             img.header.get_dim_info(), reoriented_a.header.get_dim_info()
@@ -58,7 +60,7 @@ def test_reorientation_backport():
 
         # Both approaches produce equivalent images
         assert np.allclose(reoriented_a.affine, reoriented_b.affine)
-        assert np.array_equal(reoriented_a.get_data(), reoriented_b.get_data())
+        assert np.array_equal(reoriented_a.get_fdata(), reoriented_b.get_fdata())
         assert np.array_equal(
             reoriented_a.header.get_dim_info(), reoriented_b.header.get_dim_info()
         )

--- a/nipype/interfaces/utility/base.py
+++ b/nipype/interfaces/utility/base.py
@@ -423,9 +423,9 @@ class AssertEqual(BaseInterface):
     def _run_interface(self, runtime):
         import nibabel as nb
 
-        data1 = nb.load(self.inputs.volume1).get_data()
-        data2 = nb.load(self.inputs.volume2).get_data()
+        data1 = np.asanyarray(nb.load(self.inputs.volume1))
+        data2 = np.asanyarray(nb.load(self.inputs.volume2))
 
-        if not np.all(data1 == data2):
+        if not np.array_equal(data1, data2):
             raise RuntimeError("Input images are not exactly equal")
         return runtime

--- a/nipype/utils/config.py
+++ b/nipype/utils/config.py
@@ -91,7 +91,9 @@ class NipypeConfig(object):
         self._config = configparser.ConfigParser()
         self._cwd = None
 
-        config_dir = os.path.expanduser(os.getenv("NIPYPE_CONFIG_DIR", default="~/.nipype"))
+        config_dir = os.path.expanduser(
+            os.getenv("NIPYPE_CONFIG_DIR", default="~/.nipype")
+        )
         self.data_file = os.path.join(config_dir, "nipype.json")
 
         self.set_default_config()


### PR DESCRIPTION
## Summary

Updated Travis on master to actually install pre-release dependencies. Starting on deprecation warnings.

I would appreciate a careful review. In general, `np.[as[any]]array(niimg.dataobj)` is the more conservative change, keeping `get_data()` functionality, except for caching. When floats obviously make more sense, I'm switching to `get_fdata()`. We may want to specify `dtype=np.float32` in these cases.

I'm also in passing removing unnecessary loading of data blocks, such as `get_data().shape` or `get_data().ndim`.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Purge `get_data()`
* ...?

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
