### PR TITLE
FIX: Mark strings containing regex escapes as raw

### DIFF
--- a/nipype/interfaces/diffusion_toolkit/odf.py
+++ b/nipype/interfaces/diffusion_toolkit/odf.py
@@ -96,11 +96,11 @@ class HARDIMat(CommandLine):
 
     def _create_gradient_matrix(self, bvecs_file, bvals_file):
         _gradient_matrix_file = "gradient_matrix.txt"
-        bvals = [val for val in re.split("\s+", open(bvals_file).readline().strip())]
+        bvals = [val for val in re.split(r"\s+", open(bvals_file).readline().strip())]
         bvecs_f = open(bvecs_file)
-        bvecs_x = [val for val in re.split("\s+", bvecs_f.readline().strip())]
-        bvecs_y = [val for val in re.split("\s+", bvecs_f.readline().strip())]
-        bvecs_z = [val for val in re.split("\s+", bvecs_f.readline().strip())]
+        bvecs_x = [val for val in re.split(r"\s+", bvecs_f.readline().strip())]
+        bvecs_y = [val for val in re.split(r"\s+", bvecs_f.readline().strip())]
+        bvecs_z = [val for val in re.split(r"\s+", bvecs_f.readline().strip())]
         bvecs_f.close()
         gradient_matrix_f = open(_gradient_matrix_file, "w")
         for i in range(len(bvals)):

--- a/nipype/interfaces/dipy/base.py
+++ b/nipype/interfaces/dipy/base.py
@@ -158,7 +158,7 @@ def create_interface_specs(class_name, params=None, BaseClass=TraitedSpec):
                     attr[name] = traits_type(desc=desc[-1], mandatory=is_mandatory)
             else:
                 attr[name] = traits_type(
-                    p[3], desc=desc[-1], exists=True, usedefault=True,
+                    p[3], desc=desc[-1], exists=True, usedefault=True
                 )
 
     newclass = type(str(class_name), (BaseClass,), attr)
@@ -189,7 +189,7 @@ def dipy_to_nipype_interface(cls_name, dipy_flow, BaseClass=DipyBaseInterface):
     parser = IntrospectiveArgumentParser()
     flow = dipy_flow()
     parser.add_workflow(flow)
-    default_values = inspect.getargspec(flow.run).defaults
+    default_values = inspect.getfullargspec(flow.run).defaults
     optional_params = [
         args + (val,) for args, val in zip(parser.optional_parameters, default_values)
     ]

--- a/nipype/interfaces/elastix/utils.py
+++ b/nipype/interfaces/elastix/utils.py
@@ -85,7 +85,7 @@ class EditTransform(BaseInterface):
     input_spec = EditTransformInputSpec
     output_spec = EditTransformOutputSpec
     _out_file = ""
-    _pattern = '\((?P<entry>%s\s"?)([-\.\s\w]+)("?\))'
+    _pattern = r'\((?P<entry>%s\s"?)([-\.\s\w]+)("?\))'
 
     _interp = {"nearest": 0, "linear": 1, "cubic": 3}
 
@@ -103,14 +103,14 @@ class EditTransform(BaseInterface):
             p = re.compile(
                 (self._pattern % "ResultImagePixelType").decode("string-escape")
             )
-            rep = "(\g<entry>%s\g<3>" % self.inputs.output_type
+            rep = r"(\g<entry>%s\g<3>" % self.inputs.output_type
             contents = p.sub(rep, contents)
 
         if isdefined(self.inputs.output_format):
             p = re.compile(
                 (self._pattern % "ResultImageFormat").decode("string-escape")
             )
-            rep = "(\g<entry>%s\g<3>" % self.inputs.output_format
+            rep = r"(\g<entry>%s\g<3>" % self.inputs.output_format
             contents = p.sub(rep, contents)
 
         if isdefined(self.inputs.interpolation):
@@ -119,7 +119,7 @@ class EditTransform(BaseInterface):
                     "string-escape"
                 )
             )
-            rep = "(\g<entry>%s\g<3>" % self._interp[self.inputs.interpolation]
+            rep = r"(\g<entry>%s\g<3>" % self._interp[self.inputs.interpolation]
             contents = p.sub(rep, contents)
 
         if isdefined(self.inputs.reference_image):
@@ -130,17 +130,17 @@ class EditTransform(BaseInterface):
 
             size = " ".join(["%01d" % s for s in im.shape])
             p = re.compile((self._pattern % "Size").decode("string-escape"))
-            rep = "(\g<entry>%s\g<3>" % size
+            rep = r"(\g<entry>%s\g<3>" % size
             contents = p.sub(rep, contents)
 
             index = " ".join(["0" for s in im.shape])
             p = re.compile((self._pattern % "Index").decode("string-escape"))
-            rep = "(\g<entry>%s\g<3>" % index
+            rep = r"(\g<entry>%s\g<3>" % index
             contents = p.sub(rep, contents)
 
             spacing = " ".join(["%0.4f" % f for f in im.header.get_zooms()])
             p = re.compile((self._pattern % "Spacing").decode("string-escape"))
-            rep = "(\g<entry>%s\g<3>" % spacing
+            rep = r"(\g<entry>%s\g<3>" % spacing
             contents = p.sub(rep, contents)
 
             itkmat = np.eye(4)
@@ -156,7 +156,7 @@ class EditTransform(BaseInterface):
             # contents = p.sub(rep, contents)
 
             p = re.compile((self._pattern % "Origin").decode("string-escape"))
-            rep = "(\g<entry>%s\g<3>" % orig
+            rep = r"(\g<entry>%s\g<3>" % orig
             contents = p.sub(rep, contents)
 
         with open(self._get_outfile(), "w") as of:

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -1017,7 +1017,7 @@ class SurfaceSnapshots(FSCommand):
             # extension strings
             if value.endswith(".annot"):
                 value = value[:-6]
-            if re.match("%s[\.\-_]" % self.inputs.hemi, value[:3]):
+            if re.match(r"%s[\.\-_]" % self.inputs.hemi, value[:3]):
                 value = value[3:]
             return "-annotation %s" % value
         return super(SurfaceSnapshots, self)._format_arg(name, spec, value)
@@ -1145,7 +1145,7 @@ class ImageInfo(FSCommand):
     output_spec = ImageInfoOutputSpec
 
     def info_regexp(self, info, field, delim="\n"):
-        m = re.search("%s\s*:\s+(.+?)%s" % (field, delim), info)
+        m = re.search(r"%s\s*:\s+(.+?)%s" % (field, delim), info)
         if m:
             return m.group(1)
         else:
@@ -1175,7 +1175,7 @@ class ImageInfo(FSCommand):
         outputs.ph_enc_dir = self.info_regexp(info, "PhEncDir")
 
         # File format and datatype are both keyed by "type"
-        ftype, dtype = re.findall("%s\s*:\s+(.+?)\n" % "type", info)
+        ftype, dtype = re.findall(r"%s\s*:\s+(.+?)\n" % "type", info)
         outputs.file_format = ftype
         outputs.data_type = dtype
 

--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -474,15 +474,16 @@ class EstimateContrast(SPMCommand):
             script += "condnames=names;\n"
         else:
             if self.inputs.use_derivs:
-                script += "pat = 'Sn\([0-9]*\) (.*)';\n"
+                script += r"pat = 'Sn\([0-9]*\) (.*)';" "\n"
             else:
                 script += (
-                    "pat = 'Sn\([0-9]*\) (.*)\*bf\(1\)|Sn\([0-9]*\) "
-                    ".*\*bf\([2-9]\)|Sn\([0-9]*\) (.*)';\n"
+                    r"pat = 'Sn\([0-9]*\) (.*)\*bf\(1\)|Sn\([0-9]*\) "
+                    r".*\*bf\([2-9]\)|Sn\([0-9]*\) (.*)';"
+                    "\n"
                 )
             script += "t = regexp(names,pat,'tokens');\n"
             # get sessidx for columns
-            script += "pat1 = 'Sn\(([0-9].*)\)\s.*';\n"
+            script += r"pat1 = 'Sn\(([0-9].*)\)\s.*';" "\n"
             script += "t1 = regexp(names,pat1,'tokens');\n"
             script += (
                 "for i0=1:numel(t),condnames{i0}='';condsess(i0)=0;if "

--- a/nipype/pipeline/plugins/tests/test_tools.py
+++ b/nipype/pipeline/plugins/tests/test_tools.py
@@ -21,12 +21,12 @@ def test_report_crash():
             mock_node = mock.MagicMock(name="mock_node")
             mock_node._id = "an_id"
             mock_node.config = {
-                "execution": {"crashdump_dir": ".", "crashfile_format": "pklz",}
+                "execution": {"crashdump_dir": ".", "crashfile_format": "pklz"}
             }
 
             actual_crashfile = report_crash(mock_node)
 
-            expected_crashfile = re.compile(".*/crash-.*-an_id-[0-9a-f\-]*.pklz")
+            expected_crashfile = re.compile(r".*/crash-.*-an_id-[0-9a-f\-]*.pklz")
 
             assert (
                 expected_crashfile.match(actual_crashfile).group() == actual_crashfile

--- a/nipype/sphinxext/plot_workflow.py
+++ b/nipype/sphinxext/plot_workflow.py
@@ -314,7 +314,7 @@ def remove_coding(text):
     """
     Remove the coding comment, which exec doesn't like.
     """
-    sub_re = re.compile("^#\s*-\*-\s*coding:\s*.*-\*-$", flags=re.MULTILINE)
+    sub_re = re.compile(r"^#\s*-\*-\s*coding:\s*.*-\*-$", flags=re.MULTILINE)
     return sub_re.sub("", text)
 
 


### PR DESCRIPTION
## Summary

Ran into some deprecation errors working on #3099. The escape characters were easy to handle.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
