### PR TITLE
MNT: Set junit_family to suppress pytest warning

### DIFF
--- a/nipype/pytest.ini
+++ b/nipype/pytest.ini
@@ -4,3 +4,4 @@ addopts = --doctest-modules
 doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE
 env =
     PYTHONHASHSEED=0
+junit_family=xunit2


### PR DESCRIPTION
Current [tests](https://circleci.com/gh/nipy/nipype/10565) emit this warning from pytest:

```
/opt/miniconda-latest/envs/neuro/lib/python3.6/site-packages/_pytest/junitxml.py:436

  /opt/miniconda-latest/envs/neuro/lib/python3.6/site-packages/_pytest/junitxml.py:436: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.

  Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.

    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)
```

In niworkflows, we were able to suppress it by making the included change. Selected the planned default value to embrace the future. If it fails, we can cling to the past.