### PR TITLE
Remove keyword argument to str.splitlines().

### DIFF
--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -31,7 +31,7 @@ def report_crash(node, traceback=None, hostname=None):
 
 When creating this crashfile, the results file corresponding
 to the node could not be found.""".splitlines(
-            keepends=True
+            True
         )
     except Exception as exc:
         traceback += """
@@ -40,7 +40,7 @@ During the creation of this crashfile triggered by the above exception,
 another exception occurred:\n\n{}.""".format(
             exc
         ).splitlines(
-            keepends=True
+            True
         )
     else:
         if getattr(result, "runtime", None):


### PR DESCRIPTION
Keyword arguments are not available for this function in python 2.7.x.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3113 

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Remove the `keepends` keyword, leaving the argument.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
