### PR TITLE
REL: 1.4.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -122,6 +122,7 @@ Michael Dayan <mdayan.research@gmail.com> <mdayan.comp@gmail.com>
 Michael Dayan <mdayan.research@gmail.com> mick-d <mid2021@CHUCK.(none)>
 Michael Dayan <mdayan.research@gmail.com> <michael@mail.example.com>
 Michael Joseph <josephmje.22@gmail.com>
+Michael Joseph <josephmje.22@gmail.com> <mjoseph@scclogin02.camhres.ca>
 Michael Philipp Notter <michaelnotter@hotmail.com>
 Michael Philipp Notter <michaelnotter@hotmail.com>
 Michael Waskom <michael.l.waskom@gmail.com> <mwaskom@mit.edu>
@@ -129,6 +130,7 @@ Michael Waskom <michael.l.waskom@gmail.com> <mwaskom@nyu.edu>
 Michael Waskom <michael.l.waskom@gmail.com> <mwaskom@stanford.edu>
 Miguel Molina-Romero <miguel.molina.romero@gmail.com>
 Murat Bilgel <bilgelm@gmail.com> <murat.bilgel@nih.gov>
+Nat Lee <vip3268@gmail.com>
 Oliver Contier <o.contier@gmail.com> <oliver.contier@ovgu.de>
 Olivia Stanley <oliviawstanley@gmail.com>
 Oscar Esteban <code@oscaresteban.es>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -757,6 +757,11 @@
     {
       "name": "Lee, Nat",
       "orcid": "0000-0001-9308-9988"
+    },
+    {
+      "affiliation": "NIMH, Scientific and Statistical Computing Core",
+      "name": "Glen, Daniel",
+      "orcid": "0000-0001-8456-5647"
     }
   ],
   "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,14 +11,7 @@
       "orcid": "0000-0002-6533-164X"
     },
     {
-      "affiliation": "MIT",
-      "name": "Jarecka, Dorota",
-      "orcid": "0000-0001-8282-2988"
-    },
-    {
-      "affiliation": "Independent",
-      "name": "Ziegler, Erik",
-      "orcid": "0000-0003-1857-8129"
+      "name": "Burns, Christopher"
     },
     {
       "affiliation": "University of Iowa",
@@ -26,12 +19,27 @@
       "orcid": "0000-0001-9513-2660"
     },
     {
-      "name": "Burns, Christopher"
+      "affiliation": "Independent",
+      "name": "Ziegler, Erik",
+      "orcid": "0000-0003-1857-8129"
     },
     {
       "affiliation": "Klinikum rechts der Isar, TUM. ACPySS",
       "name": "Manh\u00e3es-Savio, Alexandre",
       "orcid": "0000-0002-6608-6885"
+    },
+    {
+      "affiliation": "MIT",
+      "name": "Jarecka, Dorota",
+      "orcid": "0000-0001-8282-2988"
+    },
+    {
+      "affiliation": "The University of Iowa",
+      "name": "Ellis, David Gage",
+      "orcid": "0000-0002-3718-6836"
+    },
+    {
+      "name": "Yvernault, Benjamin"
     },
     {
       "name": "Hamalainen, Carlo",
@@ -43,17 +51,13 @@
       "orcid": "0000-0002-5866-047X"
     },
     {
-      "name": "Yvernault, Benjamin"
-    },
-    {
-      "affiliation": "The University of Iowa",
-      "name": "Ellis, David Gage",
-      "orcid": "0000-0002-3718-6836"
-    },
-    {
       "affiliation": "Florida International University",
       "name": "Salo, Taylor",
       "orcid": "0000-0001-9813-3167"
+    },
+    {
+      "affiliation": "Department of Psychology, Stanford University",
+      "name": "Waskom, Michael"
     },
     {
       "affiliation": "MIT",
@@ -66,12 +70,16 @@
       "orcid": "0000-0001-6313-0580"
     },
     {
-      "affiliation": "Department of Psychology, Stanford University",
-      "name": "Waskom, Michael"
-    },
-    {
       "affiliation": "Shattuck Lab, UCLA Brain Mapping Center",
       "name": "Wong, Jason"
+    },
+    {
+      "affiliation": "Department of Electrical and Computer Engineering, Johns Hopkins University",
+      "name": "Dewey, Blake E",
+      "orcid": "0000-0003-4554-5058"
+    },
+    {
+      "name": "Madison, Cindee"
     },
     {
       "affiliation": "Developer",
@@ -82,9 +90,9 @@
       "name": "Loney, Fred"
     },
     {
-      "affiliation": "Department of Electrical and Computer Engineering, Johns Hopkins University",
-      "name": "Dewey, Blake E",
-      "orcid": "0000-0003-4554-5058"
+      "affiliation": "UC Berkeley",
+      "name": "Clark, Dav",
+      "orcid": "0000-0002-3982-4416"
     },
     {
       "affiliation": "National Institute of Mental Health",
@@ -92,23 +100,14 @@
       "orcid": "0000-0003-4613-6643"
     },
     {
-      "name": "Madison, Cindee"
+      "affiliation": "UC Berkeley - UCSF Graduate Program in Bioengineering",
+      "name": "Keshavan, Anisha",
+      "orcid": "0000-0003-3554-043X"
     },
     {
-      "affiliation": "Molecular Imaging Research Center, CEA, France",
-      "name": "Bougacha, Salma"
-    },
-    {
-      "affiliation": "Stanford University",
-      "name": "\u0106iri\u0107 , Rastko",
-      "orcid": "0000-0001-6347-7939"
-    },
-    {
-      "affiliation": "National Institutes of Health",
-      "name": "Clark, Michael G. "
-    },
-    {
-      "name": "Modat, Marc"
+      "affiliation": "The Centre for Addiction and Mental Health",
+      "name": "Joseph, Michael",
+      "orcid": "0000-0002-0068-230X"
     },
     {
       "affiliation": "Mayo Clinic, Neurology, Rochester, MN, USA",
@@ -116,14 +115,16 @@
       "orcid": "0000-0002-2666-0969"
     },
     {
-      "affiliation": "UC Berkeley",
-      "name": "Clark, Dav",
-      "orcid": "0000-0002-3982-4416"
+      "name": "Modat, Marc"
     },
     {
-      "affiliation": "UC Berkeley - UCSF Graduate Program in Bioengineering",
-      "name": "Keshavan, Anisha",
-      "orcid": "0000-0003-3554-043X"
+      "affiliation": "Molecular Imaging Research Center, CEA, France",
+      "name": "Bougacha, Salma"
+    },
+    {
+      "affiliation": "CNRS LTCI, Telecom ParisTech, Universit\u00e9 Paris-Saclay",
+      "name": "Gramfort, Alexandre",
+      "orcid": "0000-0001-9791-4404"
     },
     {
       "affiliation": "Dartmouth College",
@@ -134,18 +135,7 @@
       "name": "Pinsard, Basile"
     },
     {
-      "affiliation": "CNRS LTCI, Telecom ParisTech, Universit\u00e9 Paris-Saclay",
-      "name": "Gramfort, Alexandre",
-      "orcid": "0000-0001-9791-4404"
-    },
-    {
-      "affiliation": "Concordia University",
-      "name": "Benderoff, Erin"
-    },
-    {
-      "affiliation": "Dartmouth College: Hanover, NH, United States",
-      "name": "Halchenko, Yaroslav O.",
-      "orcid": "0000-0003-3456-2493"
+      "name": "Berleant, Shoshana"
     },
     {
       "affiliation": "Institute for Biomedical Engineering, ETH and University of Zurich",
@@ -153,36 +143,14 @@
       "orcid": "0000-0001-7037-2449"
     },
     {
-      "name": "Berleant, Shoshana"
-    },
-    {
-      "affiliation": "The Centre for Addiction and Mental Health",
-      "name": "Joseph, Michael",
-      "orcid": "0000-0002-0068-230X"
-    },
-    {
-      "affiliation": "ARAMIS LAB, Brain and Spine Institute (ICM), Paris, France.",
-      "name": "Guillon, Je\u0301re\u0301my",
-      "orcid": "0000-0002-2672-7510"
-    },
-    {
       "affiliation": "The University of Washington eScience Institute",
       "name": "Rokem, Ariel",
       "orcid": "0000-0003-0679-1985"
     },
     {
-      "affiliation": "Indiana University, IN, USA",
-      "name": "Koudoro, Serge"
-    },
-    {
-      "affiliation": "Montreal Neurological Institute and Hospital",
-      "name": "Markello, Ross",
-      "orcid": "0000-0003-1057-1336"
-    },
-    {
-      "affiliation": "Montreal Neurological Institute and Hospital",
-      "name": "DuPre, Elizabeth",
-      "orcid": "0000-0003-1358-196X"
+      "affiliation": "Dartmouth College: Hanover, NH, United States",
+      "name": "Halchenko, Yaroslav O.",
+      "orcid": "0000-0003-3456-2493"
     },
     {
       "affiliation": "MIT",
@@ -190,12 +158,13 @@
       "orcid": "0000-0002-5544-7577"
     },
     {
-      "name": "Moloney, Brendan"
+      "affiliation": "Concordia University",
+      "name": "Benderoff, Erin"
     },
     {
-      "affiliation": "UC San Diego",
-      "name": "Cipollini, Ben",
-      "orcid": "0000-0002-7782-0790"
+      "affiliation": "Stanford University",
+      "name": "\u0106iri\u0107 , Rastko",
+      "orcid": "0000-0001-6347-7939"
     },
     {
       "affiliation": "INRIA",
@@ -203,9 +172,43 @@
       "orcid": "0000-0003-1076-5122"
     },
     {
+      "name": "Moloney, Brendan"
+    },
+    {
+      "affiliation": "Montreal Neurological Institute and Hospital",
+      "name": "DuPre, Elizabeth",
+      "orcid": "0000-0003-1358-196X"
+    },
+    {
+      "affiliation": "Indiana University, IN, USA",
+      "name": "Koudoro, Serge"
+    },
+    {
+      "affiliation": "National Institutes of Health",
+      "name": "Clark, Michael G. "
+    },
+    {
       "affiliation": "Athena EPI, Inria Sophia-Antipolis",
       "name": "Wassermann, Demian",
       "orcid": "0000-0001-5194-6056"
+    },
+    {
+      "affiliation": "UC San Diego",
+      "name": "Cipollini, Ben",
+      "orcid": "0000-0002-7782-0790"
+    },
+    {
+      "affiliation": "ARAMIS LAB, Brain and Spine Institute (ICM), Paris, France.",
+      "name": "Guillon, Je\u0301re\u0301my",
+      "orcid": "0000-0002-2672-7510"
+    },
+    {
+      "affiliation": "Montreal Neurological Institute and Hospital",
+      "name": "Markello, Ross",
+      "orcid": "0000-0003-1057-1336"
+    },
+    {
+      "name": "Buchanan, Colin"
     },
     {
       "affiliation": "Otto-von-Guericke-University Magdeburg, Germany",
@@ -213,12 +216,11 @@
       "orcid": "0000-0001-6398-6370"
     },
     {
-      "affiliation": "Vrije Universiteit, Amsterdam",
-      "name": "de Hollander, Gilles",
-      "orcid": "0000-0003-1988-5091"
+      "name": "Tungaraza, Rosalia"
     },
     {
-      "name": "Mordom, David"
+      "affiliation": "Nathan s Kline institute for psychiatric research",
+      "name": "Sikka, Sharad"
     },
     {
       "affiliation": "Australian eHealth Research Centre, Commonwealth Scientific and Industrial Research Organisation; University of Queensland",
@@ -226,32 +228,17 @@
       "orcid": "0000-0001-9130-1092"
     },
     {
-      "name": "Buchanan, Colin"
-    },
-    {
-      "affiliation": "Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany.",
-      "name": "Tabas, Alejandro",
-      "orcid": "0000-0002-8643-1543"
-    },
-    {
-      "name": "Tungaraza, Rosalia"
-    },
-    {
       "affiliation": "California Institute of Technology",
       "name": "Pauli, Wolfgang M.",
       "orcid": "0000-0002-0966-0254"
     },
     {
-      "affiliation": "Nathan s Kline institute for psychiatric research",
-      "name": "Sikka, Sharad"
+      "affiliation": "Vrije Universiteit, Amsterdam",
+      "name": "de Hollander, Gilles",
+      "orcid": "0000-0003-1988-5091"
     },
     {
       "name": "Forbes, Jessica"
-    },
-    {
-      "affiliation": "University College London",
-      "name": "Mancini, Matteo",
-      "orcid": "0000-0001-7194-4568"
     },
     {
       "affiliation": "Duke University",
@@ -259,12 +246,12 @@
       "orcid": "0000-0003-2766-8425"
     },
     {
-      "name": "Schwartz, Yannick"
+      "name": "Mordom, David"
     },
     {
-      "affiliation": "University of Washington",
-      "name": "Richie-Halford, Adam",
-      "orcid": "0000-0001-9276-9084"
+      "affiliation": "University College London",
+      "name": "Mancini, Matteo",
+      "orcid": "0000-0001-7194-4568"
     },
     {
       "affiliation": "University College London",
@@ -275,33 +262,33 @@
       "name": "Dubois, Mathieu"
     },
     {
-      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
-      "name": "Tilley II, Steven",
-      "orcid": "0000-0003-4853-5082"
+      "name": "Schwartz, Yannick"
     },
     {
       "affiliation": "Child Mind Institute",
       "name": "Frohlich, Caroline"
     },
     {
+      "affiliation": "Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany.",
+      "name": "Tabas, Alejandro",
+      "orcid": "0000-0002-8643-1543"
+    },
+    {
       "affiliation": "University of Iowa",
       "name": "Welch, David"
     },
     {
-      "affiliation": "Florida International University",
-      "name": "Bottenhorn, Katherine",
-      "orcid": "0000-0002-7796-8795"
+      "affiliation": "University of Washington",
+      "name": "Richie-Halford, Adam",
+      "orcid": "0000-0001-9276-9084"
+    },
+    {
+      "affiliation": "Holland Bloorview Kids Rehabilitation Hospital",
+      "name": "Tilley II, Steven",
+      "orcid": "0000-0003-4853-5082"
     },
     {
       "name": "Watanabe, Aimi"
-    },
-    {
-      "affiliation": "Research Group Neuroanatomy and Connectivity, Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany",
-      "name": "Huntenburg, Julia M.",
-      "orcid": "0000-0003-0579-9811"
-    },
-    {
-      "name": "Cumba, Chad"
     },
     {
       "affiliation": "SRI International",
@@ -309,9 +296,9 @@
       "orcid": "0000-0003-1099-3328"
     },
     {
-      "affiliation": "University of Texas at Austin",
-      "name": "De La Vega, Alejandro",
-      "orcid": "0000-0001-9062-3778"
+      "affiliation": "Research Group Neuroanatomy and Connectivity, Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany",
+      "name": "Huntenburg, Julia M.",
+      "orcid": "0000-0003-0579-9811"
     },
     {
       "affiliation": "University College London",
@@ -319,21 +306,20 @@
       "orcid": "0000-0002-6652-3512"
     },
     {
-      "name": "Ginsburg, Daniel"
-    },
-    {
       "affiliation": "National University Singapore",
       "name": "Schaefer, Alexander",
       "orcid": "0000-0001-6488-4739"
     },
     {
-      "affiliation": "Harvard University - Psychology",
-      "name": "Kastman, Erik",
-      "orcid": "0000-0001-7221-9042"
+      "name": "Ginsburg, Daniel"
     },
     {
-      "name": "Heinsfeld, Anibal S\u00f3lon",
-      "orcid": "0000-0002-2050-0614"
+      "affiliation": "Florida International University",
+      "name": "Bottenhorn, Katherine",
+      "orcid": "0000-0002-7796-8795"
+    },
+    {
+      "name": "Cumba, Chad"
     },
     {
       "affiliation": "Washington University in St Louis",
@@ -341,9 +327,13 @@
       "orcid": "0000-0001-6392-6634"
     },
     {
-      "affiliation": "University of Zurich",
-      "name": "Liem, Franz",
-      "orcid": "0000-0003-0646-4810"
+      "name": "Heinsfeld, Anibal S\u00f3lon",
+      "orcid": "0000-0002-2050-0614"
+    },
+    {
+      "affiliation": "Harvard University - Psychology",
+      "name": "Kastman, Erik",
+      "orcid": "0000-0001-7221-9042"
     },
     {
       "name": "Kent, James"
@@ -353,11 +343,6 @@
       "name": "Kleesiek, Jens"
     },
     {
-      "affiliation": "NIMH IRP",
-      "name": "Lee, John A.",
-      "orcid": "0000-0001-5884-4247"
-    },
-    {
       "name": "Erickson, Drew"
     },
     {
@@ -365,13 +350,23 @@
       "name": "Giavasis, Steven"
     },
     {
-      "name": "Correa, Carlos"
-    },
-    {
       "name": "Ghayoor, Ali"
     },
     {
+      "affiliation": "University of Zurich",
+      "name": "Liem, Franz",
+      "orcid": "0000-0003-0646-4810"
+    },
+    {
+      "affiliation": "University of Texas at Austin",
+      "name": "De La Vega, Alejandro",
+      "orcid": "0000-0001-9062-3778"
+    },
+    {
       "name": "K\u00fcttner, Ren\u00e9"
+    },
+    {
+      "name": "Millman, Jarrod"
     },
     {
       "affiliation": "Neurospin/Unicog/Inserm/CEA",
@@ -379,43 +374,30 @@
       "orcid": "0000-0003-4497-861X"
     },
     {
-      "name": "Millman, Jarrod"
+      "affiliation": "NIMH IRP",
+      "name": "Lee, John A.",
+      "orcid": "0000-0001-5884-4247"
     },
     {
       "name": "Zhou, Dale"
     },
     {
-      "name": "Blair, Ross"
+      "name": "Haselgrove, Christian"
     },
     {
-      "name": "Haselgrove, Christian"
+      "affiliation": "NIMH, Scientific and Statistical Computing Core",
+      "name": "Glen, Daniel",
+      "orcid": "0000-0001-8456-5647"
     },
     {
       "name": "Renfro, Mandy"
     },
     {
+      "name": "Correa, Carlos"
+    },
+    {
       "affiliation": "The University of Sydney",
       "name": "Liu, Siqi"
-    },
-    {
-      "affiliation": "University of Pennsylvania",
-      "name": "Kahn, Ari E.",
-      "orcid": "0000-0002-2127-0507"
-    },
-    {
-      "affiliation": "Korea Advanced Institute of Science and Technology",
-      "name": "Kim, Sin",
-      "orcid": "0000-0003-4652-3758"
-    },
-    {
-      "affiliation": "University College London",
-      "name": "P\u00e9rez-Garc\u00eda, Fernando",
-      "orcid": "0000-0001-9090-3024"
-    },
-    {
-      "affiliation": "Department of Psychology, Stanford University",
-      "name": "Triplett, William",
-      "orcid": "0000-0002-9546-1306"
     },
     {
       "affiliation": "MPI CBS Leipzig, Germany",
@@ -430,29 +412,19 @@
       "name": "Hallquist, Michael"
     },
     {
-      "affiliation": "Yale University; New Haven, CT, United States",
-      "name": "Sisk, Lucinda M.",
-      "orcid": "0000-0003-4900-9770"
+      "affiliation": "University of Pennsylvania",
+      "name": "Kahn, Ari E.",
+      "orcid": "0000-0002-2127-0507"
     },
     {
-      "affiliation": "Donders Institute for Brain, Cognition and Behavior, Center for Cognitive Neuroimaging",
-      "name": "Chetverikov, Andrey",
-      "orcid": "0000-0003-2767-6310"
+      "affiliation": "1 McGill Centre for Integrative Neuroscience (MCIN), Ludmer Centre for Neuroinformatics and Mental Health, Montreal Neurological Institute (MNI), McGill University, Montr\u00e9al, 3801 University Street, WB-208, H3A 2B4, Qu\u00e9bec, Canada. 2 University of Lyon, CNRS, INSERM, CREATIS., Villeurbanne, 7, avenue Jean Capelle, 69621, France.",
+      "name": "Glatard, Tristan",
+      "orcid": "0000-0003-2620-5883"
     },
     {
-      "affiliation": "GIGA Institute",
-      "name": "Grignard, Martin",
-      "orcid": "0000-0001-5549-1861"
-    },
-    {
-      "affiliation": "Dartmouth College",
-      "name": "Ma, Feilong",
-      "orcid": "0000-0002-6838-3971"
-    },
-    {
-      "affiliation": "Department of Neuropsychiatry, University of Pennsylvania",
-      "name": "Cieslak, Matthew",
-      "orcid": "0000-0002-1931-4734"
+      "affiliation": "Department of Psychology, Stanford University",
+      "name": "Triplett, William",
+      "orcid": "0000-0002-9546-1306"
     },
     {
       "affiliation": "INRIA-Saclay, Team Parietal",
@@ -463,15 +435,17 @@
       "name": "Salvatore, John"
     },
     {
+      "affiliation": "University College London",
+      "name": "P\u00e9rez-Garc\u00eda, Fernando",
+      "orcid": "0000-0001-9090-3024"
+    },
+    {
+      "affiliation": "Dartmouth College",
+      "name": "Ma, Feilong",
+      "orcid": "0000-0002-6838-3971"
+    },
+    {
       "name": "Park, Anne"
-    },
-    {
-      "affiliation": "1 McGill Centre for Integrative Neuroscience (MCIN), Ludmer Centre for Neuroinformatics and Mental Health, Montreal Neurological Institute (MNI), McGill University, Montr\u00e9al, 3801 University Street, WB-208, H3A 2B4, Qu\u00e9bec, Canada. 2 University of Lyon, CNRS, INSERM, CREATIS., Villeurbanne, 7, avenue Jean Capelle, 69621, France.",
-      "name": "Glatard, Tristan",
-      "orcid": "0000-0003-2620-5883"
-    },
-    {
-      "name": "Poldrack, Russell"
     },
     {
       "affiliation": "Child Mind Institute",
@@ -482,30 +456,34 @@
       "name": "Hinds, Oliver"
     },
     {
-      "affiliation": "TIB \u2013 Leibniz Information Centre for Science and Technology and University Library, Hannover, Germany",
-      "name": "Leinweber, Katrin",
-      "orcid": "0000-0001-5135-5758"
-    },
-    {
-      "name": "Inati, Souheil"
+      "name": "Poldrack, Russell"
     },
     {
       "affiliation": "Boston University",
       "name": "Perkins, L. Nathan"
     },
     {
-      "affiliation": "University of Newcastle, Australia",
-      "name": "Cooper, Gavin",
-      "orcid": "0000-0002-7186-5293"
+      "affiliation": "Korea Advanced Institute of Science and Technology",
+      "name": "Kim, Sin",
+      "orcid": "0000-0003-4652-3758"
     },
     {
-      "name": "Mattfeld, Aaron"
+      "affiliation": "Donders Institute for Brain, Cognition and Behavior, Center for Cognitive Neuroimaging",
+      "name": "Chetverikov, Andrey",
+      "orcid": "0000-0003-2767-6310"
     },
     {
-      "name": "Matsubara, K"
+      "name": "Inati, Souheil"
     },
     {
-      "name": "Noel, Maxime"
+      "affiliation": "Department of Neuropsychiatry, University of Pennsylvania",
+      "name": "Cieslak, Matthew",
+      "orcid": "0000-0002-1931-4734"
+    },
+    {
+      "affiliation": "GIGA Institute",
+      "name": "Grignard, Martin",
+      "orcid": "0000-0001-5549-1861"
     },
     {
       "affiliation": "University of Amsterdam",
@@ -513,8 +491,14 @@
       "orcid": "0000-0001-8972-204X"
     },
     {
-      "affiliation": "Institute of Imaging & Computer Vision, RWTH Aachen University, Germany",
-      "name": "Weninger, Leon"
+      "affiliation": "Yale University; New Haven, CT, United States",
+      "name": "Sisk, Lucinda M.",
+      "orcid": "0000-0003-4900-9770"
+    },
+    {
+      "affiliation": "TIB \u2013 Leibniz Information Centre for Science and Technology and University Library, Hannover, Germany",
+      "name": "Leinweber, Katrin",
+      "orcid": "0000-0001-5135-5758"
     },
     {
       "affiliation": "University of Pennsylvania",
@@ -522,14 +506,50 @@
       "orcid": "0000-0003-2077-3070"
     },
     {
-      "name": "Cheung, Brian"
+      "name": "Matsubara, K"
     },
     {
       "name": "Urchs, Sebastian"
     },
     {
-      "affiliation": "Dept of Medical Biophysics, Univeristy of Western Ontario",
-      "name": "Stanley, Olivia"
+      "name": "Blair, Ross"
+    },
+    {
+      "affiliation": "The University of Texas at Austin",
+      "name": "Floren, Andrew",
+      "orcid": "0000-0003-3618-2056"
+    },
+    {
+      "name": "Mattfeld, Aaron"
+    },
+    {
+      "affiliation": "Institute of Neuroinformatics, ETH/University of Zurich",
+      "name": "Gerhard, Stephan",
+      "orcid": "0000-0003-4454-6171"
+    },
+    {
+      "affiliation": "University of Newcastle, Australia",
+      "name": "Cooper, Gavin",
+      "orcid": "0000-0002-7186-5293"
+    },
+    {
+      "name": "Haehn, Daniel"
+    },
+    {
+      "name": "Tambini, Arielle"
+    },
+    {
+      "affiliation": "Duke University",
+      "name": "Broderick, William",
+      "orcid": "0000-0002-8999-9003"
+    },
+    {
+      "affiliation": "University of Helsinki",
+      "name": "Andberg, Sami Kristian",
+      "orcid": "0000-0002-5650-3964"
+    },
+    {
+      "name": "Noel, Maxime"
     },
     {
       "affiliation": "Department of Psychology, Stanford University; Parietal, INRIA",
@@ -547,72 +567,35 @@
       "orcid": "0000-0002-9533-3769"
     },
     {
-      "affiliation": "Technische Universit\u00e4t Dresden, Faculty of Medicine, Department of Child and Adolescent Psychiatry",
-      "name": "Geisler, Daniel",
-      "orcid": "0000-0003-2076-5329"
-    },
-    {
-      "affiliation": "The University of Texas at Austin",
-      "name": "Floren, Andrew",
-      "orcid": "0000-0003-3618-2056"
-    },
-    {
-      "affiliation": "Institute of Neuroinformatics, ETH/University of Zurich",
-      "name": "Gerhard, Stephan",
-      "orcid": "0000-0003-4454-6171"
-    },
-    {
-      "affiliation": "Technical University Munich",
-      "name": "Molina-Romero, Miguel",
-      "orcid": "0000-0001-8054-0426"
-    },
-    {
-      "name": "Haehn, Daniel"
-    },
-    {
-      "name": "Weinstein, Alejandro"
-    },
-    {
-      "name": "Tambini, Arielle"
-    },
-    {
-      "affiliation": "Duke University",
-      "name": "Broderick, William",
-      "orcid": "0000-0002-8999-9003"
-    },
-    {
-      "name": "Rothmei, Simon"
-    },
-    {
-      "affiliation": "University of Helsinki",
-      "name": "Andberg, Sami Kristian",
-      "orcid": "0000-0002-5650-3964"
-    },
-    {
-      "name": "Khanuja, Ranjeet"
-    },
-    {
-      "affiliation": "National Institute on Aging, Baltimore, MD, USA",
-      "name": "Bilgel, Murat",
-      "orcid": "0000-0001-5042-7422"
-    },
-    {
-      "name": "Schlamp, Kai"
-    },
-    {
       "affiliation": "CEA",
       "name": "Papadopoulos Orfanos, Dimitri",
       "orcid": "0000-0002-1242-8990"
     },
     {
-      "name": "Tarbert, Claire"
+      "affiliation": "Technische Universit\u00e4t Dresden, Faculty of Medicine, Department of Child and Adolescent Psychiatry",
+      "name": "Geisler, Daniel",
+      "orcid": "0000-0003-2076-5329"
+    },
+    {
+      "name": "Weinstein, Alejandro"
     },
     {
       "name": "Harms, Robbert"
     },
     {
+      "name": "Khanuja, Ranjeet"
+    },
+    {
       "affiliation": "University of Illinois Urbana Champaign",
       "name": "Sharp, Paul"
+    },
+    {
+      "affiliation": "Dept of Medical Biophysics, Univeristy of Western Ontario",
+      "name": "Stanley, Olivia"
+    },
+    {
+      "name": "Lee, Nat",
+      "orcid": "0000-0001-9308-9988"
     },
     {
       "name": "Crusoe, Michael R.",
@@ -641,16 +624,13 @@
       "orcid": "0000-0001-9800-4816"
     },
     {
-      "affiliation": "Vrije Universiteit Amsterdam",
-      "name": "Ort, Eduard"
-    },
-    {
       "name": "Shachnev, Dmitry"
     },
     {
-      "affiliation": "University of Cambridge",
-      "name": "McNamee, Daniel",
-      "orcid": "0000-0001-9928-4960"
+      "name": "Tarbert, Claire"
+    },
+    {
+      "name": "Cheung, Brian"
     },
     {
       "affiliation": "University of Pittsburgh",
@@ -664,6 +644,35 @@
     },
     {
       "name": "Davison, Andrew"
+    },
+    {
+      "affiliation": "Institute of Imaging & Computer Vision, RWTH Aachen University, Germany",
+      "name": "Weninger, Leon"
+    },
+    {
+      "affiliation": "Technical University Munich",
+      "name": "Molina-Romero, Miguel",
+      "orcid": "0000-0001-8054-0426"
+    },
+    {
+      "name": "Rothmei, Simon"
+    },
+    {
+      "affiliation": "National Institute on Aging, Baltimore, MD, USA",
+      "name": "Bilgel, Murat",
+      "orcid": "0000-0001-5042-7422"
+    },
+    {
+      "name": "Schlamp, Kai"
+    },
+    {
+      "affiliation": "Vrije Universiteit Amsterdam",
+      "name": "Ort, Eduard"
+    },
+    {
+      "affiliation": "University of Cambridge",
+      "name": "McNamee, Daniel",
+      "orcid": "0000-0001-9928-4960"
     },
     {
       "name": "Lai, Jeff"
@@ -753,15 +762,6 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    },
-    {
-      "name": "Lee, Nat",
-      "orcid": "0000-0001-9308-9988"
-    },
-    {
-      "affiliation": "NIMH, Scientific and Statistical Computing Core",
-      "name": "Glen, Daniel",
-      "orcid": "0000-0001-8456-5647"
     }
   ],
   "keywords": [

--- a/doc/changelog/1.X.X-changelog
+++ b/doc/changelog/1.X.X-changelog
@@ -1,3 +1,22 @@
+1.4.0 (December 20, 2019)
+=========================
+
+##### [Full changelog](https://github.com/nipy/nipype/milestone/37?closed=1)
+
+  * FIX: Mark strings containing regex escapes as raw (https://github.com/nipy/nipype/pull/3106)
+  * ENH: Pacify DeprecationWarnings caused by nibabel 3 pre-release (https://github.com/nipy/nipype/pull/3099)
+  * ENH: Allow Nipype configuration directory to be specified with NIPYPE_CONFIG_DIR environment variable (https://github.com/nipy/nipype/pull/3073)
+  * ENH: Add options and outputs to ``fsl.Eddy`` interface (https://github.com/nipy/nipype/pull/3034)
+  * ENH: Add skull_file output to fsl.BET interface (https://github.com/nipy/nipype/pull/3095)
+  * RF: Drop various remaining compatibilities for Python < 3.5 (https://github.com/nipy/nipype/pull/2831)
+  * DOC: Add Python 2 statement to README, reference maintenance branch in CONTRIBUTING (https://github.com/nipy/nipype/pull/3115)
+  * DOC: Miss underline before cmd in example code (https://github.com/nipy/nipype/pull/3107)
+  * STY: Black (https://github.com/nipy/nipype/pull/3096)
+  * MNT: Set junit_family to suppress pytest warning (https://github.com/nipy/nipype/pull/3111)
+  * MNT: Fix Dorota Jarecka ORCID (https://github.com/nipy/nipype/pull/3100)
+  * MNT: Drop Python 2 support (https://github.com/nipy/nipype/pull/2654)
+
+
 1.3.1 (November 12, 2019)
 =========================
 

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -160,14 +160,7 @@ REQUIRES = [
 # https://github.com/nipy/nipype/pull/2961#issuecomment-512035484
 REQUIRES += ["neurdflib"]
 
-TESTS_REQUIRES = [
-    "codecov",
-    "coverage<5",
-    "mock",
-    "pytest",
-    "pytest-cov",
-    "pytest-env",
-]
+TESTS_REQUIRES = ["codecov", "coverage<5", "mock", "pytest", "pytest-cov", "pytest-env"]
 
 EXTRA_REQUIRES = {
     "data": ["datalad"],

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -5,7 +5,7 @@ docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 
 # nipype version information
 # Remove -dev for release
-__version__ = "1.4.0-dev"
+__version__ = "1.4.0"
 
 
 def get_nipype_gitversion():

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -135,7 +135,6 @@ VERSION = __version__
 PROVIDES = ["nipype"]
 REQUIRES = [
     "click>=%s" % CLICK_MIN_VERSION,
-    "funcsigs",
     "networkx>=%s" % NETWORKX_MIN_VERSION,
     "nibabel>=%s" % NIBABEL_MIN_VERSION,
     'numpy>=%s ; python_version < "3.7"' % NUMPY_MIN_VERSION,

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -100,14 +100,11 @@ existing pipeline systems.
 # versions
 NIBABEL_MIN_VERSION = "2.1.0"
 NETWORKX_MIN_VERSION = "1.9"
-NETWORKX_MAX_VERSION_27 = "2.2"
 NUMPY_MIN_VERSION = "1.12"
 # Numpy bug in python 3.7:
 # https://www.opensourceanswers.com/blog/you-shouldnt-use-python-37-for-data-science-right-now.html
 NUMPY_MIN_VERSION_37 = "1.15.3"
 SCIPY_MIN_VERSION = "0.14"
-# Scipy drops 2.7 and 3.4 support in 1.3
-SCIPY_MAX_VERSION_34 = "1.3.0"
 TRAITS_MIN_VERSION = "4.6"
 DATEUTIL_MIN_VERSION = "2.2"
 FUTURE_MIN_VERSION = "0.16.0"

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -139,7 +139,6 @@ PROVIDES = ["nipype"]
 REQUIRES = [
     "click>=%s" % CLICK_MIN_VERSION,
     "funcsigs",
-    "future>=%s" % FUTURE_MIN_VERSION,
     "networkx>=%s" % NETWORKX_MIN_VERSION,
     "nibabel>=%s" % NIBABEL_MIN_VERSION,
     'numpy>=%s ; python_version < "3.7"' % NUMPY_MIN_VERSION,

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ nibabel denoted by ## START - COPIED FROM NIBABEL and a corresponding ## END
 
 """
 # Build helper
-import sys
-from glob import glob
 import os
 from os.path import join as pjoin
 
@@ -115,9 +113,6 @@ def main():
     with open(ver_file) as infofile:
         exec(infofile.read(), globals(), ldict)
 
-    SETUP_REQUIRES = ["future"]
-    if sys.version_info <= (3, 4):
-        SETUP_REQUIRES.append("configparser")
     setup(
         name=ldict["NAME"],
         maintainer=ldict["MAINTAINER"],
@@ -134,7 +129,6 @@ def main():
         version=ldict["VERSION"],
         python_requires=ldict["PYTHON_REQUIRES"],
         install_requires=ldict["REQUIRES"],
-        setup_requires=SETUP_REQUIRES,
         provides=ldict["PROVIDES"],
         packages=find_packages(),
         package_data={"nipype": testdatafiles},


### PR DESCRIPTION
## Summary

Prep for 1.4.0, for immediate release, pending completion.

Open question: Should we move from `git-line-summary` to `git shortlog` for determining .zenodo ordering? With #3096, the line summary became:

```
$ head -n 13 line-contributors.txt

 project  : nipype
 lines    :   298318
 authors  :
 109691 Oscar Esteban                       36.8%
 67391 Christopher J. Markiewicz            22.6%
 53863 Satrajit Ghosh                       18.1%
 10441 Krzysztof J. Gorgolewski             3.5%
 3841 Christopher Burns                     1.3%
 3836 Hans Johnson                          1.3%
 3828 Erik Ziegler                          1.3%
 3650 Alexandre M. Savio                    1.2%
 3458 Dorota Jarecka                        1.2%
```

Shortlog:

```
$ git shortlog -ns | head   
  3308	Satrajit Ghosh
  1968	Krzysztof J. Gorgolewski
  1810	Oscar Esteban
  1063	Christopher J. Markiewicz
   464	Christopher Burns
   383	Mathias Goncalves
   248	Dorota Jarecka
   247	Erik Ziegler
   235	Shoshana Berleant
   202	David Ellis
```

## Release checklist

* [x] Merge pending PRs
  * [x] #3099
  * [x] #3115
* [x] Update changelog
* [x] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py` and `doc/conf.py`
* [x] Update `doc/documentation.rst` with previous releases
* [x] Check conda-forge feedstock build (conda-forge/nipype-feedstock#61)
* [x] Tutorial tests (https://circleci.com/workflow-run/34220e20-d2cd-4bc8-b45f-c83aa0a603e1)

## Uncredited authors

The following authors have contributed, but not added themselves to the [`.zenodo.json`](https://github.com/nipy/nipype/blob/master/.zenodo.json) file. If you would like to be an author on Zenodo releases, please add yourself or comment with your preferred publication name, affiliation and [ORCID](https://orcid.org/). If you would like to stop being spammed whenever I'm the one doing releases, let me know, and I'll add you to a blacklist.

No entry to sort: Gio Piantoni (@gpiantoni)
No entry to sort: Isaiah Norton (@ihnorton)
No entry to sort: Niklas Förster (@niklasfoe)
No entry to sort: Kirstie Whitaker (@KirstieJane)
No entry to sort: hstojic (@hstojic)
No entry to sort: Jonathan R. Williford (@williford)
No entry to sort: Abel González (@abelalez)
No entry to sort: Victor Férat (@vferat)
No entry to sort: Kevin Sitek (@sitek)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.