### PR TITLE
[FIX] change ANTS number_of_time_steps from Float to Int

### DIFF
--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -87,7 +87,7 @@ class ANTSInputSpec(ANTSCommandInputSpec):
         desc="",
     )
     gradient_step_length = traits.Float(requires=["transformation_model"], desc="")
-    number_of_time_steps = traits.Float(requires=["gradient_step_length"], desc="")
+    number_of_time_steps = traits.Int(requires=["gradient_step_length"], desc="")
     delta_time = traits.Float(requires=["number_of_time_steps"], desc="")
     symmetry_type = traits.Float(requires=["delta_time"], desc="")
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3117  .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Change the trait type for ANTS number_of_time_steps from traits.Float to traits.Int
## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
