### PR TITLE
FIX fsl CopyGeom caching bug

### DIFF
--- a/nipype/interfaces/fsl/tests/test_auto_CopyGeom.py
+++ b/nipype/interfaces/fsl/tests/test_auto_CopyGeom.py
@@ -7,7 +7,6 @@ def test_CopyGeom_inputs():
         args=dict(argstr="%s",),
         dest_file=dict(
             argstr="%s",
-            copyfile=True,
             extensions=None,
             mandatory=True,
             name_source="dest_file",

--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -40,11 +40,9 @@ class CopyGeomInputSpec(FSLCommandInputSpec):
         argstr="%s",
         position=1,
         desc="destination image",
-        copyfile=True,
-        output_name="out_file",
-        name_source="dest_file",
-        name_template="%s",
-    )
+        output_name='out_file',
+        name_source='dest_file',
+        name_template='%s')
     ignore_dims = traits.Bool(
         desc="Do not copy image dimensions", argstr="-d", position="-1"
     )


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3136.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
remove ```copyfile=True``` to execute fslcpgeom on the destination file when caching
## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
