### PR TITLE
fix: lack of result file raises internal error. closes #3088

### DIFF
--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -67,9 +67,12 @@ def run_node(node, updatehash, taskid):
         result["result"] = node.run(updatehash=updatehash)
     except:  # noqa: E722, intendedly catch all here
         result["traceback"] = format_exception(*sys.exc_info())
-        result["result"] = node.result
+        try:
+            result["result"] = node.result
+        except FileNotFoundError:
+            result["result"] = None
 
-    # Return the result dictionary
+            # Return the result dictionary
     return result
 
 


### PR DESCRIPTION
## Summary

Fixes #3088 .

## List of changes proposed in this PR (pull-request)
trap and return None when result file does not exist after a node exception in multiproc.

## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
