### PR TITLE
fix: mapnode to generate result file when crashes in single node mode

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -155,7 +155,15 @@ REQUIRES = [
 # https://github.com/nipy/nipype/pull/2961#issuecomment-512035484
 REQUIRES += ["neurdflib"]
 
-TESTS_REQUIRES = ["codecov", "coverage<5", "mock", "pytest", "pytest-cov", "pytest-env"]
+TESTS_REQUIRES = [
+    "codecov",
+    "coverage<5",
+    "mock",
+    "pytest",
+    "pytest-cov",
+    "pytest-env",
+    "pytest-timeout",
+]
 
 EXTRA_REQUIRES = {
     "data": ["datalad"],

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -1366,13 +1366,39 @@ class MapNode(Node):
         nodenames = [nnametpl.format(i) for i in range(nitems)]
 
         # Run mapnode
-        result = self._collate_results(
-            _node_runner(
-                self._make_nodes(cwd),
-                updatehash=updatehash,
-                stop_first=str2bool(self.config["execution"]["stop_on_first_crash"]),
-            )
+        outdir = self.output_dir()
+        result = InterfaceResult(
+            interface=self._interface.__class__,
+            runtime=Bunch(
+                cwd=outdir,
+                returncode=1,
+                environ=dict(os.environ),
+                hostname=socket.gethostname(),
+            ),
+            inputs=self._interface.inputs.get_traitsfree(),
         )
+        try:
+            result = self._collate_results(
+                _node_runner(
+                    self._make_nodes(cwd),
+                    updatehash=updatehash,
+                    stop_first=str2bool(
+                        self.config["execution"]["stop_on_first_crash"]
+                    ),
+                )
+            )
+        except Exception as msg:
+            result.runtime.stderr = "%s\n\n%s".format(
+                getattr(result.runtime, "stderr", ""), msg
+            )
+            _save_resultfile(
+                result,
+                outdir,
+                self.name,
+                rebase=str2bool(self.config["execution"]["use_relative_paths"]),
+            )
+            raise
+
         # And store results
         _save_resultfile(result, cwd, self.name, rebase=False)
         # remove any node directories no longer required

--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -320,14 +320,10 @@ def test_outputmultipath_collapse(tmpdir):
 def test_mapnode_single(tmpdir):
     tmpdir.chdir()
 
-    def _producer(num=1, output_file=None, deadly_num=7):
+    def _producer(num=1, deadly_num=7):
         if num == deadly_num:
             raise RuntimeError("Got the deadly num (%d)." % num)
-        if output_file is None:
-            output_file = "producer_output_%05d" % num
-        with open(output_file, "w") as ofile:
-            ofile.write("%d" % num)
-        return output_file
+        return num + 1
 
     pnode = pe.MapNode(
         niu.Function(function=_producer), name="ProducerNode", iterfield=["num"]


### PR DESCRIPTION
## Summary

Fixes #3088  

## List of changes proposed in this PR (pull-request)
Allows MapNodes that have one subnode to generate a results file before erroring out

## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
