### PR TITLE
Backport: gh-3143 to 1.3.x branch

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -177,6 +177,7 @@ TESTS_REQUIRES = [
     'pytest',
     'pytest-cov',
     'pytest-env',
+    "pytest-timeout",
 ]
 
 EXTRA_REQUIRES = {

--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -305,3 +305,23 @@ def test_outputmultipath_collapse(tmpdir):
     assert ifres.outputs.out == [4]
     assert ndres.outputs.out == [4]
     assert select_nd.result.outputs.out == [4]
+
+
+@pytest.mark.timeout(30)
+def test_mapnode_single(tmpdir):
+    tmpdir.chdir()
+
+    def _producer(num=1, deadly_num=7):
+        if num == deadly_num:
+            raise RuntimeError("Got the deadly num (%d)." % num)
+        return num + 1
+
+    pnode = pe.MapNode(
+        niu.Function(function=_producer), name="ProducerNode", iterfield=["num"]
+    )
+    pnode.inputs.num = [7]
+    wf = pe.Workflow(name="PC_Workflow")
+    wf.add_nodes([pnode])
+    wf.base_dir = os.path.abspath("./test_output")
+    with pytest.raises(RuntimeError):
+        wf.run(plugin="MultiProc")


### PR DESCRIPTION
Backports #3143 to 1.3.x.

* fix: mapnode to generate result file when crashes in single node mode
* enh: simplify test further

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
