### PR TITLE
FIX: Move TraitType import, handle API change for NoDefaultSpecified

### DIFF
--- a/nipype/interfaces/base/traits_extension.py
+++ b/nipype/interfaces/base/traits_extension.py
@@ -24,10 +24,15 @@ from collections import Sequence
 # perform all external trait imports here
 from traits import __version__ as traits_version
 import traits.api as traits
-from traits.trait_handlers import TraitType, NoDefaultSpecified
+from traits.api import TraitType, Unicode
 from traits.trait_base import _Undefined
+try:
+    # Moved in traits 6.0
+    from traits.trait_type import NoDefaultSpecified
+except ImportError:
+    # Pre-6.0
+    from traits.trait_handlers import NoDefaultSpecified
 
-from traits.api import Unicode
 from pathlib import Path
 from ...utils.filemanip import path_resolve
 


### PR DESCRIPTION
## Summary
Addresses #3157 in `maint/1.4.x`.

After merging, `maint/1.4.x` should be merged into `master`.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
