### PR TITLE
FIX: load_resultfile crashes if open resultsfile from crashed job

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -291,7 +291,7 @@ def load_resultfile(results_file, resolve=True):
         raise FileNotFoundError(results_file)
 
     result = loadpkl(results_file)
-    if resolve and result.outputs:
+    if resolve and hasattr(result,"outputs") and result.outputs:
         try:
             outputs = result.outputs.get()
         except TypeError:  # This is a Bunch

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -291,7 +291,7 @@ def load_resultfile(results_file, resolve=True):
         raise FileNotFoundError(results_file)
 
     result = loadpkl(results_file)
-    if resolve and hasattr(result,"outputs") and result.outputs:
+    if resolve and getattr(result, "outputs", None):
         try:
             outputs = result.outputs.get()
         except TypeError:  # This is a Bunch

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -27,8 +27,6 @@ def is_pending(self, taskid):
 @patch.object(SGELikeBatchManagerBase, '_submit_batchtask', new=submit_batchtask)
 @patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
 def test_crashfile_creation(tmp_path):
-    cur_dir = os.getcwd()
-    with TemporaryDirectory(prefix="test_engine_", dir=cur_dir) as tmpdirname:
         pipe = pe.Workflow(name="pipe", base_dir=tmpdirname)
         pipe.config["execution"]["crashdump_dir"] = tmpdirname
         pipe.add_nodes([pe.Node(interface=Function(function=crasher), 

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -37,5 +37,5 @@ def test_crashfile_creation(tmp_path):
         assert (str(e.value) == 
                 "Workflow did not execute cleanly. Check log for details")
         
-        crashfiles = glob(join(tmpdirname,"crash*crasher*.pklz"))        
+        crashfiles = tmp_path.glob("crash*crasher*.pklz")
         assert len(crashfiles) == 1

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -13,8 +13,8 @@ import subprocess
 def crasher():
     raise ValueError()
 
-    
-def submit_batchtask(self, scriptfile, node):    
+
+def submit_batchtask(self, scriptfile, node):
     self._pending[1] = node.output_dir()
     subprocess.call(["bash", scriptfile])
     return 1
@@ -24,18 +24,16 @@ def is_pending(self, taskid):
     return False
 
 
-@patch.object(SGELikeBatchManagerBase, '_submit_batchtask', new=submit_batchtask)
-@patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
+@patch.object(SGELikeBatchManagerBase, "_submit_batchtask", new=submit_batchtask)
+@patch.object(SGELikeBatchManagerBase, "_is_pending", new=is_pending)
 def test_crashfile_creation(tmp_path):
-        pipe = pe.Workflow(name="pipe", base_dir=str(tmp_path))
-        pipe.config["execution"]["crashdump_dir"] = str(tmp_path)
-        pipe.add_nodes([pe.Node(interface=Function(function=crasher), 
-                            name="crasher")])    
-        sgelike_plugin = SGELikeBatchManagerBase("")
-        with pytest.raises(RuntimeError) as e:
-            assert pipe.run(plugin=sgelike_plugin)
-        assert (str(e.value) == 
-                "Workflow did not execute cleanly. Check log for details")
-        
-        crashfiles = tmp_path.glob("crash*crasher*.pklz")
-        assert len(crashfiles) == 1
+    pipe = pe.Workflow(name="pipe", base_dir=str(tmp_path))
+    pipe.config["execution"]["crashdump_dir"] = str(tmp_path)
+    pipe.add_nodes([pe.Node(interface=Function(function=crasher), name="crasher")])
+    sgelike_plugin = SGELikeBatchManagerBase("")
+    with pytest.raises(RuntimeError) as e:
+        assert pipe.run(plugin=sgelike_plugin)
+    assert str(e.value) == "Workflow did not execute cleanly. Check log for details"
+
+    crashfiles = tmp_path.glob("crash*crasher*.pklz")
+    assert len(list(crashfiles)) == 1

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -39,4 +39,3 @@ def test_crashfile_creation(tmp_path):
         
         crashfiles = glob(join(tmpdirname,"crash*crasher*.pklz"))        
         assert len(crashfiles) == 1
-    os.chdir(cur_dir)

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -1,0 +1,42 @@
+from nipype.pipeline.plugins.base import SGELikeBatchManagerBase
+from nipype.interfaces.utility import Function
+import nipype.pipeline.engine as pe
+from os.path import join
+import os
+from glob import glob
+import pytest
+from mock import patch
+from tempfile import TemporaryDirectory
+import subprocess
+
+def crasher():
+    raise ValueError()
+
+    
+def submit_batchtask(self, scriptfile, node):    
+    self._pending[1] = node.output_dir()
+    subprocess.call(["bash", scriptfile])
+    return 1
+
+def is_pending(taskid):
+    return False
+
+
+@patch.object(SGELikeBatchManagerBase, '_submit_batchtask', new=submit_batchtask)
+@patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
+def test_crashfile_creation():
+    cur_dir = os.getcwd()
+    with TemporaryDirectory(prefix="test_engine_", dir=cur_dir) as tmpdirname:
+        pipe = pe.Workflow(name="pipe", base_dir=tmpdirname)
+        pipe.config["execution"]["crashdump_dir"] = tmpdirname
+        pipe.add_nodes([pe.Node(interface=Function(function=crasher), 
+                            name="crasher")])    
+        sgelike_plugin = SGELikeBatchManagerBase("")
+        with pytest.raises(RuntimeError) as e:
+            assert pipe.run(plugin=sgelike_plugin)
+        assert (str(e.value) == 
+                "Workflow did not execute cleanly. Check log for details")
+        
+        crashfiles = glob(join(tmpdirname,"crash*crasher*.pklz"))        
+        assert len(crashfiles) == 1
+    os.chdir(cur_dir)

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -26,7 +26,7 @@ def is_pending(self, taskid):
 
 @patch.object(SGELikeBatchManagerBase, '_submit_batchtask', new=submit_batchtask)
 @patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
-def test_crashfile_creation():
+def test_crashfile_creation(tmp_path):
     cur_dir = os.getcwd()
     with TemporaryDirectory(prefix="test_engine_", dir=cur_dir) as tmpdirname:
         pipe = pe.Workflow(name="pipe", base_dir=tmpdirname)

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -27,7 +27,7 @@ def is_pending(self, taskid):
 @patch.object(SGELikeBatchManagerBase, '_submit_batchtask', new=submit_batchtask)
 @patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
 def test_crashfile_creation(tmp_path):
-        pipe = pe.Workflow(name="pipe", base_dir=tmpdirname)
+        pipe = pe.Workflow(name="pipe", base_dir=str(tmp_path))
         pipe.config["execution"]["crashdump_dir"] = tmpdirname
         pipe.add_nodes([pe.Node(interface=Function(function=crasher), 
                             name="crasher")])    

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -28,7 +28,7 @@ def is_pending(self, taskid):
 @patch.object(SGELikeBatchManagerBase, '_is_pending', new=is_pending)
 def test_crashfile_creation(tmp_path):
         pipe = pe.Workflow(name="pipe", base_dir=str(tmp_path))
-        pipe.config["execution"]["crashdump_dir"] = tmpdirname
+        pipe.config["execution"]["crashdump_dir"] = str(tmp_path)
         pipe.add_nodes([pe.Node(interface=Function(function=crasher), 
                             name="crasher")])    
         sgelike_plugin = SGELikeBatchManagerBase("")

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -9,6 +9,7 @@ from mock import patch
 from tempfile import TemporaryDirectory
 import subprocess
 
+
 def crasher():
     raise ValueError()
 
@@ -18,7 +19,8 @@ def submit_batchtask(self, scriptfile, node):
     subprocess.call(["bash", scriptfile])
     return 1
 
-def is_pending(taskid):
+
+def is_pending(self, taskid):
     return False
 
 
@@ -40,3 +42,4 @@ def test_crashfile_creation():
         crashfiles = glob(join(tmpdirname,"crash*crasher*.pklz"))        
         assert len(crashfiles) == 1
     os.chdir(cur_dir)
+

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -1,12 +1,8 @@
 from nipype.pipeline.plugins.base import SGELikeBatchManagerBase
 from nipype.interfaces.utility import Function
 import nipype.pipeline.engine as pe
-from os.path import join
-import os
-from glob import glob
 import pytest
 from unittest.mock import patch
-from tempfile import TemporaryDirectory
 import subprocess
 
 

--- a/nipype/pipeline/plugins/tests/test_sgelike.py
+++ b/nipype/pipeline/plugins/tests/test_sgelike.py
@@ -5,7 +5,7 @@ from os.path import join
 import os
 from glob import glob
 import pytest
-from mock import patch
+from unittest.mock import patch
 from tempfile import TemporaryDirectory
 import subprocess
 
@@ -42,4 +42,3 @@ def test_crashfile_creation():
         crashfiles = glob(join(tmpdirname,"crash*crasher*.pklz"))        
         assert len(crashfiles) == 1
     os.chdir(cur_dir)
-


### PR DESCRIPTION
## Problem
If a job crashes on computing nodes a result-file is written containing a dictionary (with traceback, etc). Then the 'controller' job reads the dictionary in order to produce the pickeled crash file. During reading of the results-file an exception arises in `load_resultfile` with `AttributeError: 'dict' object has no attribute 'outputs'`.

## Details
In #2985 `loadpkl` was replaced by `load_resultfile`. But `result_data` could be a dictionary as assumed in the following source snippet:
https://github.com/nipy/nipype/blob/b75a7cebc8dbefa796ed2504ca40197e65a9549e/nipype/pipeline/plugins/base.py#L531-L536
But `result_data` will never be a dictionary, because in `load_resultfile`  it has to have an attribute `outputs`:
https://github.com/nipy/nipype/blob/b75a7cebc8dbefa796ed2504ca40197e65a9549e/nipype/pipeline/engine/utils.py#L293-L294

## Solution
Just check if `result` has an attribute `outputs` before accessing it.
