### PR TITLE
[ENH] Workflow connect performance

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -158,6 +158,11 @@
       "orcid": "0000-0001-9062-3778"
     },
     {
+      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
+      "name": "Waller, Lea",
+      "orcid": "0000-0002-3239-6957"
+    },
+    {
       "affiliation": "MIT",
       "name": "Kaczmarzyk, Jakub",
       "orcid": "0000-0002-5544-7577"

--- a/nipype/pipeline/engine/tests/test_workflows.py
+++ b/nipype/pipeline/engine/tests/test_workflows.py
@@ -83,6 +83,22 @@ def test_doubleconnect():
     assert "Trying to connect" in str(excinfo.value)
 
 
+def test_nested_workflow_doubleconnect():
+    # double input with nested workflows
+    a = pe.Node(niu.IdentityInterface(fields=["a", "b"]), name="a")
+    b = pe.Node(niu.IdentityInterface(fields=["a", "b"]), name="b")
+    c = pe.Node(niu.IdentityInterface(fields=["a", "b"]), name="c")
+    flow1 = pe.Workflow(name="test1")
+    flow2 = pe.Workflow(name="test2")
+    flow3 = pe.Workflow(name="test3")
+    flow1.add_nodes([b])
+    flow2.connect(a, "a", flow1, "b.a")
+    with pytest.raises(Exception) as excinfo:
+        flow3.connect(c, "a", flow2, "test1.b.a")
+    assert "Some connections were not found" in str(excinfo.value)
+    flow3.connect(c, "b", flow2, "test1.b.b")
+
+
 def test_duplicate_node_check():
 
     wf = pe.Workflow(name="testidentity")

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -798,10 +798,10 @@ connected.
             return False
 
         if subtype == "in":
-            if not hasattr(node.inputs, attrname):
+            if not hasattr(targetnode.inputs, attrname):
                 return False
         else:
-            if not hasattr(node.outputs, attrname):
+            if not hasattr(targetnode.outputs, attrname):
                 return False
 
         if subtype == "in":


### PR DESCRIPTION
## Summary
Hi :-) I'm using nipype with fmriprep to process hundreds of subjects. When doing that, I noticed that creating the nipype workflows can be quite slow. This was mostly noticeable when there were nested workflows. To find out why, I ran a quick python cProfile.

![Screenshot 2020-03-06 21 09 22](https://user-images.githubusercontent.com/789054/76209302-d407ed00-6201-11ea-95c2-e885b18d0978.png)

It turns out that a prominent performance bottleneck is the `workflow.connect` function, or rather the `_has_attr` function that is called by it. This function checks if a nested workflow has a specific input or output. If the input/output is not found, an error message is printed. 
To check for inputs/outputs, `_has_attr` uses the workflow's `inputs` or `outputs` properties, which return a dictionary of the inputs/outputs of all nested nodes. `_has_attr` now checks whether the target input or output is listed in the dictionary and returns. 
However, accessing these properties calls a getter function that traverses all of the workflow's child nodes to generate the dictionary. As this entire procedure is repeated over again for each new connection, it can be quite slow. 

## List of changes proposed in this PR (pull-request)
Instead of generating the full dictionary, I propose that the `_has_attr` function should traverse the individual workflow graphs until it finds the target node (or not). I have created a quick implementation that leads to a ~6x speedup in creating my nipype/fmriprep workflows. The code passes integration tests. Maybe this code will be useful for the larger nipype community. 

![Screenshot 2020-03-07 12 51 34](https://user-images.githubusercontent.com/789054/76209769-f5b5a400-6202-11ea-88be-bfd55ca4bbd0.png)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
