### PR TITLE
FIX: Partial rollback of N4BiasFieldCorrection

### DIFF
--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -537,6 +537,11 @@ class N4BiasFieldCorrection(ANTSCommand, CopyHeaderInterface):
             self._out_bias_file = bias_image
         return super(N4BiasFieldCorrection, self)._parse_inputs(skip=skip)
 
+    def _list_outputs(self):
+        outputs = super(N4BiasFieldCorrection, self)._list_outputs()
+        if self._out_bias_file:
+            outputs["bias_image"] = os.path.abspath(self._out_bias_file)
+        return outputs
 
 class CorticalThicknessInputSpec(ANTSCommandInputSpec):
     dimension = traits.Enum(


### PR DESCRIPTION
In the last maintenance (#3180) of the interface, we eliminated an
important section of the ``_list_outputs``:

https://github.com/nipy/nipype/commit/6979cbdcb041cb12b064513a57ff74b000bacdad#diff-b6f33a19b0e06b91023416db5faf7323L544-L547

This PR addresses the problem:
```
Execution Outputs
-----------------

* bias_image : <undefined>
* output_image : /home/oesteban/tmp/fmriprep-ds005/fprep-work/fmriprep_wf/single_subject_01_wf/anat_preproc_wf/brain_extraction_wf/inu_n4_final/mapflow/_inu_n4_final0/sub-01_T1w_cor
rected.nii.gz

Runtime info
------------

* cmdline : N4BiasFieldCorrection --bspline-fitting [ 200 ] -d 3 --input-image /oak/stanford/groups/russpold/data/openfmri/ds000005/sub-01/anat/sub-01_T1w.nii.gz --convergence [ 50x
50x50x50x50, 1e-07 ] --output [ sub-01_T1w_corrected.nii.gz, sub-01_T1w_bias.nii.gz ] -r --shrink-factor 4 --weight-image /home/oesteban/tmp/fmriprep-ds005/fprep-work/fmriprep_wf/single_subject_01_wf/anat_preproc_wf/brain_extraction_wf/atropos_wf/copy_xform/09_relabel_wm_maths_xform.nii.gz
* duration : 15.334786
* hostname : dendrite
* prev_wd : /home/oesteban/tmp/fmriprep-ds005
* working_dir : /home/oesteban/tmp/fmriprep-ds005/fprep-work/fmriprep_wf/single_subject_01_wf/anat_preproc_wf/brain_extraction_wf/inu_n4_final/mapflow/_inu_n4_final0
```
(`bias_image` should be `'sub-01_T1w_bias.nii.gz'` given the `cmdline`)

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
