### PR TITLE
TEST: Mock terminal output before testing changing default value

### DIFF
--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -5,6 +5,7 @@ import os
 import simplejson as json
 
 import pytest
+from unittest import mock
 
 from .... import config
 from ....testing import example_data
@@ -456,17 +457,18 @@ def test_global_CommandLine_output(tmpdir):
     ci = BET()
     assert ci.terminal_output == "stream"  # default case
 
-    nib.CommandLine.set_default_terminal_output("allatonce")
-    ci = nib.CommandLine(command="ls -l")
-    assert ci.terminal_output == "allatonce"
+    with mock.patch.object(nib.CommandLine, '_terminal_output'):
+        nib.CommandLine.set_default_terminal_output("allatonce")
+        ci = nib.CommandLine(command="ls -l")
+        assert ci.terminal_output == "allatonce"
 
-    nib.CommandLine.set_default_terminal_output("file")
-    ci = nib.CommandLine(command="ls -l")
-    assert ci.terminal_output == "file"
+        nib.CommandLine.set_default_terminal_output("file")
+        ci = nib.CommandLine(command="ls -l")
+        assert ci.terminal_output == "file"
 
-    # Check default affects derived interfaces
-    ci = BET()
-    assert ci.terminal_output == "file"
+        # Check default affects derived interfaces
+        ci = BET()
+        assert ci.terminal_output == "file"
 
 
 def test_CommandLine_prefix(tmpdir):

--- a/nipype/interfaces/tests/test_extra_dcm2nii.py
+++ b/nipype/interfaces/tests/test_extra_dcm2nii.py
@@ -22,7 +22,7 @@ def fetch_data():
             """Fetches some test DICOMs using datalad"""
             api.install(path=datadir, source=DICOM_DIR)
             data = os.path.join(datadir, dicoms)
-            api.get(path=data)
+            api.get(path=data, dataset=datadir)
         except IncompleteResultsError as exc:
             pytest.skip("Failed to fetch test data: %s" % str(exc))
         return data

--- a/nipype/interfaces/tests/test_extra_dcm2nii.py
+++ b/nipype/interfaces/tests/test_extra_dcm2nii.py
@@ -32,7 +32,6 @@ def fetch_data():
 
 @pytest.mark.skipif(no_datalad, reason="Datalad required")
 @pytest.mark.skipif(no_dcm2niix, reason="Dcm2niix required")
-@pytest.mark.xfail(reason="Intermittent failures. Let's come back to this later.")
 def test_dcm2niix_dti(fetch_data, tmpdir):
     tmpdir.chdir()
     datadir = tmpdir.mkdir("data").strpath


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Closes #3185.

Without pytest-xdist, this reliably fails:

```
pytest --pdb --doctest-modules nipype/interfaces/base/tests/test_core.py nipype/interfaces/freesurfer/tests/test_utils.py
```

I assume the intermittent CI failures are for when the two tests were run on the same worker.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
