### PR TITLE
FIX: Use PackageInfo to get NiftyReg version

### DIFF
--- a/nipype/interfaces/niftyreg/base.py
+++ b/nipype/interfaces/niftyreg/base.py
@@ -102,8 +102,6 @@ class NiftyRegCommand(CommandLine):
         _version = self.version
         if not _version:
             raise Exception("Niftyreg not found")
-        # Decoding to string:
-        _version = _version.decode("utf-8")
         if StrictVersion(_version) < StrictVersion(self._min_version):
             err = "A later version of Niftyreg is required (%s < %s)"
             raise ValueError(err % (_version, self._min_version))


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #2615.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- Use `PackageInfo` to get NiftyReg version as suggested in #2615.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
