### PR TITLE
Enh/readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
@@ -15,4 +15,4 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - requirements: doc/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
adds the preferred way to set readthedocs settings for building the docs.

currently readthedocs is still failing in master with the same alt error.