### PR TITLE
REF: make invocations of python and pytest consistent with the one used/desired python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,18 @@ zipdoc: html
 
 sdist: zipdoc
 	@echo "Building source distribution..."
-	python setup.py sdist
+	$(PYTHON) setup.py sdist
 	@echo "Done building source distribution."
 	# XXX copy documentation.zip to dist directory.
 
 egg: zipdoc
 	@echo "Building egg..."
-	python setup.py bdist_egg
+	$(PYTHON) setup.py bdist_egg
 	@echo "Done building egg."
 
 upload_to_pypi: zipdoc
 	@echo "Uploading to PyPi..."
-	python setup.py sdist --formats=zip,gztar upload
+	$(PYTHON) setup.py sdist --formats=zip,gztar upload
 
 trailing-spaces:
 	find . -name "*[.py|.rst]" -type f | xargs perl -pi -e 's/[ \t]*$$//'
@@ -70,7 +70,7 @@ html:
 
 specs:
 	@echo "Checking specs and autogenerating spec tests"
-	env PYTHONPATH=".:$(PYTHONPATH)" python tools/checkspecs.py
+	env PYTHONPATH=".:$(PYTHONPATH)" $(PYTHON) tools/checkspecs.py
 
 check: check-before-commit # just a shortcut
 check-before-commit: specs trailing-spaces html test

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,10 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code: in
-	py.test --doctest-modules nipype
+	$(PYTHON) -m pytest --doctest-modules nipype
 
 test-coverage: clean-tests in
-	py.test --doctest-modules --cov-config .coveragerc --cov=nipype nipype
+	$(PYTHON) -m pytest --doctest-modules --cov-config .coveragerc --cov=nipype nipype
 
 test: tests # just another name
 tests: clean test-code

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import shutil
+import sys
 from packaging.version import Version
 import nipype
 import subprocess as sp
@@ -54,7 +55,7 @@ with TemporaryDirectory() as tmpdir:
 
 sp.run(
     [
-        "python",
+        sys.executable,
         ex2rst,
         "--outdir",
         str(example_dir),
@@ -70,7 +71,7 @@ sp.run(
 )
 sp.run(
     [
-        "python",
+        sys.executable,
         ex2rst,
         "--outdir",
         str(example_dir),

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -7,6 +7,7 @@ import os
 import os.path as op
 from glob import glob
 import shutil
+import sys
 
 import numpy as np
 from nibabel import load
@@ -726,7 +727,7 @@ class DICOMConvert(FSCommand):
         outdir = self._get_outdir()
         cmd = []
         if not os.path.exists(outdir):
-            cmdstr = "python -c \"import os; os.makedirs('%s')\"" % outdir
+            cmdstr = "%s -c \"import os; os.makedirs('%s')\"" % (op.basename(sys.executable), outdir)
             cmd.extend([cmdstr])
         infofile = os.path.join(outdir, "shortinfo.txt")
         if not os.path.exists(infofile):

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -31,7 +31,7 @@ def sh(cmd):
 def compile_tree():
     """Compile all Python files below current directory."""
     vstr = ".".join(map(str, sys.version_info[:2]))
-    stat = os.system("python %s/lib/python%s/compileall.py ." % (sys.prefix, vstr))
+    stat = os.system("%s %s/lib/python%s/compileall.py ." % (sys.executable, sys.prefix, vstr))
     if stat:
         msg = "*** ERROR: Some Python files in tree do NOT compile! ***\n"
         msg += "See messages above for the actual file that produced it.\n"


### PR DESCRIPTION
It is largely based on patches which are now in debian packaging of nipype.  In an effort to upgrade debian distribution from python 2 to 3, there should be better control over which python is actually invoked by the processes. E.g. there could be `python` and `python3` executables, and nipype imported in `python3`.  Then all underlying calls should also use `python3` and not just plain `python`.  Also Makefile already had provision (`$(PYTHON)` variable) to define which python to use but it was not uniformly used.  This PR should address those. 

See individual commits for possibly more comments