### PR TITLE
ENH: Add ``"TruncateImageIntensity"`` operation to ``ants.utils.Image.Math``

### DIFF
--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -46,6 +46,7 @@ class ImageMathInputSpec(ANTSCommandInputSpec):
         "GE",
         "GO",
         "GC",
+        "TruncateImageIntensity",
         mandatory=True,
         position=3,
         argstr="%s",
@@ -91,6 +92,12 @@ class ImageMath(ANTSCommand, CopyHeaderInterface):
     ...     operation='G',
     ...     op2='4').cmdline
     'ImageMath 3 structural_maths.nii G structural.nii 4'
+
+    >>> ImageMath(
+    ...     op1='structural.nii',
+    ...     operation='TruncateImageIntensity',
+    ...     op2='0.005 0.999 256').cmdline
+    'ImageMath 3 structural_maths.nii TruncateImageIntensity structural.nii 0.005 0.999 256'
 
     """
 


### PR DESCRIPTION
``"TruncateImageIntensity"`` is part of ``antsBrainExtraction.sh`` and therefore, having it supported by nipype is of great interest.

This PR addresses a problem @eilidhmacnicol just discovered. Having this merged will also allow us to call the upstreaming of ANTS interfaces from niworkflows done.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [ ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
