### PR TITLE
volterra_expansion_order documentation error

### DIFF
--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -81,7 +81,7 @@ Dictionary names of the basis function to parameters:
         mandatory=True,
     )
     volterra_expansion_order = traits.Enum(
-        1, 2, field="volt", desc=("Model interactions - yes:1, no:2")
+        1, 2, field="volt", desc=("Model interactions - no:1, yes:2")
     )
     global_intensity_normalization = traits.Enum(
         "none",


### PR DESCRIPTION
For fMRI model specification, in SPM, matlabbatch{n}.spm.stats.fmri_spec.volt = 2 corresponds to 'Model Interactions' and matlabbatch{n}.spm.stats.fmri_spec.volt =1 corresponds to 'Do not model Interactions'.
Currently, for the corresponding process in nipype, the Level1Design, we see volterra_expansion_order = traits.Enum(1, 2, field="volt", desc=("Model interactions - yes:1, no:2")).
I guess the correct description should rather be volterra_expansion_order = traits.Enum(1, 2, field="volt", desc=("Model interactions - no:1, yes:2"))

