### PR TITLE
FIX: report.rst terminal output

### DIFF
--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -736,7 +736,7 @@ def write_rst_header(header, level=0):
 
 def write_rst_list(items, prefix=""):
     out = []
-    for item in items:
+    for item in ensure_list(items):
         out.append("{} {}".format(prefix, str(item)))
     return "\n".join(out) + "\n\n"
 

--- a/nipype/utils/tests/test_filemanip.py
+++ b/nipype/utils/tests/test_filemanip.py
@@ -30,6 +30,7 @@ from ...utils.filemanip import (
     loadcrash,
     savepkl,
     path_resolve,
+    write_rst_list,
 )
 
 
@@ -652,3 +653,17 @@ def test_pickle(tmp_path, save_versioning):
     savepkl(pickle_fname, testobj, versioning=save_versioning)
     outobj = loadpkl(pickle_fname)
     assert outobj == testobj
+
+
+@pytest.mark.parametrize("items,expected", [
+    ('', ' \n\n'),
+    ('A string', ' A string\n\n'),
+    (['A list', 'Of strings'], ' A list\n Of strings\n\n'),
+    (None, TypeError),
+])
+def test_write_rst_list(tmp_path, items, expected):
+    if items is not None:
+        assert write_rst_list(items) == expected
+    else:
+        with pytest.raises(expected):
+            write_rst_list(items)


### PR DESCRIPTION
Closes #3103 

This should fix cases where terminal output (stdout / stderr) is given as a string, and each character is printed on a new line.