### PR TITLE
FIX: Permit identity transforms in list of transforms given to ants.ApplyTransforms

### DIFF
--- a/nipype/interfaces/ants/resampling.py
+++ b/nipype/interfaces/ants/resampling.py
@@ -502,8 +502,6 @@ class ApplyTransforms(ANTSCommand):
         if opt == "output_image":
             return self._get_output_warped_filename()
         elif opt == "transforms":
-            if val == "identity":
-                return "-t identity"
             return self._get_transform_filenames()
         elif opt == "interpolation":
             if self.inputs.interpolation in [


### PR DESCRIPTION
## Summary

antsApplyTransforms currently permits `identity` or a chain of transformations, but it can be useful to insert an `identity` into a chain.

## List of changes proposed in this PR (pull-request)

* Changes transforms from `Either(InputMultiObject(File), "identity")` to `InputMultiObject(Either(File, "identity"))`.
* Change `InputMultiPath` to `InputMultiObject` throughout the file, in passing.
* Simplifies the logic for constructing `--transform` arguments.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
