### PR TITLE
FIX: test_no_et hanging on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
 script:
 - |
     if [ "$CHECK_TYPE" = "test" ]; then
-        py.test -v --cov nipype --cov-config .coveragerc --cov-report xml:cov.xml -c nipype/pytest.ini --doctest-modules nipype -n auto
+        py.test -sv --cov nipype --cov-config .coveragerc --cov-report xml:cov.xml -c nipype/pytest.ini --doctest-modules nipype -n auto
     fi
 - |
     if [ "$CHECK_TYPE" = "specs" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
 script:
 - |
     if [ "$CHECK_TYPE" = "test" ]; then
-        py.test -sv --cov nipype --cov-config .coveragerc --cov-report xml:cov.xml -c nipype/pytest.ini --doctest-modules nipype -n auto
+        py.test -sv --cov nipype --cov-config .coveragerc --cov-report xml:cov.xml -c nipype/pytest.ini --doctest-modules nipype -n 2
     fi
 - |
     if [ "$CHECK_TYPE" = "specs" ]; then


### PR DESCRIPTION
## Summary

Travis is consistently hanging on Python 3.8, apparently at test_no_et. This adds verbosity, and splits up the test to hopefully make it easier to track down.

Cannot reproduce this locally by running the specific file, but there may be state changes in the test workers...

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [ ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
