### PR TITLE
FIX: Serialize all interface arguments when exporting workflows

### DIFF
--- a/nipype/pipeline/engine/tests/test_utils.py
+++ b/nipype/pipeline/engine/tests/test_utils.py
@@ -11,7 +11,12 @@ from ... import engine as pe
 from ....interfaces import base as nib
 from ....interfaces import utility as niu
 from .... import config
-from ..utils import clean_working_directory, write_workflow_prov, load_resultfile
+from ..utils import (
+    clean_working_directory,
+    write_workflow_prov,
+    load_resultfile,
+    format_node,
+)
 
 
 class InputSpec(nib.TraitedSpec):
@@ -327,3 +332,11 @@ def test_save_load_resultfile(tmpdir, use_relative):
             )
 
     config.set("execution", "use_relative_paths", old_use_relative)
+
+
+def test_format_node():
+    node = pe.Node(niu.IdentityInterface(fields=["a", "b"]), name="node")
+    serialized = format_node(node)
+    workspace = {"Node": pe.Node}
+    exec("\n".join(serialized), workspace)
+    assert workspace["node"].interface._fields == node.interface._fields

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -365,7 +365,6 @@ def format_node(node, format="python", include_config=False):
         comment = "# Node: %s" % node.fullname
         spec = signature(node.interface.__init__)
         args = [p.name for p in list(spec.parameters.values())]
-        args = args[1:]
         if args:
             filled_args = []
             for arg in args:

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -369,9 +369,15 @@ def format_node(node, format="python", include_config=False):
             filled_args = []
             for arg in args:
                 if hasattr(node.interface, "_%s" % arg):
-                    filled_args.append(
-                        "%s=%s" % (arg, getattr(node.interface, "_%s" % arg))
-                    )
+                    argval = getattr(node.interface, "_%s" % arg)
+                    if isinstance(argval, str):
+                        filled_args.append(
+                            "%s='%s'" % (arg, argval)
+                        )
+                    else:
+                        filled_args.append(
+                            "%s=%s" % (arg, argval)
+                        )
             args = ", ".join(filled_args)
         else:
             args = ""

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -364,23 +364,12 @@ def format_node(node, format="python", include_config=False):
         importline = "from %s import %s" % (klass.__module__, klass.__class__.__name__)
         comment = "# Node: %s" % node.fullname
         spec = signature(node.interface.__init__)
-        args = [p.name for p in list(spec.parameters.values())]
-        if args:
-            filled_args = []
-            for arg in args:
-                if hasattr(node.interface, "_%s" % arg):
-                    argval = getattr(node.interface, "_%s" % arg)
-                    if isinstance(argval, str):
-                        filled_args.append(
-                            "%s='%s'" % (arg, argval)
-                        )
-                    else:
-                        filled_args.append(
-                            "%s=%s" % (arg, argval)
-                        )
-            args = ", ".join(filled_args)
-        else:
-            args = ""
+        filled_args = []
+        for param in spec.parameters.values():
+            val = getattr(node.interface, f"_{param.name}", None)
+            if val is not None:
+                filled_args.append(f"{param.name}={val!r}")
+        args = ", ".join(filled_args)
         klass_name = klass.__class__.__name__
         if isinstance(node, MapNode):
             nodedef = '%s = MapNode(%s(%s), iterfield=%s, name="%s")' % (


### PR DESCRIPTION
## Summary

@matteomancini Apologies for taking over your PR. I had some maintenance changes to make, and ended up making more significant changes than I felt comfortable force-pushing to your branch. Feel free to take these changes to your PR, if you have further changes you want to make. I would also appreciate your review.

Fixes #3230.
Closes #3231.

## List of changes proposed in this PR (pull-request)

#3231 Ensured that values passed to nodes would be reproduced after being serialized. This PR:

1) Added a test to verify that the problem was demonstrated and the solution resolved it. (It did.)
2) Rebased against `maint/1.5.x` so that this can go in the next release.
3) Decided to use f-strings and the `repr` (`!r`) format to avoid branching, then saw opportunities to further refactor.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
