### PR TITLE
FIX: Warn for min/max_ver traits when tool version can't be parsed

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -277,15 +277,15 @@ class BaseInterface(Interface):
             for name in names:
                 min_ver = LooseVersion(str(trait_object.traits()[name].min_ver))
                 try:
-                    min_ver > version
+                    too_old = min_ver > version
                 except TypeError:
                     iflogger.warning(
-                        'Nipype is having issues parsing the package version '
-                        f'for Trait {name} ({self.__class__.__name__})'
-                        f'You may want to check whether {version} is larger than {min_ver}'
-                        )
+                        f"Nipype cannot validate the package version {version!r} for "
+                        f"{self.__class__.__name__}. Trait {name} requires version "
+                        f">={min_ver}. Please verify validity."
+                    )
                     continue
-                if min_ver > version:
+                if too_old:
                     unavailable_traits.append(name)
                     if not isdefined(getattr(trait_object, name)):
                         continue
@@ -303,15 +303,15 @@ class BaseInterface(Interface):
             for name in names:
                 max_ver = LooseVersion(str(trait_object.traits()[name].max_ver))
                 try:
-                    max_ver > version
+                    too_new = max_ver < version
                 except TypeError:
                     iflogger.warning(
-                        'Nipype is having issues parsing the package version '
-                        f'for Trait {name} ({self.__class__.__name__})'
-                        f'You may want to check whether {version} is smaller than {max_ver}'
-                        )
+                        f"Nipype cannot validate the package version {version!r} for "
+                        f"{self.__class__.__name__}. Trait {name} requires version "
+                        f"<={max_ver}. Please verify validity."
+                    )
                     continue
-                if max_ver < version:
+                if too_new:
                     unavailable_traits.append(name)
                     if not isdefined(getattr(trait_object, name)):
                         continue

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -276,6 +276,15 @@ class BaseInterface(Interface):
             version = LooseVersion(str(self.version))
             for name in names:
                 min_ver = LooseVersion(str(trait_object.traits()[name].min_ver))
+                try:
+                    min_ver > version
+                except TypeError:
+                    iflogger.warning(
+                        'Nipype is having issues parsing the package version '
+                        f'for Trait {name} ({self.__class__.__name__})'
+                        f'You may want to check whether {version} is larger than {min_ver}'
+                        )
+                    continue
                 if min_ver > version:
                     unavailable_traits.append(name)
                     if not isdefined(getattr(trait_object, name)):
@@ -293,6 +302,15 @@ class BaseInterface(Interface):
             version = LooseVersion(str(self.version))
             for name in names:
                 max_ver = LooseVersion(str(trait_object.traits()[name].max_ver))
+                try:
+                    max_ver > version
+                except TypeError:
+                    iflogger.warning(
+                        'Nipype is having issues parsing the package version '
+                        f'for Trait {name} ({self.__class__.__name__})'
+                        f'You may want to check whether {version} is smaller than {max_ver}'
+                        )
+                    continue
                 if max_ver < version:
                     unavailable_traits.append(name)
                     if not isdefined(getattr(trait_object, name)):

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -278,12 +278,14 @@ class BaseInterface(Interface):
                 min_ver = LooseVersion(str(trait_object.traits()[name].min_ver))
                 try:
                     too_old = min_ver > version
-                except TypeError:
-                    iflogger.warning(
+                except TypeError as err:
+                    msg = (
                         f"Nipype cannot validate the package version {version!r} for "
-                        f"{self.__class__.__name__}. Trait {name} requires version "
-                        f">={min_ver}. Please verify validity."
+                        f"{self.__class__.__name__}. Trait {name} requires version >={min_ver}."
                     )
+                    iflogger.warning(f"{msg}. Please verify validity.")
+                    if config.getboolean("execution", "stop_on_unknown_version"):
+                        raise ValueError(msg) from err
                     continue
                 if too_old:
                     unavailable_traits.append(name)
@@ -304,12 +306,14 @@ class BaseInterface(Interface):
                 max_ver = LooseVersion(str(trait_object.traits()[name].max_ver))
                 try:
                     too_new = max_ver < version
-                except TypeError:
-                    iflogger.warning(
+                except TypeError as err:
+                    msg = (
                         f"Nipype cannot validate the package version {version!r} for "
-                        f"{self.__class__.__name__}. Trait {name} requires version "
-                        f"<={max_ver}. Please verify validity."
+                        f"{self.__class__.__name__}. Trait {name} requires version <={max_ver}."
                     )
+                    iflogger.warning(f"{msg}. Please verify validity.")
+                    if config.getboolean("execution", "stop_on_unknown_version"):
+                        raise ValueError(msg) from err
                     continue
                 if too_new:
                     unavailable_traits.append(name)

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -3,6 +3,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 import os
 import simplejson as json
+import logging
 
 import pytest
 from unittest import mock
@@ -234,6 +235,21 @@ def test_input_version_6():
     obj = DerivedInterface1()
     obj.inputs.foo = 1
     obj._check_version_requirements(obj.inputs)
+
+
+def test_input_version_missing(caplog):
+    class DerivedInterface(nib.BaseInterface):
+        class input_spec(nib.TraitedSpec):
+            foo = nib.traits.Int(min_ver="0.9")
+            bar = nib.traits.Int(max_ver="0.9")
+        _version = "misparsed-garbage"
+
+    obj = DerivedInterface()
+    obj.inputs.foo = 1
+    obj.inputs.bar = 1
+    with caplog.at_level(logging.WARNING, logger="nipype.interface"):
+        obj._check_version_requirements(obj.inputs)
+    assert len(caplog.records) == 2
 
 
 def test_output_version():


### PR DESCRIPTION
## Summary

@TheChymera Apologies for taking over #3234, but I would like to get a bug-fix release out quickly.

## List of changes proposed in this PR (pull-request)


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
