### PR TITLE
[ENH] Optimize workflow.run performance

### DIFF
--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -838,15 +838,28 @@ connected.
         """Returns the underlying node corresponding to an input or
         output parameter
         """
-        if subtype == "in":
-            subobject = self.inputs
-        else:
-            subobject = self.outputs
         attrlist = parameter.split(".")
-        cur_out = subobject
-        for attr in attrlist[:-1]:
-            cur_out = getattr(cur_out, attr)
-        return cur_out.traits()[attrlist[-1]].node
+        _ = attrlist.pop()  # take attribute name
+        nodename = attrlist.pop()
+
+        targetworkflow = self
+        while attrlist:
+            workflowname = attrlist.pop(0)
+            workflow = None
+            for node in targetworkflow._graph.nodes():
+                if node.name == workflowname and isinstance(node, Workflow):
+                    workflow = node
+                    break
+            if workflow is None:
+                return
+            targetworkflow = workflow
+
+        for node in targetworkflow._graph.nodes():
+            if node.name == nodename:
+                if isinstance(node, Workflow):
+                    return
+                else:
+                    return node
 
     def _check_outputs(self, parameter):
         return self._has_attr(parameter, subtype="out")

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -962,7 +962,7 @@ connected.
                     logger.debug("in: connections-> %s", str(d["connect"]))
                     for cd in deepcopy(d["connect"]):
                         logger.debug("in: %s", str(cd))
-                        dstnode = node.get_node(parameter.rsplit(".", 1)[0])
+                        dstnode = node.get_node(cd[1].rsplit(".", 1)[0])
                         srcnode = u
                         srcout = cd[0]
                         dstin = cd[1].split(".")[-1]

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -834,33 +834,6 @@ connected.
 
         return True
 
-    def _get_parameter_node(self, parameter, subtype="in"):
-        """Returns the underlying node corresponding to an input or
-        output parameter
-        """
-        attrlist = parameter.split(".")
-        _ = attrlist.pop()  # take attribute name
-        nodename = attrlist.pop()
-
-        targetworkflow = self
-        while attrlist:
-            workflowname = attrlist.pop(0)
-            workflow = None
-            for node in targetworkflow._graph.nodes():
-                if node.name == workflowname and isinstance(node, Workflow):
-                    workflow = node
-                    break
-            if workflow is None:
-                return
-            targetworkflow = workflow
-
-        for node in targetworkflow._graph.nodes():
-            if node.name == nodename:
-                if isinstance(node, Workflow):
-                    return
-                else:
-                    return node
-
     def _check_outputs(self, parameter):
         return self._has_attr(parameter, subtype="out")
 
@@ -989,7 +962,7 @@ connected.
                     logger.debug("in: connections-> %s", str(d["connect"]))
                     for cd in deepcopy(d["connect"]):
                         logger.debug("in: %s", str(cd))
-                        dstnode = node._get_parameter_node(cd[1], subtype="in")
+                        dstnode = node.get_node(parameter.rsplit(".", 1)[0])
                         srcnode = u
                         srcout = cd[0]
                         dstin = cd[1].split(".")[-1]
@@ -1009,7 +982,7 @@ connected.
                             parameter = cd[0][0]
                         else:
                             parameter = cd[0]
-                        srcnode = node._get_parameter_node(parameter, subtype="out")
+                        srcnode = node.get_node(parameter.rsplit(".", 1)[0])
                         if isinstance(cd[0], tuple):
                             srcout = list(cd[0])
                             srcout[0] = parameter.split(".")[-1]


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
A few months back, I submitted pull request #3184 to improve the performance of using `connect` when creating large workflows. Specifically, I had discovered that the use of the `inputs` or `outputs` properties of workflows can create a performance bottleneck if there are many child nodes or nested workflows. 

Recently, I noticed that the same bottleneck can cause a delay between calling `workflow.run()` and the start of the actual execution, meaning when nodes and interfaces start to run. 

Running cProfile suggests that the delay occurs in `_create_flat_graph`. Note that the profile does not include the full workflow execution, but was cancelled immediately when the first node started to run.
![Screen Shot 2020-08-07 at 10 47 49 AM](https://user-images.githubusercontent.com/789054/96377545-8cc5df80-1186-11eb-8233-5252226c284c.png)

As far as I can tell, before execution starts, nested workflows are merged into one overall workflow using `_create_flat_graph`. To resolve the final connections between nodes in this merged workflow, `_create_flat_graph` calls `_get_parameter_node` for each input from or output to a nested workflow, and then modifies the connection information accordingly.
https://github.com/nipy/nipype/blob/e9217c299149be829a985d8f822c3a91e29b2f4b/nipype/pipeline/engine/workflows.py#L975-L979

As a result, for each connection to/from a nested workflow, `_get_parameter_node` constructs the entire `inputs` or `outputs` data structure of the nested workflow, and then uses it to resolve the correct connection information. Just as for #3184, constructing this entire data structure over and over again for each connection can reduce performance.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
Instead of generating the full `inputs` or `outputs` data structure, I propose that the `_get_parameter_node` function should traverse the individual workflow graphs until it finds the target node (or not). 

I have created a quick implementation that leads to a significant speedup. This implementation is a slightly modified copy of the code from #3184. 
![Screen Shot 2020-08-07 at 11 47 01 AM](https://user-images.githubusercontent.com/789054/96377543-8c2d4900-1186-11eb-9871-0154c8be82ef.png)

I hope that this code will be useful for the nipype community.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
