### PR TITLE
[FIX] EpiReg changed to not list certain outputs when 'wmseg' input is specified

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -487,7 +487,7 @@
       "name": "Perkins, L. Nathan"
     },
     {
-      "affiliation": "Otto-von-Guericke-University Magdeburg, Germany",
+      "affiliation": "Max Planck Institute for Human Cognitive and Brain Sciences",
       "name": "Contier, Oliver",
       "orcid": "0000-0002-2983-4709"
     },

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -1306,20 +1306,19 @@ class EpiReg(FSLCommand):
             outputs["epi2str_inv"] = os.path.join(
                 os.getcwd(), self.inputs.out_base + "_inv.mat"
             )
-
+        if not isdefined(self.inputs.wmseg):
+            outputs["wmedge"] = os.path.join(
+                os.getcwd(), self.inputs.out_base + "_fast_wmedge.nii.gz"
+            )
+            outputs["wmseg"] = os.path.join(
+                os.getcwd(), self.inputs.out_base + "_fast_wmseg.nii.gz"
+            )
+            outputs["seg"] = os.path.join(
+                os.getcwd(), self.inputs.out_base + "_fast_seg.nii.gz"
+            )
         outputs["epi2str_mat"] = os.path.join(
             os.getcwd(), self.inputs.out_base + ".mat"
         )
-        outputs["wmedge"] = os.path.join(
-            os.getcwd(), self.inputs.out_base + "_fast_wmedge.nii.gz"
-        )
-        outputs["wmseg"] = os.path.join(
-            os.getcwd(), self.inputs.out_base + "_fast_wmseg.nii.gz"
-        )
-        outputs["seg"] = os.path.join(
-            os.getcwd(), self.inputs.out_base + "_fast_seg.nii.gz"
-        )
-
         return outputs
 
 


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3264 

FSL's epi_reg script does not perform segmentation when a white matter segmented file is already provided. Hence, the interface should not check whether the 'seg' output exists in in case a 'wmseg' input is specified.

## List of changes proposed in this PR (pull-request)
* added simple conditional to the _list_outputs() methods of the EpiReg interface such that the outputs 'seg', 'wmseg', and 'wmedge' are not listed when 'wmseg' is already specified as an input

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
