### PR TITLE
FIX: Canonicalize environment dicts to strings in Windows

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -26,7 +26,7 @@ from traits.trait_errors import TraitError
 from ... import config, logging, LooseVersion
 from ...utils.provenance import write_provenance
 from ...utils.misc import str2bool, rgetcwd
-from ...utils.filemanip import split_filename, which, get_dependencies
+from ...utils.filemanip import split_filename, which, get_dependencies, canonicalize_env
 from ...utils.subprocess import run_command
 
 from ...external.due import due
@@ -778,7 +778,7 @@ class CommandLine(BaseInterface):
             proc = sp.Popen(
                 " ".join((cmd, flag)),
                 shell=True,
-                env=env,
+                env=canonicalize_env(env),
                 stdout=sp.PIPE,
                 stderr=sp.PIPE,
             )

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -26,11 +26,7 @@ from .misc import is_container
 
 fmlogger = logging.getLogger("nipype.utils")
 
-related_filetype_sets = [
-    (".hdr", ".img", ".mat"),
-    (".nii", ".mat"),
-    (".BRIK", ".HEAD"),
-]
+related_filetype_sets = [(".hdr", ".img", ".mat"), (".nii", ".mat"), (".BRIK", ".HEAD")]
 
 
 def _resolve_with_filenotfound(path, **kwargs):
@@ -876,7 +872,7 @@ def get_dependencies(name, environ):
 
 
 def canonicalize_env(env):
-    """Windows requires that environment be dicts with bytes as keys and values
+    """Windows requires that environment be dicts with str as keys and values
     This function converts any unicode entries for Windows only, returning the
     dictionary untouched in other environments.
 
@@ -888,7 +884,7 @@ def canonicalize_env(env):
     Returns
     -------
     env : dict
-        Windows: environment dictionary with bytes keys and values
+        Windows: environment dictionary with str keys and values
         Other: untouched input ``env``
     """
     if os.name != "nt":
@@ -896,10 +892,10 @@ def canonicalize_env(env):
 
     out_env = {}
     for key, val in env.items():
-        if not isinstance(key, bytes):
-            key = key.encode("utf-8")
-        if not isinstance(val, bytes):
-            val = val.encode("utf-8")
+        if not isinstance(key, str):
+            key = key.decode("utf-8")
+        if not isinstance(val, str):
+            val = val.decode("utf-8")
         out_env[key] = val
     return out_env
 


### PR DESCRIPTION
## Summary
Reading through #2509 and CPython's [_winapi.c](https://github.com/python/cpython/blob/e087f7cd43dfa4223c55a8ecd71f4a7d685178e4/Modules/_winapi.c#L801-L805), it looks like we actually want to pass `dict`s of `str`, rather than `bytes`.

```C
        if (! PyUnicode_Check(key) || ! PyUnicode_Check(value)) {
            PyErr_SetString(PyExc_TypeError,
                "environment can only contain strings");
            goto error;
        }
```

Fixes #2509.

## List of changes proposed in this PR (pull-request)

* Fix canonicalize to str
* Pass canonicalized env to Popen in `version_from_command()`

This last is deprecated and shouldn't be getting called, but NiftyReg still uses it, so that's a separate task.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
