### PR TITLE
FIX: Purge deprecated exception content accesses

### DIFF
--- a/nipype/interfaces/base/tests/test_specs.py
+++ b/nipype/interfaces/base/tests/test_specs.py
@@ -183,7 +183,7 @@ def test_deprecation():
         except nib.TraitError:
             not_raised = False
         assert not_raised
-        assert len(w) == 1, "deprecated warning 1 %s" % [w1.message for w1 in w]
+        assert len(w) == 1, f"deprecated warning 1 {[str(w1) for w1 in w]}"
 
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings("always", "", UserWarning)
@@ -201,7 +201,7 @@ def test_deprecation():
         assert not_raised
         assert spec_instance.foo == Undefined
         assert spec_instance.bar == 1
-        assert len(w) == 1, "deprecated warning 2 %s" % [w1.message for w1 in w]
+        assert len(w) == 1, f"deprecated warning 2 {[str(w1) for w1 in w]}"
 
 
 def test_namesource(setup_file):

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -1010,11 +1010,8 @@ class S3DataGrabber(LibraryBaseInterface, IOBase):
                         try:
                             filledtemplate = template % tuple(argtuple)
                         except TypeError as e:
-                            raise TypeError(
-                                e.message
-                                + ": Template %s failed to convert with args %s"
-                                % (template, str(tuple(argtuple)))
-                            )
+                            raise TypeError(f"{e}: Template {template} failed to convert "
+                                            f"with args {tuple(argtuple)}")
                     outfiles = []
                     for fname in bkt_files:
                         if re.match(filledtemplate, fname):
@@ -1286,11 +1283,8 @@ class DataGrabber(IOBase):
                         try:
                             filledtemplate = template % tuple(argtuple)
                         except TypeError as e:
-                            raise TypeError(
-                                e.message
-                                + ": Template %s failed to convert with args %s"
-                                % (template, str(tuple(argtuple)))
-                            )
+                            raise TypeError(f"{e}: Template {template} failed to convert "
+                                            f"with args {tuple(argtuple)}")
                     outfiles = glob.glob(filledtemplate)
                     if len(outfiles) == 0:
                         msg = "Output key: %s Template: %s returned no files" % (
@@ -2664,11 +2658,8 @@ class SSHDataGrabber(LibraryBaseInterface, DataGrabber):
                         try:
                             filledtemplate = template % tuple(argtuple)
                         except TypeError as e:
-                            raise TypeError(
-                                e.message
-                                + ": Template %s failed to convert with args %s"
-                                % (template, str(tuple(argtuple)))
-                            )
+                            raise TypeError(f"{e}: Template {template} failed to convert "
+                                            f"with args {tuple(argtuple)}")
 
                     outputs[key].append(self._get_files_over_ssh(filledtemplate))
 

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -439,7 +439,7 @@ def copyfile(
             fmlogger.debug("Copying File: %s->%s", newfile, originalfile)
             shutil.copyfile(originalfile, newfile)
         except shutil.Error as e:
-            fmlogger.warning(e.message)
+            fmlogger.warning(str(e))
 
     # Associated files
     if copy_related_files:
@@ -870,10 +870,8 @@ def get_dependencies(name, environ):
         o, e = proc.communicate()
         deps = o.rstrip()
     except Exception as ex:
-        deps = '"%s" failed' % command
-        fmlogger.warning(
-            "Could not get dependencies of %s. Error:\n%s", name, ex.message
-        )
+        deps = f'{command!r} failed'
+        fmlogger.warning(f"Could not get dependencies of {name}s. Error:\n{ex}")
     return deps
 
 

--- a/nipype/utils/subprocess.py
+++ b/nipype/utils/subprocess.py
@@ -124,7 +124,7 @@ def run_command(runtime, output=None, timeout=0.01):
                 res = select.select(streams, [], [], timeout)
             except select.error as e:
                 iflogger.info(e)
-                if e[0] == errno.EINTR:
+                if e.errno == errno.EINTR:
                     return
                 else:
                     raise


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
Apparently this was deprecated in Python 2.6 and we missed it. `BaseException.__str__` is the generic way to access messages.

Fixes #3270.

## List of changes proposed in this PR (pull-request)
* Remove uses of `BaseException.message; Update to `BaseException.__str__`
* Remove uses of `OSError.__getitem__`; Update to `OSError.errno`

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
