### PR TITLE
handle unavailable traits due to version differences

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -31,7 +31,7 @@ from ...utils.subprocess import run_command
 
 from ...external.due import due
 
-from .traits_extension import traits, isdefined
+from .traits_extension import traits, isdefined, Undefined
 from .specs import (
     BaseInterfaceInputSpec,
     CommandLineInputSpec,
@@ -371,8 +371,10 @@ class BaseInterface(Interface):
 
         enable_rm = config.resource_monitor and self.resource_monitor
         self.inputs.trait_set(**inputs)
+        unavailable_traits = self._check_version_requirements(self.inputs)
+        if unavailable_traits:
+            self.inputs.traitset(**{k: Undefined for k in unavailable_traits})
         self._check_mandatory_inputs()
-        self._check_version_requirements(self.inputs)
         interface = self.__class__
         self._duecredit_cite()
 

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -272,6 +272,46 @@ def test_input_version_missing_error():
             obj._check_version_requirements(obj.inputs)
 
 
+def test_unavailable_input():
+    class WithInput(nib.BaseInterface):
+        class input_spec(nib.TraitedSpec):
+            foo = nib.traits.Int(3, usedefault=True, max_ver="0.5")
+
+        _version = "0.4"
+
+        def _run_interface(self, runtime):
+            return runtime
+
+    class WithoutInput(WithInput):
+        _version = "0.6"
+
+    has = WithInput()
+    hasnt = WithoutInput()
+    trying_anyway = WithoutInput(foo=3)
+    assert has.inputs.foo == 3
+    assert not nib.isdefined(hasnt.inputs.foo)
+    assert trying_anyway.inputs.foo == 3
+
+    has.run()
+    hasnt.run()
+    with pytest.raises(Exception):
+        trying_anyway.run()
+
+    # Still settable
+    has.inputs.foo = 4
+    hasnt.inputs.foo = 4
+    trying_anyway.inputs.foo = 4
+    assert has.inputs.foo == 4
+    assert hasnt.inputs.foo == 4
+    assert trying_anyway.inputs.foo == 4
+
+    has.run()
+    with pytest.raises(Exception):
+        hasnt.run()
+    with pytest.raises(Exception):
+        trying_anyway.run()
+
+
 def test_output_version():
     class InputSpec(nib.TraitedSpec):
         foo = nib.traits.Int(desc="a random int")

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -245,14 +245,12 @@ def test_input_version_missing(caplog):
 
         _version = "misparsed-garbage"
 
-    with caplog.at_level(logging.WARNING, logger="nipype.interface"):
-        obj = DerivedInterface()
-    assert len(caplog.records) == 2
+    obj = DerivedInterface()
     obj.inputs.foo = 1
     obj.inputs.bar = 1
     with caplog.at_level(logging.WARNING, logger="nipype.interface"):
         obj._check_version_requirements(obj.inputs)
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 2
 
 
 def test_input_version_missing_error(caplog):
@@ -265,17 +263,15 @@ def test_input_version_missing_error(caplog):
 
         _version = "misparsed-garbage"
 
-    with caplog.at_level(logging.WARNING, logger="nipype.interface"):
-        obj1 = DerivedInterface(foo=1)
-        obj2 = DerivedInterface(bar=1)
-    assert len(caplog.records) == 4
+    obj1 = DerivedInterface(foo=1)
+    obj2 = DerivedInterface(bar=1)
     with caplog.at_level(logging.WARNING, logger="nipype.interface"):
         with mock.patch.object(config, "getboolean", return_value=True):
             with pytest.raises(ValueError):
                 obj1._check_version_requirements(obj1.inputs)
             with pytest.raises(ValueError):
                 obj2._check_version_requirements(obj2.inputs)
-    assert len(caplog.records) == 6
+    assert len(caplog.records) == 2
 
 
 def test_unavailable_input():

--- a/nipype/interfaces/tests/test_io.py
+++ b/nipype/interfaces/tests/test_io.py
@@ -465,7 +465,7 @@ def test_datasink_substitutions(tmpdir):
         files.append(f)
         open(f, "w")
     ds = nio.DataSink(
-        parametrization=False,
+        parameterization=False,
         base_directory=str(outdir),
         substitutions=[("ababab", "ABABAB")],
         # end archoring ($) is used to assure operation on the filename


### PR DESCRIPTION
## Summary

This turns all unavailable traits to undefined at runtime, and switches the order of checks. i'm not sure run is the best place for this yet.

Needs tests. @salma1601 and @effigies let's use this to see if we can address this. 

Fixes #3138 .

## List of changes proposed in this PR (pull-request)
- Make unavailable traits undefined

## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
