### PR TITLE
REL: 1.6.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -407,6 +407,16 @@
       "name": "Welch, David"
     },
     {
+      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
+      "name": "Waller, Lea",
+      "orcid": "0000-0002-3239-6957"
+    },
+    {
+      "affiliation": "Max Planck Institute for Human Cognitive and Brain Sciences",
+      "name": "Contier, Oliver",
+      "orcid": "0000-0002-2983-4709"
+    },
+    {
       "affiliation": "Department of Psychology, Stanford University",
       "name": "Triplett, William",
       "orcid": "0000-0002-9546-1306"
@@ -487,16 +497,15 @@
       "name": "Perkins, L. Nathan"
     },
     {
-      "affiliation": "Max Planck Institute for Human Cognitive and Brain Sciences",
-      "name": "Contier, Oliver",
-      "orcid": "0000-0002-2983-4709"
-    },
-    {
       "name": "Zhou, Dale"
     },
     {
       "name": "Bielievtsov, Dmytro",
       "orcid": "0000-0003-3846-7696"
+    },
+    {
+      "affiliation": "Sagol School of Neuroscience, Tel Aviv University",
+      "name": "Ben-Zvi, Gal"
     },
     {
       "affiliation": "University of Newcastle, Australia",
@@ -512,11 +521,6 @@
       "affiliation": "German Institute for International Educational Research",
       "name": "Linkersd\u00f6rfer, Janosch",
       "orcid": "0000-0002-1577-1233"
-    },
-    {
-      "affiliation": "Charite Universitatsmedizin Berlin, Germany",
-      "name": "Waller, Lea",
-      "orcid": "0000-0002-3239-6957"
     },
     {
       "name": "Renfro, Mandy"
@@ -564,6 +568,11 @@
       "affiliation": "Max Planck Research Group for Neuroanatomy & Connectivity, Max Planck Institute for Human Cognitive and Brain Sciences, Leipzig, Germany",
       "name": "Margulies, Daniel S.",
       "orcid": "0000-0002-8880-9204"
+    },
+    {
+      "affiliation": "CNRS, UMS3552 IRMaGe",
+      "name": "Condamine, Eric",
+      "orcid": "0000-0002-9533-3769"
     },
     {
       "affiliation": "Dartmouth College",
@@ -635,11 +644,6 @@
       "name": "Ort, Eduard"
     },
     {
-      "affiliation": "CNRS, UMS3552 IRMaGe",
-      "name": "Condamine, Eric",
-      "orcid": "0000-0002-9533-3769"
-    },
-    {
       "affiliation": "Stanford University",
       "name": "Lerma-Usabiaga, Garikoitz",
       "orcid": "0000-0001-9800-4816"
@@ -696,10 +700,6 @@
     {
       "affiliation": "Sagol School of Neuroscience, Tel Aviv University",
       "name": "Baratz, Zvi"
-    },
-    {
-      "affiliation": "Sagol School of Neuroscience, Tel Aviv University",
-      "name": "Ben-Zvi, Gal"
     },
     {
       "name": "Matsubara, K"

--- a/doc/changelog/1.X.X-changelog.rst
+++ b/doc/changelog/1.X.X-changelog.rst
@@ -1,3 +1,26 @@
+1.6.0 (November 27, 2020)
+=========================
+
+New feature release in the 1.6.x series.
+
+In addition to the usual bug fixes, significant reductions were made
+in workflow startup costs.
+
+(`Full changelog <https://github.com/nipy/nipype/milestone/1.6.0?closed=1>`__)
+
+  * FIX: Canonicalize environment dicts to strings in Windows (https://github.com/nipy/nipype/pull/3267)
+  * FIX: Purge deprecated exception content accesses (https://github.com/nipy/nipype/pull/3272)
+  * FIX: Handle changes in CLI structure of mrtrix3.DWIBiasCorrect (https://github.com/nipy/nipype/pull/3248)
+  * FIX: EpiReg changed to not list certain outputs when 'wmseg' input is specified (https://github.com/nipy/nipype/pull/3265)
+  * FIX: CI issues (https://github.com/nipy/nipype/pull/3262)
+  * FIX: SPM SliceTiming must accept either Int or float for ref_slice and sli… (https://github.com/nipy/nipype/pull/3255)
+  * FIX: Raise version error when using ``-g`` with ``antsAI`` < 2.3.0 (https://github.com/nipy/nipype/pull/3256)
+  * FIX: No longer depending on pydotplus (networkx >=2.0 update) (https://github.com/nipy/nipype/pull/3251)
+  * FIX: ANTs' utilities revision - bug fixes and add more operations to ``ants.ImageMath`` (https://github.com/nipy/nipype/pull/3236)
+  * ENH: Handle unavailable traits due to version differences (https://github.com/nipy/nipype/pull/3273)
+  * ENH: Optimize workflow.run performance (https://github.com/nipy/nipype/pull/3260)
+  * DOC: Remove myself (@mr-c) from the zenodo metadata (https://github.com/nipy/nipype/pull/3271)
+
 1.5.1 (August 16, 2020)
 =======================
 

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -5,7 +5,7 @@ docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 
 # nipype version information
 # Remove -dev for release
-__version__ = "1.6.0-dev"
+__version__ = "1.6.0"
 
 
 def get_nipype_gitversion():


### PR DESCRIPTION
## Summary

Release prep for 1.6.0. No specific timeline.

Remaining issues/PRs:

* [x] FIX: Canonicalize environment dicts to strings in Windows #3267
* [x] Bad version check for NiftyReg #3268

## Release checklist

* [x] Merge pending PRs
* [x] Update changelog
* [x] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py`
* [x] Update `doc/interfaces.rst` with previous releases
* [x] Check conda-forge feedstock build (https://github.com/conda-forge/nipype-feedstock/pull/74)
* [x] Tutorial tests (https://github.com/miykael/nipype_tutorial/pull/163)

## Uncredited authors

Going to skip this. Many releases of no responses suggest I'm just spamming at this point. @satra has also suggested paring down the authors to more recently active contributors.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.