### PR TITLE
MNT: Drop support for numpy < 1.15.3

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -100,10 +100,9 @@ existing pipeline systems.
 # versions
 NIBABEL_MIN_VERSION = "2.1.0"
 NETWORKX_MIN_VERSION = "2.0"
-NUMPY_MIN_VERSION = "1.13"
 # Numpy bug in python 3.7:
 # https://www.opensourceanswers.com/blog/you-shouldnt-use-python-37-for-data-science-right-now.html
-NUMPY_MIN_VERSION_37 = "1.15.3"
+NUMPY_MIN_VERSION = "1.15.3"
 SCIPY_MIN_VERSION = "0.14"
 TRAITS_MIN_VERSION = "4.6"
 DATEUTIL_MIN_VERSION = "2.2"
@@ -138,8 +137,7 @@ REQUIRES = [
     "click>=%s" % CLICK_MIN_VERSION,
     "networkx>=%s" % NETWORKX_MIN_VERSION,
     "nibabel>=%s" % NIBABEL_MIN_VERSION,
-    'numpy>=%s ; python_version < "3.7"' % NUMPY_MIN_VERSION,
-    'numpy>=%s ; python_version >= "3.7"' % NUMPY_MIN_VERSION_37,
+    'numpy>=%s' % NUMPY_MIN_VERSION,
     "packaging",
     "prov>=%s" % PROV_VERSION,
     "pydot>=%s" % PYDOT_MIN_VERSION,


### PR DESCRIPTION
## Summary

We forgot to drop support for numpy < 1.14 for the last minor release, but the next [NEP29+1y](https://github.com/nipy/nibabel/issues/803) milestone is Jan 7 2021, and I doubt we'll have a minor release before then. This drops support for <1.15.3, which means we can drop our split between 3.6 and 3.7+ dependencies.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
