### PR TITLE
CI: Build docker images with Python 3.8

### DIFF
--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -87,7 +87,7 @@ function generate_main_dockerfile() {
     --label maintainer="The nipype developers https://github.com/nipy/nipype" \
     --env MKL_NUM_THREADS=1 \
           OMP_NUM_THREADS=1 \
-    --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=6 BUILD_DATE VCS_REF VERSION \
+    --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 BUILD_DATE VCS_REF VERSION \
     --user neuro \
     --workdir /home/neuro \
     --miniconda create_env=neuro \


### PR DESCRIPTION
Circle tests are failing because h5py no longer builds wheels for Python 3.6, and our docker images are not equipped to build the wheels. Python 3.6 is on its way out, so upgrading to Python 3.8.

Or should I target 3.9?