### PR TITLE
FIX: Restore generate_gantt_chart functionality

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -789,6 +789,11 @@
       "name": "Tambini, Arielle"
     },
     {
+      "affiliation": "Child Mind Institute",
+      "name": "Clucas, Jon",
+      "orcid": "0000-0001-7590-5806"
+    },
+    {
       "affiliation": "Weill Cornell Medicine",
       "name": "Xie, Xihe",
       "orcid": "0000-0001-6595-2473"

--- a/nipype/pipeline/plugins/tests/test_callback.py
+++ b/nipype/pipeline/plugins/tests/test_callback.py
@@ -61,3 +61,36 @@ def test_callback_exception(tmpdir, plugin, stop_on_first_crash):
 
     sleep(0.5)  # Wait for callback to be called (python 2.7)
     assert so.statuses == [("f_node", "start"), ("f_node", "exception")]
+
+
+@pytest.mark.parametrize("plugin", ["Linear", "MultiProc", "LegacyMultiProc"])
+def test_callback_gantt(tmpdir, plugin):
+    import logging
+    import logging.handlers
+
+    from os import path
+
+    from nipype.utils.profiler import log_nodes_cb
+    from nipype.utils.draw_gantt_chart import generate_gantt_chart
+
+    log_filename = 'callback.log'
+    logger = logging.getLogger('callback')
+    logger.setLevel(logging.DEBUG)
+    handler = logging.FileHandler(log_filename)
+    logger.addHandler(handler)
+
+    #create workflow
+    wf = pe.Workflow(name="test", base_dir=tmpdir.strpath)
+    f_node = pe.Node(
+        niu.Function(function=func, input_names=[], output_names=[]), name="f_node"
+    )
+    wf.add_nodes([f_node])
+    wf.config["execution"] = {"crashdump_dir": wf.base_dir, "poll_sleep_duration": 2}
+
+    plugin_args = {"status_callback": log_nodes_cb}
+    if plugin != "Linear":
+        plugin_args['n_procs'] = 8
+    wf.run(plugin=plugin, plugin_args=plugin_args)
+
+    generate_gantt_chart('callback.log', 1 if plugin == "Linear" else 8)
+    assert path.exists('callback.log.html')

--- a/nipype/pipeline/plugins/tests/test_callback.py
+++ b/nipype/pipeline/plugins/tests/test_callback.py
@@ -73,13 +73,13 @@ def test_callback_gantt(tmpdir, plugin):
     from nipype.utils.profiler import log_nodes_cb
     from nipype.utils.draw_gantt_chart import generate_gantt_chart
 
-    log_filename = 'callback.log'
-    logger = logging.getLogger('callback')
+    log_filename = "callback.log"
+    logger = logging.getLogger("callback")
     logger.setLevel(logging.DEBUG)
     handler = logging.FileHandler(log_filename)
     logger.addHandler(handler)
 
-    #create workflow
+    # create workflow
     wf = pe.Workflow(name="test", base_dir=tmpdir.strpath)
     f_node = pe.Node(
         niu.Function(function=func, input_names=[], output_names=[]), name="f_node"
@@ -89,8 +89,8 @@ def test_callback_gantt(tmpdir, plugin):
 
     plugin_args = {"status_callback": log_nodes_cb}
     if plugin != "Linear":
-        plugin_args['n_procs'] = 8
+        plugin_args["n_procs"] = 8
     wf.run(plugin=plugin, plugin_args=plugin_args)
 
-    generate_gantt_chart('callback.log', 1 if plugin == "Linear" else 8)
-    assert path.exists('callback.log.html')
+    generate_gantt_chart("callback.log", 1 if plugin == "Linear" else 8)
+    assert path.exists("callback.log.html")

--- a/nipype/pipeline/plugins/tests/test_callback.py
+++ b/nipype/pipeline/plugins/tests/test_callback.py
@@ -73,7 +73,7 @@ def test_callback_gantt(tmpdir, plugin):
     from nipype.utils.profiler import log_nodes_cb
     from nipype.utils.draw_gantt_chart import generate_gantt_chart
 
-    log_filename = "callback.log"
+    log_filename = path.join(tmpdir, "callback.log")
     logger = logging.getLogger("callback")
     logger.setLevel(logging.DEBUG)
     handler = logging.FileHandler(log_filename)
@@ -92,5 +92,7 @@ def test_callback_gantt(tmpdir, plugin):
         plugin_args["n_procs"] = 8
     wf.run(plugin=plugin, plugin_args=plugin_args)
 
-    generate_gantt_chart("callback.log", 1 if plugin == "Linear" else 8)
-    assert path.exists("callback.log.html")
+    generate_gantt_chart(
+        path.join(tmpdir, "callback.log"), 1 if plugin == "Linear" else 8
+    )
+    assert path.exists(path.join(tmpdir, "callback.log.html"))

--- a/nipype/utils/draw_gantt_chart.py
+++ b/nipype/utils/draw_gantt_chart.py
@@ -292,7 +292,7 @@ def draw_nodes(start, nodes_list, cores, minute_scale, space_between_minutes, co
             "offset": offset,
             "scale_duration": scale_duration,
             "color": color,
-            "node_name": node["name"],
+            "node_name": node.get("name", node.get("id", "")),
             "node_dur": node["duration"] / 60.0,
             "node_start": node_start.strftime("%Y-%m-%d %H:%M:%S"),
             "node_finish": node_finish.strftime("%Y-%m-%d %H:%M:%S"),
@@ -512,6 +512,20 @@ def generate_gantt_chart(
 
     # Read in json-log to get list of node dicts
     nodes_list = log_to_dict(logfile)
+
+    # Only include nodes with timing information, and covert timestamps
+    # from strings to datetimes
+    nodes_list = [{
+        k: datetime.datetime.strptime(
+            i[k], "%Y-%m-%dT%H:%M:%S.%f"
+        ) if k in {"start", "finish"} else i[k] for k in i
+    } for i in nodes_list if "start" in i and "finish" in i]
+
+    for node in nodes_list:
+        if "duration" not in node:
+            node["duration"] = (
+                node["finish"] - node["start"]
+            ).total_seconds()
 
     # Create the header of the report with useful information
     start_node = nodes_list[0]

--- a/nipype/utils/draw_gantt_chart.py
+++ b/nipype/utils/draw_gantt_chart.py
@@ -138,13 +138,14 @@ def calculate_resource_timeseries(events, resource):
     all_res = 0.0
 
     # Iterate through the events
+    nan = {"Unknown", "N/A"}
     for _, event in sorted(events.items()):
         if event["event"] == "start":
-            if resource in event and event[resource] != "Unknown":
+            if resource in event and event[resource] not in nan:
                 all_res += float(event[resource])
             current_time = event["start"]
         elif event["event"] == "finish":
-            if resource in event and event[resource] != "Unknown":
+            if resource in event and event[resource] not in nan:
                 all_res -= float(event[resource])
             current_time = event["finish"]
         res[current_time] = all_res

--- a/nipype/utils/draw_gantt_chart.py
+++ b/nipype/utils/draw_gantt_chart.py
@@ -138,15 +138,20 @@ def calculate_resource_timeseries(events, resource):
     all_res = 0.0
 
     # Iterate through the events
-    nan = {"Unknown", "N/A"}
     for _, event in sorted(events.items()):
         if event["event"] == "start":
-            if resource in event and event[resource] not in nan:
-                all_res += float(event[resource])
+            if resource in event:
+                try:
+                    all_res += float(event[resource])
+                except ValueError:
+                    next
             current_time = event["start"]
         elif event["event"] == "finish":
-            if resource in event and event[resource] not in nan:
-                all_res -= float(event[resource])
+            if resource in event:
+                try:
+                    all_res -= float(event[resource])
+                except ValueError:
+                    next
             current_time = event["finish"]
         res[current_time] = all_res
 

--- a/nipype/utils/draw_gantt_chart.py
+++ b/nipype/utils/draw_gantt_chart.py
@@ -12,6 +12,7 @@ import datetime
 import simplejson as json
 
 from collections import OrderedDict
+from warnings import warn
 
 # Pandas
 try:
@@ -69,9 +70,9 @@ def create_event_dict(start_time, nodes_list):
         finish_delta = (node["finish"] - start_time).total_seconds()
 
         # Populate dictionary
-        if events.get(start_delta) or events.get(finish_delta):
+        if events.get(start_delta):
             err_msg = "Event logged twice or events started at exact same time!"
-            raise KeyError(err_msg)
+            warn(str(KeyError(err_msg)), category=Warning)
         events[start_delta] = start_node
         events[finish_delta] = finish_node
 

--- a/nipype/utils/draw_gantt_chart.py
+++ b/nipype/utils/draw_gantt_chart.py
@@ -517,17 +517,20 @@ def generate_gantt_chart(
 
     # Only include nodes with timing information, and covert timestamps
     # from strings to datetimes
-    nodes_list = [{
-        k: datetime.datetime.strptime(
-            i[k], "%Y-%m-%dT%H:%M:%S.%f"
-        ) if k in {"start", "finish"} else i[k] for k in i
-    } for i in nodes_list if "start" in i and "finish" in i]
+    nodes_list = [
+        {
+            k: datetime.datetime.strptime(i[k], "%Y-%m-%dT%H:%M:%S.%f")
+            if k in {"start", "finish"}
+            else i[k]
+            for k in i
+        }
+        for i in nodes_list
+        if "start" in i and "finish" in i
+    ]
 
     for node in nodes_list:
         if "duration" not in node:
-            node["duration"] = (
-                node["finish"] - node["start"]
-            ).total_seconds()
+            node["duration"] = (node["finish"] - node["start"]).total_seconds()
 
     # Create the header of the report with useful information
     start_node = nodes_list[0]


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #2982.

All tests pass locally. <sup>8</sup>/<sub>13</sub> jobs pass [on Travis](https://travis-ci.com/github/shnizzedy/nipype/builds/212518190). The Travis failures seem unrelated to the changes in this PR.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] Updates https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/utils/draw_gantt_chart.py#L391 to handle changes to profiler
   - [x] filter log file to [include only logged nodes with timing information](https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/utils/draw_gantt_chart.py#L528)
   - [x] [convert datetime strings to datetime objects](https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/utils/draw_gantt_chart.py#L522) before doing datetime math
   - [x] for nodes with timing information but no `name`, [use `id` or an empty string for `name`](https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/utils/draw_gantt_chart.py#L297) instead of crashing
   - [x] [warn if a node is suspected of being included twice instead of raising an exception](https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/utils/draw_gantt_chart.py#L74-L75)
   - [x] skip nodes with non-timestamp `start` and `finish` values like `"N/A"` and `"Unknown"`
       https://github.com/nipy/nipype/blob/a08ee57aa54868a6ce85f0799dfe4fd7cc00df3e/nipype/utils/draw_gantt_chart.py#L144-L147
       https://github.com/nipy/nipype/blob/a08ee57aa54868a6ce85f0799dfe4fd7cc00df3e/nipype/utils/draw_gantt_chart.py#L151-L154
- [x] Adds a test https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/nipype/pipeline/plugins/tests/test_callback.py#L66-L98 to make sure the Gantt chart HTML page generates without error
- [x] [Adds myself as a contributor to .zenodo.json](https://github.com/nipy/nipype/blob/fa65cafa83e937538827d8ba6ac6f32296711b82/.zenodo.json#L791-L795)

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
