### PR TITLE
FIX: BET raising "No image files match: ..." with very long file names

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -169,7 +169,8 @@ class BET(FSLCommand):
         out_file = self.inputs.out_file
         if not isdefined(out_file) and isdefined(self.inputs.in_file):
             out_file = self._gen_fname(self.inputs.in_file, suffix="_brain")
-        return op.relpath(out_file, start=os.getcwd())
+            return op.relpath(out_file, start=os.getcwd())
+        return out_file
 
     def _list_outputs(self):
         outputs = self.output_spec().get()

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -165,10 +165,21 @@ class BET(FSLCommand):
             self.raise_exception(runtime)
         return runtime
 
+    def _format_arg(self, name, spec, value):
+        formatted = super(BET, self)._format_arg(name, spec, value)
+        if name == "in_file":
+            # Convert to relative path to prevent BET failure
+            # with long paths.
+            return op.relpath(formatted, start=os.getcwd())
+        return formatted
+
     def _gen_outfilename(self):
         out_file = self.inputs.out_file
+        # Generate default output filename if non specified.
         if not isdefined(out_file) and isdefined(self.inputs.in_file):
             out_file = self._gen_fname(self.inputs.in_file, suffix="_brain")
+            # Convert to relative path to prevent BET failure
+            # with long paths.
             return op.relpath(out_file, start=os.getcwd())
         return out_file
 

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -169,11 +169,11 @@ class BET(FSLCommand):
         out_file = self.inputs.out_file
         if not isdefined(out_file) and isdefined(self.inputs.in_file):
             out_file = self._gen_fname(self.inputs.in_file, suffix="_brain")
-        return os.path.abspath(out_file)
+        return op.relpath(out_file, start=os.getcwd())
 
     def _list_outputs(self):
         outputs = self.output_spec().get()
-        outputs["out_file"] = self._gen_outfilename()
+        outputs["out_file"] = os.path.abspath(self._gen_outfilename())
 
         basename = os.path.basename(outputs["out_file"])
         cwd = os.path.dirname(outputs["out_file"])

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -35,6 +35,7 @@ class BETInputSpec(FSLCommandInputSpec):
         argstr="%s",
         position=0,
         mandatory=True,
+        copyfile=False,
     )
     out_file = File(
         desc="name of output skull stripped image",
@@ -1309,10 +1310,7 @@ class FNIRT(FSLCommand):
 
             if key == "out_intensitymap_file" and isdefined(outputs[key]):
                 basename = FNIRT.intensitymap_file_basename(outputs[key])
-                outputs[key] = [
-                    outputs[key],
-                    "%s.txt" % basename,
-                ]
+                outputs[key] = [outputs[key], "%s.txt" % basename]
         return outputs
 
     def _format_arg(self, name, spec, value):

--- a/nipype/interfaces/fsl/tests/test_preprocess.py
+++ b/nipype/interfaces/fsl/tests/test_preprocess.py
@@ -41,8 +41,7 @@ def test_bet(setup_infile):
     # Test generated outfile name
     better.inputs.in_file = tmp_infile
     outfile = fsl_name(better, "foo_brain")
-    outpath = os.path.join(os.getcwd(), outfile)
-    realcmd = "bet %s %s" % (tmp_infile, outpath)
+    realcmd = "bet %s %s" % (tmp_infile, outfile)
     assert better.cmdline == realcmd
     # Test specified outfile name
     outfile = fsl_name(better, "/newdata/bar")
@@ -79,12 +78,11 @@ def test_bet(setup_infile):
     # test each of our arguments
     better = fsl.BET()
     outfile = fsl_name(better, "foo_brain")
-    outpath = os.path.join(os.getcwd(), outfile)
     for name, settings in list(opt_map.items()):
         better = fsl.BET(**{name: settings[1]})
         # Add mandatory input
         better.inputs.in_file = tmp_infile
-        realcmd = " ".join([better.cmd, tmp_infile, outpath, settings[0]])
+        realcmd = " ".join([better.cmd, tmp_infile, outfile, settings[0]])
         assert better.cmdline == realcmd
 
 

--- a/nipype/interfaces/fsl/tests/test_preprocess.py
+++ b/nipype/interfaces/fsl/tests/test_preprocess.py
@@ -31,6 +31,9 @@ def setup_infile(tmpdir):
 @pytest.mark.skipif(no_fsl(), reason="fsl is not installed")
 def test_bet(setup_infile):
     tmp_infile, tp_dir = setup_infile
+    # BET converts the in_file path to be relative to prevent
+    # failure with long paths.
+    tmp_infile = os.path.relpath(tmp_infile, start=os.getcwd())
     better = fsl.BET()
     assert better.cmd == "bet"
 


### PR DESCRIPTION
Trying to fix #3211.
@satra or @oesteban, I'll try a couple of things and see if it works, but I'm not confident if I completely understood:

> 2. make the output filename be local (no absolute path) for generation, but not for list_outputs.

If you could help clarify how exactly this would be best implemented, I would be happy to update the PR and hopefully resolve this issue.

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.