### PR TITLE
FIX: Update SmoothEstimateOutputSpec resels description

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -1886,7 +1886,7 @@ class SmoothEstimateInputSpec(FSLCommandInputSpec):
 class SmoothEstimateOutputSpec(TraitedSpec):
     dlh = traits.Float(desc="smoothness estimate sqrt(det(Lambda))")
     volume = traits.Int(desc="number of voxels in mask")
-    resels = traits.Float(desc="number of resels")
+    resels = traits.Float(desc="number of voxels per resel")
 
 
 class SmoothEstimate(FSLCommand):

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -1886,7 +1886,7 @@ class SmoothEstimateInputSpec(FSLCommandInputSpec):
 class SmoothEstimateOutputSpec(TraitedSpec):
     dlh = traits.Float(desc="smoothness estimate sqrt(det(Lambda))")
     volume = traits.Int(desc="number of voxels in mask")
-    resels = traits.Float(desc="number of voxels per resel")
+    resels = traits.Float(desc="volume of resel, in voxels, defined as FWHM_x * FWHM_y * FWHM_z")
 
 
 class SmoothEstimate(FSLCommand):


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
As mentioned previously (https://github.com/poldracklab/ds003-post-fMRIPrep-analysis/issues/7), the `resels` output of FSL's smoothest refers to the size of a resel, not the *number of resels*. 


## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
I propose to update the output spec to avoid misunderstandings.

## Acknowledgment
- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
