### PR TITLE
[FIX] change fsl interface randomise --f_only to --fonly for #3322

### DIFF
--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -2245,7 +2245,7 @@ class RandomiseInputSpec(FSLCommandInputSpec):
         desc=("carry out Threshold-Free Cluster Enhancement with 2D " "optimisation"),
         argstr="--T2",
     )
-    f_only = traits.Bool(desc="calculate f-statistics only", argstr="--f_only")
+    f_only = traits.Bool(desc="calculate f-statistics only", argstr="--fonly")
     raw_stats_imgs = traits.Bool(
         desc="output raw ( unpermuted ) statistic images", argstr="-R"
     )

--- a/nipype/interfaces/fsl/tests/test_auto_Randomise.py
+++ b/nipype/interfaces/fsl/tests/test_auto_Randomise.py
@@ -37,7 +37,7 @@ def test_Randomise_inputs():
             argstr="-S %.2f",
         ),
         f_only=dict(
-            argstr="--f_only",
+            argstr="--fonly",
         ),
         fcon=dict(
             argstr="-f %s",


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3322.

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
- corrects typo in fsl randomise interface for running only f-tests.

## Acknowledgment

- [ x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
