### PR TITLE
[DOC] Fixed Developer Setup Link in install.rst

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -807,6 +807,9 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "name": "Jalan, Raunak",
     }
   ],
   "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -799,6 +799,9 @@
       "orcid": "0000-0001-5715-6442"
     },
     {
+      "name": "Jalan, Raunak",
+    },
+    {
       "affiliation": "Department of Psychology, Stanford University",
       "name": "Gorgolewski, Krzysztof J.",
       "orcid": "0000-0003-3321-7583"
@@ -807,9 +810,6 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    },
-    {
-      "name": "Jalan, Raunak",
     }
   ],
   "keywords": [

--- a/doc/users/install.rst
+++ b/doc/users/install.rst
@@ -116,7 +116,7 @@ NeuroDocker_.
 Installation for developers
 ---------------------------
 
-Developers should start `here <../devel/testing_nipype.html>`_.
+Developers should start `here <../devel/testing_nipype.rst>`_.
 
 Developers can also use this docker container: `docker pull nipype/nipype:master`
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Changed the link for developer setup in install.rst to make it working. Previously showing Error 404.
Now the link is working and redirecting to appropriate page.

![Developer Install Page](https://user-images.githubusercontent.com/41023976/115732644-277dc180-a356-11eb-9deb-19ecb14d86c3.png)

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * o
Fixes #r -) and filled checkboxes [x] here -->
* [x] Change link of developer setup to <../devel/testing_nipype.rst> instead of <../devel/testing_nipype.html>


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
