### PR TITLE
[REF] Cache nodes in workflow to speed up construction, other optimizations

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1100,11 +1100,12 @@ def generate_expanded_graph(graph_in):
             old_edge_dict = jedge_dict[jnode]
             # the edge source node replicates
             expansions = defaultdict(list)
-            for node in graph_in.nodes():
+            for node in graph_in:
                 for src_id in list(old_edge_dict.keys()):
                     # Drop the original JoinNodes; only concerned with
                     # generated Nodes
-                    if hasattr(node, "joinfield") and node.itername == src_id:
+                    itername = node.itername
+                    if hasattr(node, "joinfield") and itername == src_id:
                         continue
                     # Patterns:
                     #   - src_id : Non-iterable node
@@ -1113,10 +1114,12 @@ def generate_expanded_graph(graph_in):
                     #   - src_id.[a-z]I.[a-z]\d+ :
                     #       Non-IdentityInterface w/ iterables
                     #   - src_idJ\d+ : JoinNode(IdentityInterface)
-                    if re.match(
-                        src_id + r"((\.[a-z](I\.[a-z])?|J)\d+)?$", node.itername
-                    ):
-                        expansions[src_id].append(node)
+                    if itername.startswith(src_id):
+                        itername = itername[len(src_id):]
+                        if re.fullmatch(
+                            r"((\.[a-z](I\.[a-z])?|J)\d+)?", itername
+                        ):
+                            expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug(
                     "The join node %s input %s was expanded" " to %d nodes.",

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -753,7 +753,7 @@ def _merge_graphs(
     # nodes of the supergraph.
     supernodes = supergraph.nodes()
     ids = [n._hierarchy + n._id for n in supernodes]
-    if len(np.unique(ids)) != len(ids):
+    if len(set(ids)) != len(ids):
         # This should trap the problem of miswiring when multiple iterables are
         # used at the same level. The use of the template below for naming
         # updates to nodes is the general solution.

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -1115,10 +1115,8 @@ def generate_expanded_graph(graph_in):
                     #       Non-IdentityInterface w/ iterables
                     #   - src_idJ\d+ : JoinNode(IdentityInterface)
                     if itername.startswith(src_id):
-                        itername = itername[len(src_id):]
-                        if re.fullmatch(
-                            r"((\.[a-z](I\.[a-z])?|J)\d+)?", itername
-                        ):
+                        suffix = itername[len(src_id):]
+                        if re.fullmatch(r"((\.[a-z](I\.[a-z])?|J)\d+)?", suffix):
                             expansions[src_id].append(node)
             for in_id, in_nodes in list(expansions.items()):
                 logger.debug(

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -333,7 +333,7 @@ connected.
         newnodes = []
         all_nodes = self._get_all_nodes()
         for node in nodes:
-            if self._has_node(node):
+            if node in all_nodes:
                 raise IOError("Node %s already exists in the workflow" % node)
             if isinstance(node, Workflow):
                 for subnode in node._get_all_nodes():

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -970,7 +970,7 @@ connected.
             raise Exception(
                 ("Workflow: %s is not a directed acyclic graph " "(DAG)") % self.name
             )
-        nodes = list(nx.topological_sort(self._graph))
+        nodes = list(self._graph.nodes)
         for node in nodes:
             logger.debug("processing node: %s", node)
             if isinstance(node, Workflow):

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -912,10 +912,12 @@ connected.
         return allnodes
 
     def _has_node(self, wanted_node):
-        for node in self._graph.nodes():
+        if wanted_node in self._graph:
+            return True  # best case scenario
+        for node in self._graph:  # iterate otherwise
             if wanted_node == node:
                 return True
-            if isinstance(node, Workflow):
+            if hasattr(node, "_has_node"):  # hasattr is faster than isinstance
                 if node._has_node(wanted_node):
                     return True
         return False

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -144,7 +144,7 @@ class Workflow(EngineBase):
             self.disconnect(connection_list)
             return
 
-        newnodes = []
+        newnodes = set()
         for srcnode, destnode, _ in connection_list:
             if self in [srcnode, destnode]:
                 msg = (
@@ -154,9 +154,9 @@ class Workflow(EngineBase):
 
                 raise IOError(msg)
             if (srcnode not in newnodes) and not self._has_node(srcnode):
-                newnodes.append(srcnode)
+                newnodes.add(srcnode)
             if (destnode not in newnodes) and not self._has_node(destnode):
-                newnodes.append(destnode)
+                newnodes.add(destnode)
         if newnodes:
             self._check_nodes(newnodes)
             for node in newnodes:

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -166,15 +166,16 @@ class Workflow(EngineBase):
         connected_ports = {}
         for srcnode, destnode, connects in connection_list:
             if destnode not in connected_ports:
-                connected_ports[destnode] = []
+                connected_ports[destnode] = set()
             # check to see which ports of destnode are already
             # connected.
             if not disconnect and (destnode in self._graph.nodes()):
                 for edge in self._graph.in_edges(destnode):
                     data = self._graph.get_edge_data(*edge)
-                    for sourceinfo, destname in data["connect"]:
-                        if destname not in connected_ports[destnode]:
-                            connected_ports[destnode] += [destname]
+                    connected_ports[destnode].update(
+                        destname
+                        for _, destname in data["connect"]
+                    )
             for source, dest in connects:
                 # Currently datasource/sink/grabber.io modules
                 # determine their inputs/outputs depending on
@@ -229,7 +230,7 @@ connected.
                         )
                     if sourcename and not srcnode._check_outputs(sourcename):
                         not_found.append(["out", srcnode.name, sourcename])
-                connected_ports[destnode] += [dest]
+                connected_ports[destnode].add(dest)
         infostr = []
         for info in not_found:
             infostr += [

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -913,11 +913,9 @@ connected.
         node.set_input(param, deepcopy(newval))
 
     def _get_all_nodes(self):
-        allnodes = [
-            *self._nodes_cache.difference(self._nested_workflows_cache)
-        ]  # all nodes that are not workflows
+        allnodes = self._nodes_cache - self._nested_workflows_cache
         for node in self._nested_workflows_cache:
-            allnodes.extend(node._get_all_nodes())
+            allnodes |= node._get_all_nodes()
         return allnodes
 
     def _update_node_cache(self):

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -932,12 +932,13 @@ connected.
                 self._nested_workflows_cache.add(node)
 
     def _has_node(self, wanted_node):
-        if wanted_node in self._nodes_cache:
-            return True
-        for node in self._nested_workflows_cache:
-            if node._has_node(wanted_node):
-                return True
-        return False
+        return (
+            wanted_node in self._nodes_cache or
+            any(
+                wf._has_node(wanted_node)
+                for wf in self._nested_workflows_cache
+            )
+        )
 
     def _create_flat_graph(self):
         """Make a simple DAG where no node is a workflow."""

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -273,7 +273,8 @@ connected.
                 "(%s, %s): new edge data: %s", srcnode, destnode, str(edge_data)
             )
 
-        self._update_node_cache()
+        if newnodes:
+            self._update_node_cache()
 
     def disconnect(self, *args):
         """Disconnect nodes
@@ -319,8 +320,6 @@ connected.
                 self._graph.remove_edge(srcnode, dstnode)
             else:
                 self._graph.add_edges_from([(srcnode, dstnode, edge_data)])
-
-        self._update_node_cache()
 
     def add_nodes(self, nodes):
         """ Add nodes to a workflow


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

I'm working with fMRIPrep and large data sets (via the ENIGMA consortium). In my testing, Nipype workflows with more than a few hundred thousand nodes can be prohibitively slow, so that it can take days before processing starts. This comes specifically from the function `_generate_flatgraph` and `generate_expanded_graph`. While my previous pull requests #3184 and #3260 fixed some bottlenecks, I recently had the time to do some more profiling and try to fix some more. 
I understand that Pydra is just around the corner, and that switching to it may solve my performance troubles then. However, the small changes outlined here can reduce the time before processing starts by approximately half (in my testing with a workflow of 75k nodes). 
I have tried to divide up the changes into independent commits, so that you can decide which ones may be interesting for inclusion.

Here is my profile before starting out. Please not that the absolute durations are not interpretable, because the profiler reduces performance by a lot.
<img width="1457" alt="2021-04-30_13-04" src="https://user-images.githubusercontent.com/789054/116693869-c17ce400-a9be-11eb-9e07-9f52e64e3018.png">

Here is the profile with all proposed changes. Note that `_create_flat_graph` has become the dark gray box without caption on the bottom right.
<img width="1457" alt="2021-04-30_14-16" src="https://user-images.githubusercontent.com/789054/116693806-b32ec800-a9be-11eb-82f3-8922a5d9ade8.png">

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- The `workflow._has_node` function is called for every new connection, and currently iterates through all nodes in the workflow and nested workflows. It then compares each node to the `wanted_node`. We can speed this up, because `networkx` graphs are dictionaries and have support the `in` statement. This way we can reduce the scaling behavior from linear to almost constant time, but only in the best-case scenario that the `wanted_node` is in the workflow. 
Otherwise, we still need to iterate to find all nested workflows. To overcome this last limitations, we can cache the nested workflows in a set, and update it whenever the graph is changes.
https://github.com/nipy/nipype/blob/4e8f54d8e304dd940cfdc5d42f37288651bc8a03/nipype/pipeline/engine/workflows.py#L906-L913

- The `_merge_graphs` function uses `np.unique` for a list of strings. We can use the built-in `set` to avoid casting to Numpy array. `np.unique` additionally sorts the input array, which we really don't need here
https://github.com/nipy/nipype/blob/4e8f54d8e304dd940cfdc5d42f37288651bc8a03/nipype/pipeline/engine/utils.py#L756

- Use sets wherever order is not important and we just need to check whether a string or a node is contained or not, again reducing linear scaling to a constant time look-up.
https://github.com/nipy/nipype/blob/4e8f54d8e304dd940cfdc5d42f37288651bc8a03/nipype/pipeline/engine/workflows.py#L173-L174

- Remove a topological sort that may not be necessary. Please correct me if I'm wrong :-)
https://github.com/nipy/nipype/blob/4e8f54d8e304dd940cfdc5d42f37288651bc8a03/nipype/pipeline/engine/workflows.py#L942

- Avoid re-compiling regular expressions in a loop by using Python's built-in functions
https://github.com/nipy/nipype/blob/4e8f54d8e304dd940cfdc5d42f37288651bc8a03/nipype/pipeline/engine/utils.py#L1114-L1116

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
