### PR TITLE
MNT: Blacklist Dipy 1.4.1

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -162,7 +162,7 @@ TESTS_REQUIRES = [
 EXTRA_REQUIRES = {
     "data": ["datalad"],
     "doc": [
-        "dipy",
+        "dipy!=1.4.1",
         "ipython",
         "matplotlib",
         "nbsphinx",
@@ -172,7 +172,7 @@ EXTRA_REQUIRES = {
         "sphinxcontrib-napoleon",
     ],
     "duecredit": ["duecredit"],
-    "nipy": ["nitime", "nilearn", "dipy", "nipy", "matplotlib"],
+    "nipy": ["nitime", "nilearn", "dipy!=1.4.1", "nipy", "matplotlib"],
     "profiler": ["psutil>=5.0"],
     "pybids": ["pybids>=0.7.0"],
     "specs": ["black"],


### PR DESCRIPTION
## Summary
CI is failing because dipy 1.4.1 is incompatible with our conversion script.

See https://github.com/dipy/dipy/issues/2402 for more details.

## List of changes proposed in this PR (pull-request)
* Avoid installing dipy 1.4.1

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
