### PR TITLE
FIX: Set DistributedPluginBase.refidx type correctly

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -417,14 +417,10 @@ class DistributedPluginBase(PluginBase):
         import networkx as nx
 
         self.procs, _ = topological_sort(graph)
-        try:
-            self.depidx = nx.to_scipy_sparse_matrix(
-                graph, nodelist=self.procs, format="lil"
-            )
-        except:
-            self.depidx = nx.to_scipy_sparse_matrix(graph, nodelist=self.procs)
-        self.refidx = deepcopy(self.depidx)
-        self.refidx.astype = np.int
+        self.depidx = nx.to_scipy_sparse_matrix(
+            graph, nodelist=self.procs, format="lil"
+        )
+        self.refidx = self.depidx.astype(int)
         self.proc_done = np.zeros(len(self.procs), dtype=bool)
         self.proc_pending = np.zeros(len(self.procs), dtype=bool)
 


### PR DESCRIPTION
## Summary

In 39c4ee391baf9fb3bd3093a7b4b8db63ad26ac4e, we had

```Diff
     def _generate_dependency_list(self, graph):
         """ Generates a dependency list for a list of graphs.
         """
         self.procs = graph.nodes()
-        self.depidx = nx.adj_matrix(graph).__array__()
-        self.refidx = deepcopy(self.depidx>0)
-        self.refidx.dtype = np.int8
+        self.depidx = ssp.lil_matrix(nx.adj_matrix(graph).__array__())
+        self.refidx = deepcopy(self.depidx)
+        self.refidx.astype = np.int
         self.proc_done    = np.zeros(len(self.procs), dtype=bool)
         self.proc_pending = np.zeros(len(self.procs), dtype=bool)
```

This looks like a typo, that should have been `self.refidx = deepcopy(self.depidx).astype(np.int)` or similar.

In this PR, I simply use `self.depidx.astype(int)`. [`scipy.sparse.lil_matrix.astype`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.lil_matrix.astype.html) copies by default.

Found while removing a deprecated call to `np.int`.

I also remove a guard for networkx versions that were old in 2012: b908b84706b24a360dde1ec25c738e8aec81caa6