### PR TITLE
MNT: Remove deprecated np.float usage

### DIFF
--- a/nipype/algorithms/modelgen.py
+++ b/nipype/algorithms/modelgen.py
@@ -383,7 +383,7 @@ None])
         for i, info in enumerate(infolist):
             sessinfo.insert(i, dict(cond=[]))
             if isdefined(self.inputs.high_pass_filter_cutoff):
-                sessinfo[i]["hpf"] = np.float(self.inputs.high_pass_filter_cutoff)
+                sessinfo[i]["hpf"] = float(self.inputs.high_pass_filter_cutoff)
 
             if hasattr(info, "conditions") and info.conditions is not None:
                 for cid, cond in enumerate(info.conditions):

--- a/nipype/algorithms/rapidart.py
+++ b/nipype/algorithms/rapidart.py
@@ -583,7 +583,7 @@ class ArtifactDetect(BaseInterface):
             tidx = find_indices(normval > self.inputs.norm_threshold)
             ridx = find_indices(normval < 0)
             if displacement is not None:
-                dmap = np.zeros((x, y, z, timepoints), dtype=np.float)
+                dmap = np.zeros((x, y, z, timepoints), dtype=np.float64)
                 for i in range(timepoints):
                     dmap[
                         voxel_coords[0], voxel_coords[1], voxel_coords[2], i


### PR DESCRIPTION
Wanted to run this one by people rather than tucking into #3336.

Because `np.float` is just `__builtins__.float`, which is in turn promoted to `np.float64` when used as a dtype, this should have no effect. Just want to make sure that this is what's intended in these cases.