### PR TITLE
ENH: Add new flags to MRtrix/preprocess.py (DWI2Tensor, MRtransform)

### DIFF
--- a/nipype/interfaces/mrtrix/preprocess.py
+++ b/nipype/interfaces/mrtrix/preprocess.py
@@ -217,6 +217,13 @@ class DWI2TensorInputSpec(CommandLineInputSpec):
             "specified when computing the tensor."
         ),
     )
+    mask = File(
+        exists=True,
+        argstr="-mask %s",
+        desc=(
+            "Only perform computation within the specified binary brain mask image."
+        ),
+    )
     quiet = traits.Bool(
         argstr="-quiet",
         position=1,

--- a/nipype/interfaces/mrtrix/preprocess.py
+++ b/nipype/interfaces/mrtrix/preprocess.py
@@ -872,6 +872,17 @@ class MRTransformInputSpec(CommandLineInputSpec):
         position=1,
         desc="Invert the specified transform before using it",
     )
+    linear_transform = File(
+        exists=True,
+        argstr="-linear %s",
+        position=1,
+        desc=(
+            "Specify a linear transform to apply, in the form of a 3x4 or 4x4 ascii file. "
+            "Note the standard reverse convention is used, "
+            "where the transform maps points in the template image to the moving image. "
+            "Note that the reverse convention is still assumed even if no -template image is supplied."
+        ),
+    )
     replace_transform = traits.Bool(
         argstr="-replace",
         position=1,

--- a/nipype/interfaces/mrtrix/tests/test_auto_DWI2Tensor.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_DWI2Tensor.py
@@ -35,6 +35,10 @@ def test_DWI2Tensor_inputs():
             mandatory=True,
             position=-2,
         ),
+        mask=dict(
+            argstr="-mask %s",
+            extensions=None,
+        ),
         out_filename=dict(
             argstr="%s",
             extensions=None,

--- a/nipype/interfaces/mrtrix/tests/test_auto_MRTransform.py
+++ b/nipype/interfaces/mrtrix/tests/test_auto_MRTransform.py
@@ -28,6 +28,11 @@ def test_MRTransform_inputs():
             argstr="-inverse",
             position=1,
         ),
+        linear_transform=dict(
+            argstr="-linear %s",
+            extensions=None,
+            position=1,
+        ),
         out_filename=dict(
             argstr="%s",
             extensions=None,


### PR DESCRIPTION
## Summary

This PR adds some new flags to MRtrix commands.

Please let me known if anything is missing.

## List of changes proposed in this PR (pull-request)

- [X] Add `-mask` flag for [`dwi2tensor` command](https://mrtrix.readthedocs.io/en/latest/reference/commands/dwi2tensor.html)
- [X] Add `-linear` flag for [`mrtransform` command](https://mrtrix.readthedocs.io/en/latest/reference/commands/mrtransform.html)


## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
