### PR TITLE
[FIX] coord for mrconvert

### DIFF
--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -560,7 +560,7 @@ class MRConvertInputSpec(MRTrix3BaseInputSpec):
         desc="output image",
     )
     coord = traits.List(
-        traits.Float,
+        traits.Int,
         sep=" ",
         argstr="-coord %s",
         desc="extract data at the specified coordinates",


### PR DESCRIPTION
mrconvert in the newest version of MRtrix3 crashes if -coord is float

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [ ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
