### PR TITLE
ENH: ``verbose`` input should not be hashed in ``ants.Registration``

### DIFF
--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -584,7 +584,7 @@ class RegistrationInputSpec(ANTSCommandInputSpec):
         desc="The Lower quantile to clip image ranges",
     )
 
-    verbose = traits.Bool(argstr="-v", default_value=False, usedefault=True)
+    verbose = traits.Bool(argstr="-v", default_value=False, usedefault=True, nohash=True)
 
 
 class RegistrationOutputSpec(TraitedSpec):

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -584,7 +584,9 @@ class RegistrationInputSpec(ANTSCommandInputSpec):
         desc="The Lower quantile to clip image ranges",
     )
 
-    verbose = traits.Bool(argstr="-v", default_value=False, usedefault=True, nohash=True)
+    verbose = traits.Bool(
+        argstr="-v", default_value=False, usedefault=True, nohash=True
+    )
 
 
 class RegistrationOutputSpec(TraitedSpec):

--- a/nipype/interfaces/ants/tests/test_auto_Registration.py
+++ b/nipype/interfaces/ants/tests/test_auto_Registration.py
@@ -154,6 +154,7 @@ def test_Registration_inputs():
         ),
         verbose=dict(
             argstr="-v",
+            nohash=True,
             usedefault=True,
         ),
         winsorize_lower_quantile=dict(

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -157,7 +157,7 @@ def test_BaseInterface_load_save_inputs(tmpdir):
     assert {} == check_dict(data_dict, tsthash2.inputs.get_traitsfree())
 
     _, hashvalue = tsthash.inputs.get_hashval(hash_method="timestamp")
-    assert "8562a5623562a871115eb14822ee8d02" == hashvalue
+    assert hashvalue == "e35bf07fea8049cc02de9235f85e8903"
 
 
 class MinVerInputSpec(nib.TraitedSpec):


### PR DESCRIPTION
A tiny correction.