### PR TITLE
MNT: Add user name and email to Docker to appease git/annex/datalad

### DIFF
--- a/docker/generate_dockerfiles.sh
+++ b/docker/generate_dockerfiles.sh
@@ -89,6 +89,8 @@ function generate_main_dockerfile() {
           OMP_NUM_THREADS=1 \
     --arg PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 BUILD_DATE VCS_REF VERSION \
     --user neuro \
+    --run 'git config --global user.name nipybot
+           && git config --global user.email "nipybot@gmail.com"' \
     --workdir /home/neuro \
     --miniconda create_env=neuro \
                 conda_install='python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}


### PR DESCRIPTION
Fixing an apparent datalad 0.15 regression that causes failures if `user.name` and `user.email` aren't set in Docker containers.