### PR TITLE
FIX: Extension not extensions, after pybids v0.9

### DIFF
--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -2935,12 +2935,12 @@ class BIDSDataGrabber(LibraryBaseInterface, IOBase):
                 "bold": {
                     "datatype": "func",
                     "suffix": "bold",
-                    "extensions": ["nii", ".nii.gz"],
+                    "extension": ["nii", ".nii.gz"],
                 },
                 "T1w": {
                     "datatype": "anat",
                     "suffix": "T1w",
-                    "extensions": ["nii", ".nii.gz"],
+                    "extension": ["nii", ".nii.gz"],
                 },
             }
 


### PR DESCRIPTION
## Summary
Updates `BIDSDataGrabber` to reflect that `extensions` is a deprecated keyword, in favor of `extension`

Related issue: https://neurostars.org/t/issue-with-bidsdatagrabber-in-nipype-1-6-1/20243/3

## Acknowledgment

- [ X ] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
