### PR TITLE
[FIX] Removed exists=True from MathsOutput

### DIFF
--- a/nipype/interfaces/fsl/maths.py
+++ b/nipype/interfaces/fsl/maths.py
@@ -41,7 +41,7 @@ class MathsInput(FSLCommandInputSpec):
 
 class MathsOutput(TraitedSpec):
 
-    out_file = File(exists=True, desc="image written after calculations")
+    out_file = File(desc="image written after calculations")
 
 
 class MathsCommand(FSLCommand):


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
When setting MathsCommand().inputs.out_file argument, a Trait error is thrown because of the exists=True, although this file is to be created. This PR fixed this by removing the `exists=True` argument.

Fixes #3384 .

## List of changes proposed in this PR (pull-request)
* Removed `exists=True` from `MathsOutput` `File()`.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
