### PR TITLE
ENH: Add expected steps for FreeSurfer 7 recon-all

### DIFF
--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -1330,7 +1330,11 @@ class ReconAll(CommandLine):
             ("careg", ["mri/transforms/talairach.m3z"], []),
             (
                 "calabel",
-                ["mri/aseg.auto_noCCseg.mgz", "mri/aseg.auto.mgz", "mri/aseg.presurf.mgz"],
+                [
+                    "mri/aseg.auto_noCCseg.mgz",
+                    "mri/aseg.auto.mgz",
+                    "mri/aseg.presurf.mgz",
+                ],
                 [],
             ),
             ("normalization2", ["mri/brain.mgz"], []),


### PR DESCRIPTION
They hid their new recon-all table: https://surfer.nmr.mgh.harvard.edu/fswiki/ReconAllTableStableV6.0#ReconAllTableStable7.1.1