### PR TITLE
CI: Update CircleCI machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 _machine_kwds: &machine_kwds
-  image: circleci/classic:201808-01
+  image: ubuntu-2004:202107-02
 
 _store_artifacts_kwds: &store_artifacts_kwds
   path: /home/circleci/work/tests


### PR DESCRIPTION
Builds are failing because coverage uses f-strings in its `setup.py`, and we're working on Python 3.6 images. It's not worth pinning an old coverage with Py36 EOL at the end of the year.