### PR TITLE
FIX: Make ants.LaplacianThickness output_image a string, not file

### DIFF
--- a/nipype/interfaces/ants/segmentation.py
+++ b/nipype/interfaces/ants/segmentation.py
@@ -268,7 +268,7 @@ class LaplacianThicknessInputSpec(ANTSCommandInputSpec):
         desc="gray matter segmentation image",
         position=2,
     )
-    output_image = File(
+    output_image = traits.Str(
         desc="name of output file",
         argstr="%s",
         position=3,

--- a/nipype/interfaces/ants/tests/test_auto_LaplacianThickness.py
+++ b/nipype/interfaces/ants/tests/test_auto_LaplacianThickness.py
@@ -36,7 +36,6 @@ def test_LaplacianThickness_inputs():
         ),
         output_image=dict(
             argstr="%s",
-            extensions=None,
             hash_files=False,
             keep_extension=True,
             name_source=["input_wm"],


### PR DESCRIPTION
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3390.