### PR TITLE
ENH: json-related entities in MRConvert's inputs specification

### DIFF
--- a/doc/devel/matlab_example1.py
+++ b/doc/devel/matlab_example1.py
@@ -1,13 +1,17 @@
 from nipype.interfaces.matlab import MatlabCommand
-from nipype.interfaces.base import TraitedSpec, \
-    BaseInterface, BaseInterfaceInputSpec, File
+from nipype.interfaces.base import (
+    TraitedSpec,
+    BaseInterface,
+    BaseInterfaceInputSpec,
+    File,
+)
 import os
 from string import Template
 
 
 class ConmapTxt2MatInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True)
-    out_file = File('cmatrix.mat', usedefault=True)
+    out_file = File("cmatrix.mat", usedefault=True)
 
 
 class ConmapTxt2MatOutputSpec(TraitedSpec):
@@ -19,14 +23,15 @@ class ConmapTxt2Mat(BaseInterface):
     output_spec = ConmapTxt2MatOutputSpec
 
     def _run_interface(self, runtime):
-        d = dict(in_file=self.inputs.in_file,
-                 out_file=self.inputs.out_file)
+        d = dict(in_file=self.inputs.in_file, out_file=self.inputs.out_file)
         # This is your MATLAB code template
-        script = Template("""in_file = '$in_file';
+        script = Template(
+            """in_file = '$in_file';
                              out_file = '$out_file';
                              ConmapTxt2Mat(in_file, out_file);
                              exit;
-                          """).substitute(d)
+                          """
+        ).substitute(d)
 
         # mfile = True  will create an .m file with your script and executed.
         # Alternatively
@@ -43,5 +48,5 @@ class ConmapTxt2Mat(BaseInterface):
 
     def _list_outputs(self):
         outputs = self._outputs().get()
-        outputs['out_file'] = os.path.abspath(self.inputs.out_file)
+        outputs["out_file"] = os.path.abspath(self.inputs.out_file)
         return outputs

--- a/doc/devel/matlab_example2.py
+++ b/doc/devel/matlab_example2.py
@@ -4,8 +4,7 @@ from nipype.interfaces.matlab import MatlabCommand, MatlabInputSpec
 
 
 class HelloWorldInputSpec(MatlabInputSpec):
-    name = traits.Str(mandatory=True,
-                      desc='Name of person to say hello to')
+    name = traits.Str(mandatory=True, desc="Name of person to say hello to")
 
 
 class HelloWorldOutputSpec(TraitedSpec):
@@ -29,6 +28,7 @@ class HelloWorld(MatlabCommand):
     >>> out = hello.run()
     >>> print out.outputs.matlab_output
     """
+
     input_spec = HelloWorldInputSpec
     output_spec = HelloWorldOutputSpec
 
@@ -37,7 +37,9 @@ class HelloWorld(MatlabCommand):
         script = """
         disp('Hello %s Python')
         two = 1 + 1
-        """ % (self.inputs.name)
+        """ % (
+            self.inputs.name
+        )
         return script
 
     def run(self, **inputs):

--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -121,7 +121,9 @@ def read_mrtrix_streamlines(in_file, header, as_generator=True):
                         "Expecting %s points, found only %s" % (stream_count, n_streams)
                     )
                     iflogger.error(
-                        "Expecting %s points, found only %s", stream_count, n_streams
+                        "Expecting %s points, found only %s",
+                        stream_count,
+                        n_streams,
                     )
                 break
             pts = np.ndarray(shape=(n_pts, pt_cols), dtype=f4dt, buffer=pts_str)
@@ -193,7 +195,10 @@ class MRTrix2TrackVis(DipyBaseInterface):
     output_spec = MRTrix2TrackVisOutputSpec
 
     def _run_interface(self, runtime):
-        from dipy.tracking.utils import move_streamlines, affine_from_fsl_mat_file
+        from dipy.tracking.utils import (
+            move_streamlines,
+            affine_from_fsl_mat_file,
+        )
 
         dx, dy, dz = get_data_dims(self.inputs.image_file)
         vx, vy, vz = get_vox_dims(self.inputs.image_file)
@@ -215,7 +220,8 @@ class MRTrix2TrackVis(DipyBaseInterface):
             self.inputs.registration_image_file
         ):
             iflogger.info(
-                "Applying transformation from matrix file %s", self.inputs.matrix_file
+                "Applying transformation from matrix file %s",
+                self.inputs.matrix_file,
             )
             xfm = np.genfromtxt(self.inputs.matrix_file)
             iflogger.info(xfm)

--- a/nipype/interfaces/mrtrix3/tests/test_auto_MRConvert.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_MRConvert.py
@@ -44,6 +44,16 @@ def test_MRConvert_inputs():
             mandatory=True,
             position=-2,
         ),
+        json_export=dict(
+            argstr="-json_export %s",
+            extensions=None,
+            mandatory=False,
+        ),
+        json_import=dict(
+            argstr="-json_import %s",
+            extensions=None,
+            mandatory=False,
+        ),
         nthreads=dict(
             argstr="-nthreads %d",
             nohash=True,
@@ -73,6 +83,9 @@ def test_MRConvert_inputs():
 
 def test_MRConvert_outputs():
     output_map = dict(
+        json_export=dict(
+            extensions=None,
+        ),
         out_file=dict(
             extensions=None,
         ),

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -638,10 +638,20 @@ class MRConvertInputSpec(MRTrix3BaseInputSpec):
         mandatory=False,
         desc="import data from a JSON file into header key-value pairs",
     )
+    json_export = File(
+        exists=False,
+        argstr="-json_export %s",
+        mandatory=False,
+        desc="export data from an image header key-value pairs into a JSON file",
+    )
 
 
 class MRConvertOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="output image")
+    json_export = File(
+        exists=True,
+        desc="exported data from an image header key-value pairs in a JSON file",
+    )
 
 
 class MRConvert(MRTrix3Base):

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -666,7 +666,8 @@ class MRConvert(MRTrix3Base):
     def _list_outputs(self):
         outputs = self.output_spec().get()
         outputs["out_file"] = op.abspath(self.inputs.out_file)
-        outputs["json_export"] = op.abspath(self.inputs.json_export)
+        if self.inputs.json_export:
+            outputs["json_export"] = op.abspath(self.inputs.json_export)
         return outputs
 
 

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -678,6 +678,7 @@ class MRConvert(MRTrix3Base):
     def _list_outputs(self):
         outputs = self.output_spec().get()
         outputs["out_file"] = op.abspath(self.inputs.out_file)
+        outputs["json_export"] = op.abspath(self.inputs.json_export)
         return outputs
 
 

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -144,9 +144,7 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         position=-2,
         desc="input image",
     )
-    out_file = File(
-        argstr="%s", mandatory=True, position=-1, desc="output image"
-    )
+    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
 
 
 class Generate5ttOutputSpec(TraitedSpec):
@@ -192,12 +190,8 @@ class TensorMetricsInputSpec(CommandLineInputSpec):
 
     out_fa = File(argstr="-fa %s", desc="output FA file")
     out_adc = File(argstr="-adc %s", desc="output ADC file")
-    out_evec = File(
-        argstr="-vector %s", desc="output selected eigenvector(s) file"
-    )
-    out_eval = File(
-        argstr="-value %s", desc="output selected eigenvalue(s) file"
-    )
+    out_evec = File(argstr="-vector %s", desc="output selected eigenvector(s) file")
+    out_eval = File(argstr="-value %s", desc="output selected eigenvalue(s) file")
     component = traits.List(
         [1],
         usedefault=True,
@@ -212,8 +206,7 @@ class TensorMetricsInputSpec(CommandLineInputSpec):
         exists=True,
         argstr="-mask %s",
         desc=(
-            "only perform computation within the specified binary"
-            " brain mask image"
+            "only perform computation within the specified binary" " brain mask image"
         ),
     )
     modulate = traits.Enum(
@@ -301,8 +294,7 @@ class ComputeTDIInputSpec(CommandLineInputSpec):
     )
     max_tod = traits.Int(
         argstr="-tod %d",
-        desc="generate a Track Orientation "
-        "Distribution (TOD) in each voxel.",
+        desc="generate a Track Orientation " "Distribution (TOD) in each voxel.",
     )
 
     contrast = traits.Enum(
@@ -392,8 +384,7 @@ class ComputeTDIInputSpec(CommandLineInputSpec):
     )
     nthreads = traits.Int(
         argstr="-nthreads %d",
-        desc="number of threads. if zero, the number"
-        " of available cpus will be used",
+        desc="number of threads. if zero, the number" " of available cpus will be used",
         nohash=True,
     )
 
@@ -498,8 +489,7 @@ class TCK2VTKInputSpec(CommandLineInputSpec):
 
     nthreads = traits.Int(
         argstr="-nthreads %d",
-        desc="number of threads. if zero, the number"
-        " of available cpus will be used",
+        desc="number of threads. if zero, the number" " of available cpus will be used",
         nohash=True,
     )
 
@@ -543,9 +533,7 @@ class DWIExtractInputSpec(MRTrix3BaseInputSpec):
         position=-2,
         desc="input image",
     )
-    out_file = File(
-        argstr="%s", mandatory=True, position=-1, desc="output image"
-    )
+    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
     bzero = traits.Bool(argstr="-bzero", desc="extract b=0 volumes")
     nobzero = traits.Bool(argstr="-no_bzero", desc="extract non b=0 volumes")
     singleshell = traits.Bool(
@@ -690,9 +678,7 @@ class MRMathInputSpec(MRTrix3BaseInputSpec):
         position=-3,
         desc="input image",
     )
-    out_file = File(
-        argstr="%s", mandatory=True, position=-1, desc="output image"
-    )
+    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
     operation = traits.Enum(
         "mean",
         "median",
@@ -875,9 +861,7 @@ class SHConvInputSpec(CommandLineInputSpec):
 
 
 class SHConvOutputSpec(TraitedSpec):
-    out_file = File(
-        exists=True, desc="the output convoluted spherical harmonics file"
-    )
+    out_file = File(exists=True, desc="the output convoluted spherical harmonics file")
 
 
 class SHConv(CommandLine):
@@ -941,9 +925,7 @@ class SH2AmpInputSpec(CommandLineInputSpec):
 
 
 class SH2AmpOutputSpec(TraitedSpec):
-    out_file = File(
-        exists=True, desc="the output convoluted spherical harmonics file"
-    )
+    out_file = File(exists=True, desc="the output convoluted spherical harmonics file")
 
 
 class SH2Amp(CommandLine):

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -66,7 +66,11 @@ class BrainMask(CommandLine):
 
 class Mesh2PVEInputSpec(CommandLineInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-3, desc="input mesh"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-3,
+        desc="input mesh",
     )
     reference = File(
         exists=True,
@@ -134,9 +138,15 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         desc="tissue segmentation algorithm",
     )
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input image"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-2,
+        desc="input image",
     )
-    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
+    out_file = File(
+        argstr="%s", mandatory=True, position=-1, desc="output image"
+    )
 
 
 class Generate5ttOutputSpec(TraitedSpec):
@@ -173,13 +183,21 @@ class Generate5tt(MRTrix3Base):
 
 class TensorMetricsInputSpec(CommandLineInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-1, desc="input DTI image"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-1,
+        desc="input DTI image",
     )
 
     out_fa = File(argstr="-fa %s", desc="output FA file")
     out_adc = File(argstr="-adc %s", desc="output ADC file")
-    out_evec = File(argstr="-vector %s", desc="output selected eigenvector(s) file")
-    out_eval = File(argstr="-value %s", desc="output selected eigenvalue(s) file")
+    out_evec = File(
+        argstr="-vector %s", desc="output selected eigenvector(s) file"
+    )
+    out_eval = File(
+        argstr="-value %s", desc="output selected eigenvalue(s) file"
+    )
     component = traits.List(
         [1],
         usedefault=True,
@@ -194,7 +212,8 @@ class TensorMetricsInputSpec(CommandLineInputSpec):
         exists=True,
         argstr="-mask %s",
         desc=(
-            "only perform computation within the specified binary" " brain mask image"
+            "only perform computation within the specified binary"
+            " brain mask image"
         ),
     )
     modulate = traits.Enum(
@@ -246,10 +265,18 @@ class TensorMetrics(CommandLine):
 
 class ComputeTDIInputSpec(CommandLineInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input tractography"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-2,
+        desc="input tractography",
     )
     out_file = File(
-        "tdi.mif", argstr="%s", usedefault=True, position=-1, desc="output TDI file"
+        "tdi.mif",
+        argstr="%s",
+        usedefault=True,
+        position=-1,
+        desc="output TDI file",
     )
     reference = File(
         exists=True,
@@ -274,7 +301,8 @@ class ComputeTDIInputSpec(CommandLineInputSpec):
     )
     max_tod = traits.Int(
         argstr="-tod %d",
-        desc="generate a Track Orientation " "Distribution (TOD) in each voxel.",
+        desc="generate a Track Orientation "
+        "Distribution (TOD) in each voxel.",
     )
 
     contrast = traits.Enum(
@@ -353,7 +381,8 @@ class ComputeTDIInputSpec(CommandLineInputSpec):
         "(these lengths are then taken into account during TWI calculation)",
     )
     ends_only = traits.Bool(
-        argstr="-ends_only", desc="only map the streamline" " endpoints to the image"
+        argstr="-ends_only",
+        desc="only map the streamline" " endpoints to the image",
     )
 
     tck_weights = File(
@@ -363,7 +392,8 @@ class ComputeTDIInputSpec(CommandLineInputSpec):
     )
     nthreads = traits.Int(
         argstr="-nthreads %d",
-        desc="number of threads. if zero, the number" " of available cpus will be used",
+        desc="number of threads. if zero, the number"
+        " of available cpus will be used",
         nohash=True,
     )
 
@@ -438,10 +468,18 @@ class ComputeTDI(MRTrix3Base):
 
 class TCK2VTKInputSpec(CommandLineInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input tractography"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-2,
+        desc="input tractography",
     )
     out_file = File(
-        "tracks.vtk", argstr="%s", usedefault=True, position=-1, desc="output VTK file"
+        "tracks.vtk",
+        argstr="%s",
+        usedefault=True,
+        position=-1,
+        desc="output VTK file",
     )
     reference = File(
         exists=True,
@@ -460,7 +498,8 @@ class TCK2VTKInputSpec(CommandLineInputSpec):
 
     nthreads = traits.Int(
         argstr="-nthreads %d",
-        desc="number of threads. if zero, the number" " of available cpus will be used",
+        desc="number of threads. if zero, the number"
+        " of available cpus will be used",
         nohash=True,
     )
 
@@ -498,9 +537,15 @@ class TCK2VTK(MRTrix3Base):
 
 class DWIExtractInputSpec(MRTrix3BaseInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input image"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-2,
+        desc="input image",
     )
-    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
+    out_file = File(
+        argstr="%s", mandatory=True, position=-1, desc="output image"
+    )
     bzero = traits.Bool(argstr="-bzero", desc="extract b=0 volumes")
     nobzero = traits.Bool(argstr="-no_bzero", desc="extract non b=0 volumes")
     singleshell = traits.Bool(
@@ -549,7 +594,11 @@ class DWIExtract(MRTrix3Base):
 
 class MRConvertInputSpec(MRTrix3BaseInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input image"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-2,
+        desc="input image",
     )
     out_file = File(
         "dwi.mif",
@@ -566,7 +615,10 @@ class MRConvertInputSpec(MRTrix3BaseInputSpec):
         desc="extract data at the specified coordinates",
     )
     vox = traits.List(
-        traits.Float, sep=",", argstr="-vox %s", desc="change the voxel dimensions"
+        traits.Float,
+        sep=",",
+        argstr="-vox %s",
+        desc="change the voxel dimensions",
     )
     axes = traits.List(
         traits.Int,
@@ -579,6 +631,12 @@ class MRConvertInputSpec(MRTrix3BaseInputSpec):
         sep=",",
         argstr="-scaling %s",
         desc="specify the data scaling parameter",
+    )
+    json_import = File(
+        exists=True,
+        argstr="-json_import %s",
+        mandatory=False,
+        desc="import data from a JSON file into header key-value pairs",
     )
 
 
@@ -615,9 +673,15 @@ class MRConvert(MRTrix3Base):
 
 class MRMathInputSpec(MRTrix3BaseInputSpec):
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-3, desc="input image"
+        exists=True,
+        argstr="%s",
+        mandatory=True,
+        position=-3,
+        desc="input image",
     )
-    out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
+    out_file = File(
+        argstr="%s", mandatory=True, position=-1, desc="output image"
+    )
     operation = traits.Enum(
         "mean",
         "median",
@@ -637,7 +701,9 @@ class MRMathInputSpec(MRTrix3BaseInputSpec):
         desc="operation to computer along a specified axis",
     )
     axis = traits.Int(
-        0, argstr="-axis %d", desc="specfied axis to perform the operation along"
+        0,
+        argstr="-axis %d",
+        desc="specfied axis to perform the operation along",
     )
 
 
@@ -677,7 +743,11 @@ class MRMath(MRTrix3Base):
 
 class MRResizeInputSpec(MRTrix3BaseInputSpec):
     in_file = File(
-        exists=True, argstr="%s", position=-2, mandatory=True, desc="input DWI image"
+        exists=True,
+        argstr="%s",
+        position=-2,
+        mandatory=True,
+        desc="input DWI image",
     )
     image_size = traits.Tuple(
         (traits.Int, traits.Int, traits.Int),
@@ -794,7 +864,9 @@ class SHConvInputSpec(CommandLineInputSpec):
 
 
 class SHConvOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc="the output convoluted spherical harmonics file")
+    out_file = File(
+        exists=True, desc="the output convoluted spherical harmonics file"
+    )
 
 
 class SHConv(CommandLine):
@@ -858,7 +930,9 @@ class SH2AmpInputSpec(CommandLineInputSpec):
 
 
 class SH2AmpOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc="the output convoluted spherical harmonics file")
+    out_file = File(
+        exists=True, desc="the output convoluted spherical harmonics file"
+    )
 
 
 class SH2Amp(CommandLine):

--- a/tools/checkspecs.py
+++ b/tools/checkspecs.py
@@ -13,8 +13,7 @@ import black
 
 # Functions and classes
 class InterfaceChecker(object):
-    """Class for checking all interface specifications
-    """
+    """Class for checking all interface specifications"""
 
     def __init__(
         self,
@@ -23,7 +22,7 @@ class InterfaceChecker(object):
         module_skip_patterns=None,
         class_skip_patterns=None,
     ):
-        r""" Initialize package for parsing
+        r"""Initialize package for parsing
 
         Parameters
         ----------
@@ -113,14 +112,14 @@ class InterfaceChecker(object):
         return path
 
     def _path2uri(self, dirpath):
-        """ Convert directory path to uri """
+        """Convert directory path to uri"""
         relpath = dirpath.replace(self.root_path, self.package_name)
         if relpath.startswith(os.path.sep):
             relpath = relpath[1:]
         return relpath.replace(os.path.sep, ".")
 
     def _parse_module(self, uri):
-        """ Parse module defined in *uri* """
+        """Parse module defined in *uri*"""
         filename = self._uri2path(uri)
         if filename is None:
             # nothing that we could handle here.
@@ -131,7 +130,7 @@ class InterfaceChecker(object):
         return functions, classes
 
     def _parse_lines(self, linesource, module):
-        """ Parse lines of text for functions and classes """
+        """Parse lines of text for functions and classes"""
         functions = []
         classes = []
         for line in linesource:
@@ -387,7 +386,7 @@ class InterfaceChecker(object):
         return bad_specs
 
     def _survives_exclude(self, matchstr, match_type):
-        """ Returns True if *matchstr* does not match patterns
+        """Returns True if *matchstr* does not match patterns
 
         ``self.package_name`` removed from front of string if present
 
@@ -429,7 +428,7 @@ class InterfaceChecker(object):
         return True
 
     def discover_modules(self):
-        """ Return module sequence discovered from ``self.package_name``
+        """Return module sequence discovered from ``self.package_name``
 
 
         Parameters

--- a/tools/gitwash_dumper.py
+++ b/tools/gitwash_dumper.py
@@ -50,9 +50,7 @@ def cp_files(in_path, globs, out_path):
 
 
 def filename_search_replace(sr_pairs, filename, backup=False):
-    """ Search and replace for expressions in files
-
-    """
+    """Search and replace for expressions in files"""
     in_txt = open(filename, "rt").read(-1)
     out_txt = in_txt[:]
     for in_exp, out_exp in sr_pairs:
@@ -94,7 +92,7 @@ def make_link_targets(
     url=None,
     ml_url=None,
 ):
-    """ Check and make link targets
+    """Check and make link targets
 
     If url is None or ml_url is None, check if there are links present for
     these in `known_link_fname`.  If not, raise error.  The check is:

--- a/tools/run_examples.py
+++ b/tools/run_examples.py
@@ -4,9 +4,15 @@ from textwrap import dedent
 
 
 if __name__ == "__main__":
-    print(dedent("""Nipype examples have been moved to niflow-nipype1-examples.
+    print(
+        dedent(
+            """Nipype examples have been moved to niflow-nipype1-examples.
 
-Install with: pip install niflow-nipype1-examples"""))
+Install with: pip install niflow-nipype1-examples"""
+        )
+    )
     if sys.argv[1:]:
-        print("Run this command with: niflow-nipype1-examples " + " ".join(sys.argv[1:]))
+        print(
+            "Run this command with: niflow-nipype1-examples " + " ".join(sys.argv[1:])
+        )
     sys.exit(1)

--- a/tools/toollib.py
+++ b/tools/toollib.py
@@ -31,7 +31,9 @@ def sh(cmd):
 def compile_tree():
     """Compile all Python files below current directory."""
     vstr = ".".join(map(str, sys.version_info[:2]))
-    stat = os.system("%s %s/lib/python%s/compileall.py ." % (sys.executable, sys.prefix, vstr))
+    stat = os.system(
+        "%s %s/lib/python%s/compileall.py ." % (sys.executable, sys.prefix, vstr)
+    )
     if stat:
         msg = "*** ERROR: Some Python files in tree do NOT compile! ***\n"
         msg += "See messages above for the actual file that produced it.\n"


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
Fixes #3400  - jsons' import and export are now available under "json_import" and "json_export" optional inputs respectively.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
