### PR TITLE
rename dipy `move_streamlines` to `transform_tracking_output`

### DIFF
--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -40,7 +40,10 @@ def get_data_dims(volume):
 
 
 def transform_to_affine(streams, header, affine):
-    from dipy.tracking.utils import transform_tracking_output
+    try:
+        from dipy.tracking.utils import transform_tracking_output
+    except ImportError:
+        from dipy.tracking.utils import move_streamlines as transform_tracking_output
 
     rotation, scale = np.linalg.qr(affine)
     streams = transform_tracking_output(streams, rotation)
@@ -193,10 +196,11 @@ class MRTrix2TrackVis(DipyBaseInterface):
     output_spec = MRTrix2TrackVisOutputSpec
 
     def _run_interface(self, runtime):
-        from dipy.tracking.utils import (
-            affine_from_fsl_mat_file,
-            transform_tracking_output,
-        )
+        from dipy.tracking.utils import affine_from_fsl_mat_file
+        try:
+            from dipy.tracking.utils import transform_tracking_output
+        except ImportError:
+            from dipy.tracking.utils import move_streamlines as transform_tracking_output
 
         dx, dy, dz = get_data_dims(self.inputs.image_file)
         vx, vy, vz = get_vox_dims(self.inputs.image_file)

--- a/nipype/interfaces/mrtrix/convert.py
+++ b/nipype/interfaces/mrtrix/convert.py
@@ -197,10 +197,13 @@ class MRTrix2TrackVis(DipyBaseInterface):
 
     def _run_interface(self, runtime):
         from dipy.tracking.utils import affine_from_fsl_mat_file
+
         try:
             from dipy.tracking.utils import transform_tracking_output
         except ImportError:
-            from dipy.tracking.utils import move_streamlines as transform_tracking_output
+            from dipy.tracking.utils import (
+                move_streamlines as transform_tracking_output,
+            )
 
         dx, dy, dz = get_data_dims(self.inputs.image_file)
         vx, vy, vz = get_vox_dims(self.inputs.image_file)


### PR DESCRIPTION
The dipy function `move_streamlines` was removed (https://dipy.org/documentation/1.1.1./api_changes/) and later added back under a different name (https://github.com/dipy/dipy/commit/1046084862054166ec23f58ecf5b7c802c047ab3).

I haven't been able to test this yet due to an unrelated error (#3413).

## Acknowledgment

* [x]  I acknowledge that this contribution will be available under the Apache 2 license.