### PR TITLE
[FIX] Import error for nipype.interfaces.dipy.base

### DIFF
--- a/nipype/info.py
+++ b/nipype/info.py
@@ -162,7 +162,7 @@ TESTS_REQUIRES = [
 EXTRA_REQUIRES = {
     "data": ["datalad"],
     "doc": [
-        "dipy!=1.4.1",
+        "dipy",
         "ipython",
         "matplotlib",
         "nbsphinx",
@@ -172,7 +172,7 @@ EXTRA_REQUIRES = {
         "sphinxcontrib-napoleon",
     ],
     "duecredit": ["duecredit"],
-    "nipy": ["nitime", "nilearn", "dipy!=1.4.1", "nipy", "matplotlib"],
+    "nipy": ["nitime", "nilearn", "dipy", "nipy", "matplotlib"],
     "profiler": ["psutil>=5.0"],
     "pybids": ["pybids>=0.7.0"],
     "specs": ["black"],

--- a/nipype/interfaces/dipy/base.py
+++ b/nipype/interfaces/dipy/base.py
@@ -27,13 +27,13 @@ except ImportError:
 
 
 def no_dipy():
-    """Check if dipy is available"""
+    """Check if dipy is available."""
     global HAVE_DIPY
     return not HAVE_DIPY
 
 
 def dipy_version():
-    """Check dipy version"""
+    """Check dipy version."""
     if no_dipy():
         return None
 
@@ -41,9 +41,7 @@ def dipy_version():
 
 
 class DipyBaseInterface(LibraryBaseInterface):
-    """
-    A base interface for py:mod:`dipy` computations
-    """
+    """A base interface for py:mod:`dipy` computations."""
 
     _pkg = "dipy"
 
@@ -57,9 +55,7 @@ class DipyBaseInterfaceInputSpec(BaseInterfaceInputSpec):
 
 
 class DipyDiffusionInterface(DipyBaseInterface):
-    """
-    A base interface for py:mod:`dipy` computations
-    """
+    """A base interface for py:mod:`dipy` computations."""
 
     input_spec = DipyBaseInterfaceInputSpec
 
@@ -100,6 +96,7 @@ def get_default_args(func):
     Returns
     -------
     dict
+
     """
     signature = inspect.signature(func)
     return {k: v.default for k, v in signature.parameters.items()

--- a/nipype/interfaces/dipy/base.py
+++ b/nipype/interfaces/dipy/base.py
@@ -90,6 +90,23 @@ class DipyDiffusionInterface(DipyBaseInterface):
         return out_prefix + "_" + name + ext
 
 
+def get_default_args(func):
+    """Return optional arguments of a function.
+
+    Parameters
+    ----------
+    func: callable
+
+    Returns
+    -------
+    dict
+    """
+    signature = inspect.signature(func)
+    return {k: v.default for k, v in signature.parameters.items()
+            if v.default is not inspect.Parameter.empty
+            }
+
+
 def convert_to_traits_type(dipy_type, is_file=False):
     """Convert DIPY type to Traits type."""
     dipy_type = dipy_type.lower()
@@ -189,7 +206,7 @@ def dipy_to_nipype_interface(cls_name, dipy_flow, BaseClass=DipyBaseInterface):
     parser = IntrospectiveArgumentParser()
     flow = dipy_flow()
     parser.add_workflow(flow)
-    default_values = inspect.getfullargspec(flow.run).defaults
+    default_values = list(get_default_args(flow.run).values())
     optional_params = [
         args + (val,) for args, val in zip(parser.optional_parameters, default_values)
     ]

--- a/nipype/interfaces/dipy/tests/test_base.py
+++ b/nipype/interfaces/dipy/tests/test_base.py
@@ -12,7 +12,7 @@ from ..base import (
     get_default_args,
     dipy_version
 )
-DIPY_1_14_LESS = LooseVersion(dipy_version()) < LooseVersion("1.14")
+DIPY_1_4_LESS = LooseVersion(dipy_version()) < LooseVersion("1.4")
 
 
 def test_convert_to_traits_type():
@@ -116,7 +116,7 @@ def test_create_interface_specs():
     assert "out_params" in current_params.keys()
 
 
-@pytest.mark.skipif(no_dipy() and DIPY_1_14_LESS,
+@pytest.mark.skipif(no_dipy() and DIPY_1_4_LESS,
                     reason="DIPY is not installed")
 def test_get_default_args():
     from dipy.utils.deprecator import deprecated_params

--- a/nipype/interfaces/dipy/tests/test_base.py
+++ b/nipype/interfaces/dipy/tests/test_base.py
@@ -1,5 +1,5 @@
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 from collections import namedtuple
 from ...base import traits, File, TraitedSpec, BaseInterfaceInputSpec
 from ..base import (

--- a/nipype/interfaces/dipy/tests/test_base.py
+++ b/nipype/interfaces/dipy/tests/test_base.py
@@ -115,8 +115,8 @@ def test_create_interface_specs():
     assert "out_params" in current_params.keys()
 
 
-@pytest.mark.skipif(no_dipy() and DIPY_1_4_LESS,
-                    reason="DIPY is not installed")
+@pytest.mark.skipif(no_dipy() or Version(dipy_version()) < Version("1.4"),
+                    reason="DIPY >=1.4 required")
 def test_get_default_args():
     from dipy.utils.deprecator import deprecated_params
 

--- a/nipype/interfaces/dipy/tests/test_base.py
+++ b/nipype/interfaces/dipy/tests/test_base.py
@@ -12,7 +12,6 @@ from ..base import (
     get_default_args,
     dipy_version
 )
-DIPY_1_4_LESS = LooseVersion(dipy_version()) < LooseVersion("1.4")
 
 
 def test_convert_to_traits_type():


### PR DESCRIPTION
This PR should fix the import issue with the DIPY interface. DIPY project introduces a new deprecator decorator which was not well handled by  `inspect.getfullargspec()`. So,  I just replace `inspect.getfullargspec()`  by `inspect.signature()`. 

fix #3411
fix https://github.com/dipy/dipy/issues/2402

Could you test this PR  @koenhelwegen  @HippocampusGirl? Thank you.

## Acknowledgment

- [x] I acknowledge that this contribution will be available under the Apache 2 license.
