### PR TITLE
[FIX] Escape metacharacters when parsing dcm2niix outputs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -860,6 +860,9 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
+    },
+    {
+      "name": "Hui Qian, Tan"
     }
   ],
   "keywords": [

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -452,7 +452,6 @@ class Dcm2niix(CommandLine):
         for line in stdout.split("\n"):
             if line.startswith("Convert "):  # output
                 fname = str(re.search(r"\S+/\S+", line).group(0))
-                fname = glob.escape(fname)
                 filenames.append(os.path.abspath(fname))
         return filenames
 
@@ -496,4 +495,4 @@ class Dcm2niix(CommandLine):
 
 # https://stackoverflow.com/a/4829130
 def search_files(prefix, outtypes):
-    return it.chain.from_iterable(iglob(prefix + outtype) for outtype in outtypes)
+    return it.chain.from_iterable(iglob(glob.escape(prefix + outtype)) for outtype in outtypes)

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -4,6 +4,7 @@ import os
 import re
 from copy import deepcopy
 import itertools as it
+import glob
 from glob import iglob
 
 from ..utils.filemanip import split_filename
@@ -451,6 +452,7 @@ class Dcm2niix(CommandLine):
         for line in stdout.split("\n"):
             if line.startswith("Convert "):  # output
                 fname = str(re.search(r"\S+/\S+", line).group(0))
+                fname = glob.escape(fname)
                 filenames.append(os.path.abspath(fname))
         return filenames
 

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -495,4 +495,6 @@ class Dcm2niix(CommandLine):
 
 # https://stackoverflow.com/a/4829130
 def search_files(prefix, outtypes):
-    return it.chain.from_iterable(iglob(glob.escape(prefix + outtype)) for outtype in outtypes)
+    return it.chain.from_iterable(
+        iglob(glob.escape(prefix + outtype)) for outtype in outtypes
+    )

--- a/nipype/interfaces/tests/test_dcm2nii.py
+++ b/nipype/interfaces/tests/test_dcm2nii.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+from nipype.interfaces import dcm2nii
+
+
+@pytest.mark.parametrize(
+    "fname, extension",
+    [
+        ("output_1", ".txt"),
+        ("output_w_[]_meta_1", ".json"),
+        ("output_w_**^$?_meta_2", ".txt"),
+    ],
+)
+def test_search_files(tmp_path, fname, extension):
+    tmp_fname = fname + extension
+    test_file = tmp_path / tmp_fname
+    test_file.touch()
+    actual_files_list = dcm2nii.search_files(str(tmp_path / fname), [extension])
+    for f in actual_files_list:
+        assert str(test_file) == f


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
This PR should fix the issue with dcm2niix interface not able to parse the output files when the file name contains meta characters. 

Fixes #3416 .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

## Acknowledgment

- [X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
