### PR TITLE
[FIX] TypeError from 'v' of ANTs version string

### DIFF
--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -45,7 +45,6 @@ class Info(PackageInfo):
         # if there is a 'v' at the beginning, it may be stripped
         v_string = v_string.lstrip('v')
 
-
         # 2.2.0-equivalent version string
         if "post" in v_string and LooseVersion(v_string) >= LooseVersion(
             "2.1.0.post789"

--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -42,6 +42,9 @@ class Info(PackageInfo):
 
         # -githash may or may not be appended
         v_string = v_string.split("-")[0]
+        # if there is a 'v' at the beginning, it may be stripped
+        v_string = v_string.lstrip('v')
+
 
         # 2.2.0-equivalent version string
         if "post" in v_string and LooseVersion(v_string) >= LooseVersion(


### PR DESCRIPTION
## Summary

Building ANTs from source code, actually the recommended procedure, leads to a version string with a leading `v` that causes the `TypeError`.

#Fixes #3427

## List of changes proposed in this PR (pull-request)

[x]  Strip the leading v in the ANTs version-string parsing function

## Acknowledgment

- [ X] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
