### PR TITLE
[ENH] Include several operations to ANTs's ImageMath interface, including ReplicateImage and ReplicateDisplacement

### DIFF
--- a/nipype/interfaces/ants/tests/test_auto_ImageMath.py
+++ b/nipype/interfaces/ants/tests/test_auto_ImageMath.py
@@ -6,6 +6,7 @@ def test_ImageMath_inputs():
     input_map = dict(
         args=dict(
             argstr="%s",
+            position=-1,
         ),
         copy_header=dict(
             usedefault=True,
@@ -27,11 +28,11 @@ def test_ImageMath_inputs():
             argstr="%s",
             extensions=None,
             mandatory=True,
-            position=-2,
+            position=-3,
         ),
         op2=dict(
             argstr="%s",
-            position=-1,
+            position=-2,
         ),
         operation=dict(
             argstr="%s",

--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -158,7 +158,7 @@ class ImageMath(ANTSCommand, CopyHeaderInterface):
 
     By default, Nipype copies headers from the first input image (``op1``)
     to the output image.
-    For the ``PadImage`` operation, the header cannot be copied from inputs to
+    For some operations, as the ``PadImage`` operation, the header cannot be copied from inputs to
     outputs, and so ``copy_header`` option is automatically set to ``False``.
 
     >>> pad = ImageMath(

--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -208,7 +208,10 @@ class ImageMath(ANTSCommand, CopyHeaderInterface):
             self.inputs.copy_header = False
 
     def _copyheader_update(self):
-        if self.inputs.copy_header and self._no_copy_header_operation:
+        if (
+            self.inputs.copy_header
+            and self.inputs.operation in self._no_copy_header_operation
+        ):
             warn(
                 f"copy_header cannot be updated to True with {self.inputs.operation} as operation."
             )

--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -19,6 +19,7 @@ class ImageMathInputSpec(ANTSCommandInputSpec):
         keep_extension=True,
     )
     operation = traits.Enum(
+        # Mathematical Operations
         "m",
         "vm",
         "+",
@@ -37,6 +38,7 @@ class ImageMathInputSpec(ANTSCommandInputSpec):
         "vtotal",
         "Decision",
         "Neg",
+        # Spatial Filtering Operations
         "Project",
         "G",
         "MD",
@@ -47,22 +49,72 @@ class ImageMathInputSpec(ANTSCommandInputSpec):
         "GE",
         "GO",
         "GC",
-        "TruncateImageIntensity",
-        "Laplacian",
-        "GetLargestComponent",
+        "ExtractContours",
+        # Transform Image Operations
+        "Translate",
+        # Tensor Operations
+        "4DTensorTo3DTensor",
+        "ExtractVectorComponent",
+        "TensorColor",
+        "TensorFA",
+        "TensorFADenominator",
+        "TensorFANumerator",
+        "TensorMeanDiffusion",
+        "TensorRadialDiffusion",
+        "TensorAxialDiffusion",
+        "TensorEigenvalue",
+        "TensorToVector",
+        "TensorToVectorComponent",
+        "TensorMask",
+        # Unclassified Operators
+        "Byte",
+        "CorruptImage",
+        "D",
+        "MaurerDistance",
+        "ExtractSlice",
         "FillHoles",
+        "Convolve",
+        "Finite",
+        "FlattenImage",
+        "GetLargestComponent",
+        "Grad",
+        "RescaleImage",
+        "WindowImage",
+        "NeighborhoodStats",
+        "ReplicateDisplacement",
+        "ReplicateImage",
+        "LabelStats",
+        "Laplacian",
+        "Canny",
+        "Lipschitz",
+        "MTR",
+        "Normalize",
         "PadImage",
+        "SigmoidImage",
+        "Sharpen",
+        "UnsharpMask",
+        "PValueImage",
+        "ReplaceVoxelValue",
+        "SetTimeSpacing",
+        "SetTimeSpacingWarp",
+        "stack",
+        "ThresholdAtMean",
+        "TriPlanarView",
+        "TruncateImageIntensity",
         mandatory=True,
         position=3,
         argstr="%s",
         desc="mathematical operations",
     )
     op1 = File(
-        exists=True, mandatory=True, position=-2, argstr="%s", desc="first operator"
+        exists=True, mandatory=True, position=-3, argstr="%s", desc="first operator"
     )
     op2 = traits.Either(
-        File(exists=True), Str, position=-1, argstr="%s", desc="second operator"
+        File(exists=True), Str, position=-2, argstr="%s", desc="second operator"
     )
+
+    args = Str(position=-1, argstr="%s", desc="Additional parameters to the command")
+
     copy_header = traits.Bool(
         True,
         usedefault=True,
@@ -135,22 +187,31 @@ class ImageMath(ANTSCommand, CopyHeaderInterface):
     input_spec = ImageMathInputSpec
     output_spec = ImageMathOuputSpec
     _copy_header_map = {"output_image": "op1"}
+    _no_copy_header_operation = (
+        "PadImage",
+        "LabelStats",
+        "SetTimeSpacing",
+        "SetTimeSpacingWarp",
+        "TriPlanarView",
+    )
 
     def __init__(self, **inputs):
         super(ImageMath, self).__init__(**inputs)
-        if self.inputs.operation in ("PadImage",):
+        if self.inputs.operation in self._no_copy_header_operation:
             self.inputs.copy_header = False
 
         self.inputs.on_trait_change(self._operation_update, "operation")
         self.inputs.on_trait_change(self._copyheader_update, "copy_header")
 
     def _operation_update(self):
-        if self.inputs.operation in ("PadImage",):
+        if self.inputs.operation in self._no_copy_header_operation:
             self.inputs.copy_header = False
 
     def _copyheader_update(self):
-        if self.inputs.copy_header and self.inputs.operation in ("PadImage",):
-            warn("copy_header cannot be updated to True with PadImage as operation.")
+        if self.inputs.copy_header and self._no_copy_header_operation:
+            warn(
+                f"copy_header cannot be updated to True with {self.inputs.operation} as operation."
+            )
             self.inputs.copy_header = False
 
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #3434 . ReplicateImage and ReplicateDisplacement operations have been included in ANTs's ImageMath interface. Futhermore several other operations, that work well with the current structure of the interface, are included. Also, "args" trait has been overloaded so that its content is in the last position of the command line. Finally, for several of the included operations, copying the header of the input image does not make sense. A tuple called "_no_copy_header_operation" is defined to list such operations.

## List of changes proposed in this PR (pull-request)
- [x] ReplicateImage and ReplicateDisplacement operations have been included 
- [x] Several other operations included 
- [x] "args" trait has been overloaded so that its content is in the last position of the command line 
- [x] A tuple called "_no_copy_header_operation" is defined and used to set to False the trait "copy_header" and avoid that it is set to True 
- [x] Documentation string modified so that mentions that there are more operations other than "PadImage" that so not allow for copy_header 


## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
