### PR TITLE
MNT: Test on Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04']
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: ['ubuntu-latest']
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         check: ['test']
         pip-flags: ['']
         depends: ['REQUIREMENTS']

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -57,6 +57,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
 ]
 PYTHON_REQUIRES = ">= 3.6"

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -171,7 +171,6 @@ EXTRA_REQUIRES = {
         "sphinx-argparse",
         "sphinx>=2.1.2",
         "sphinxcontrib-apidoc",
-        "sphinxcontrib-napoleon",
     ],
     "duecredit": ["duecredit"],
     "nipy": ["nitime", "nilearn", "dipy", "nipy", "matplotlib"],

--- a/nipype/sphinxext/apidoc/__init__.py
+++ b/nipype/sphinxext/apidoc/__init__.py
@@ -2,7 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Settings for sphinxext.interfaces and connection to sphinx-apidoc."""
 import re
-from sphinxcontrib.napoleon import (
+from sphinx.ext.napoleon import (
     Config as NapoleonConfig,
     _patch_python_domain,
     _skip_member as _napoleon_skip_member,

--- a/nipype/sphinxext/apidoc/docstring.py
+++ b/nipype/sphinxext/apidoc/docstring.py
@@ -2,8 +2,8 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Reformat interface docstrings."""
 import re
-from sphinxcontrib.napoleon._upstream import _
-from sphinxcontrib.napoleon.docstring import NumpyDocstring
+from sphinx.locale import _
+from sphinx.ext.napoleon.docstring import NumpyDocstring
 
 
 class NipypeDocstring(NumpyDocstring):
@@ -34,7 +34,7 @@ class InterfaceDocstring(NipypeDocstring):
     docstring : :obj:`str` or :obj:`list` of :obj:`str`
         The docstring to parse, given either as a string or split into
         individual lines.
-    config: :obj:`sphinxcontrib.napoleon.Config` or :obj:`sphinx.config.Config`
+    config: :obj:`sphinx.ext.napoleon.Config` or :obj:`sphinx.config.Config`
         The configuration settings to use. If not given, defaults to the
         config object on `app`; or if `app` is not given defaults to the
         a new :class:`nipype.sphinxext.apidoc.Config` object.

--- a/nipype/utils/tests/test_cmd.py
+++ b/nipype/utils/tests/test_cmd.py
@@ -45,9 +45,13 @@ nipype_cmd: error: the following arguments are required: module, interface
         assert exit_exception.code == 0
 
         assert stderr.getvalue() == ""
+        if sys.version_info >= (3, 10):
+            options = "options"
+        else:
+            options = "optional arguments"
         assert (
             stdout.getvalue()
-            == """usage: nipype_cmd [-h] module interface
+            == f"""usage: nipype_cmd [-h] module interface
 
 Nipype interface runner
 
@@ -55,7 +59,7 @@ positional arguments:
   module      Module name
   interface   Interface name
 
-optional arguments:
+{options}:
   -h, --help  show this help message and exit
 """
         )


### PR DESCRIPTION
Should be advertising that we support 3.9. Checking that we support 3.10 while we're at it.

Next minor release should drop support for 3.6.