### PR TITLE
FIX: Use a more robust strategy for detecting ANTs version

### DIFF
--- a/nipype/interfaces/ants/base.py
+++ b/nipype/interfaces/ants/base.py
@@ -42,6 +42,8 @@ class Info(PackageInfo):
 
         # -githash may or may not be appended
         v_string = v_string.split("-")[0]
+        # if there is a 'v' at the beginning, it may be stripped
+        v_string = v_string.lstrip('v')
 
         # 2.2.0-equivalent version string
         if "post" in v_string and LooseVersion(v_string) >= LooseVersion(

--- a/nipype/interfaces/ants/tests/test_base.py
+++ b/nipype/interfaces/ants/tests/test_base.py
@@ -1,0 +1,25 @@
+from nipype.interfaces.ants.base import Info
+
+import pytest
+
+# fmt: off
+ANTS_VERSIONS = [("""\
+ANTs Version: 2.3.3.dev168-g29bdf
+Compiled: Jun  9 2020 03:44:55
+
+""", "2.3.3"), ("""\
+ANTs Version: v2.3.5.post76-g28dd25c
+Compiled: Nov 16 2021 14:57:48
+
+""", "2.3.5"), ("""\
+ANTs Version: v2.1.0.post789-g0740f
+Compiled: I don't still have this so not going to pretend
+
+""", "2.2.0"),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize("raw_info, version", ANTS_VERSIONS)
+def test_version_parser(raw_info, version):
+    assert Info.parse_version(raw_info) == version


### PR DESCRIPTION
Fixes #3427.
Replaces #3430.