### PR TITLE
FIX: Change plt.hist() argument from deprecated 'normed' to 'density'

### DIFF
--- a/nipype/algorithms/metrics.py
+++ b/nipype/algorithms/metrics.py
@@ -150,7 +150,7 @@ class Distance(BaseInterface):
         import matplotlib.pyplot as plt
 
         plt.figure()
-        plt.hist(min_dist_matrix, 50, normed=1, facecolor="green")
+        plt.hist(min_dist_matrix, 50, density=True, facecolor="green")
         plt.savefig(self._hist_filename)
         plt.clf()
         plt.close()


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

Fixes #3451 .
