### PR TITLE
REL: 1.8.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -22,6 +22,8 @@ Anna Doll <45283972+AnnaD15@users.noreply.github.com>
 Ariel Rokem <arokem@berkeley.edu>
 Ariel Rokem <arokem@berkeley.edu> <arokem@gmail.com>
 Arman Eshaghi <arman.eshaghi@gmail.com>
+Avneet Kaur <avneetkaur@bohr.neurobio.nru.dk>
+Avneet Kaur <avneetkaur@bohr.neurobio.nru.dk> <avneet14027@iiitd.ac.in>
 Ashely Gillman <gillmanash@gmail.com> <ashley.gillman@csiro.au>
 Basille Pinsard <basile.pinsard@umontreal.ca>
 Basille Pinsard <basile.pinsard@umontreal.ca> <bpinsard@imed.jussieu.fr>
@@ -84,7 +86,8 @@ Hrvoje Stojic <hrvoje.stojic@protonmail.com>
 Isaac Schwabacher <ischwabacher@wisc.edu>
 Jakub Kaczmarzyk <jakubk@mit.edu>
 James Kent <james-kent@uiowa.edu>
-James Kent <james-kent@uiowa.edu> Fred Mertz <mertzf@bargle.argle>
+James Kent <james-kent@uiowa.edu> <mertzf@bargle.argle>
+James Kent <james-kent@uiowa.edu> <jamesdkent21@gmail.com>
 Janosch Linkersdörfer <linkersdoerfer@gmail.com>
 Jason Wong <jf126dolphin@gmail.com>
 Jason Wong <jf126dolphin@gmail.com> <jasonwong73@ucla.edu>
@@ -114,6 +117,7 @@ Sin Kim <kimsin98@gmail.com>
 Sin Kim <kimsin98@gmail.com> <AKSoo@users.noreply.github.com>
 Koen Helwegen <kg.helwegen@gmail.com>
 Kornelius Podranski <kilo13@web.de>
+Kristofer Montazeri <kristofer.montazeri@gmail.com>
 Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com>
 Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com> <chris.gorgolewski@gmail.com>
 Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com> <filo@filo-Precision-M6500.(none)>
@@ -128,6 +132,7 @@ Marcel Falkiewicz <mfalkiewicz@gmail.com> <m.falkiewicz@nencki.gov.pl>
 Maria de Fatima Dias <mfatimamachado13@gmail.com>
 Maria de Fatima Dias <mfatimamachado13@gmail.com> <fmachado@dei.uc.pt>
 Martin Perez-Guevara <mperezguevara@gmail.com>
+Martin Norgaard <martin.noergaard@nru.dk>
 Mathias Goncalves <goncalves.mathias@gmail.com> <mathiasg@mit.edu>
 Mathias Goncalves <goncalves.mathias@gmail.com> <mathiasg@stanford.edu>
 Mathieu Dubois <mathieu.dubois@icm-institute.org> <mathieu.dubois@cea.fr>
@@ -189,6 +194,7 @@ Steven Giavasis <sgiava77@gmail.com> <steven.giavasis@cmi-rsch-li001.childmind.o
 Steven Giavasis <sgiava77@gmail.com> <sgiavasis@ieee.org>
 Steven Tilley <stilley@hollandbloorview.ca> <steve@steventilley.com>
 Sulantha Mathotaarachchi <sulantha.s@gmail.com>
+Sunjae Shim <85246533+sjshim@users.noreply.github.com>
 Tim Robert-Fitzgerald <tim.terf@gmail.com>
 Tom Close <Thomas.close@sydney.edu.au>
 Tom Close <Thomas.close@sydney.edu.au> <tom.g.close@gmail.com>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -85,6 +85,11 @@
       "name": "Loney, Fred"
     },
     {
+      "affiliation": "Department of Psychology, Stanford University",
+      "name": "Norgaard, Martin",
+      "orcid": "0000-0003-2131-5688"
+    },
+    {
       "affiliation": "Florida International University",
       "name": "Salo, Taylor",
       "orcid": "0000-0001-9813-3167"
@@ -172,6 +177,11 @@
       "name": "Clark, Michael G. "
     },
     {
+      "affiliation": "Neuroscience Program, University of Iowa",
+      "name": "Kent, James D.",
+      "orcid": "0000-0002-4892-2659"
+    },
+    {
       "affiliation": "Concordia University",
       "name": "Benderoff, Erin"
     },
@@ -182,11 +192,6 @@
       "affiliation": "CIBIT, UC",
       "name": "Dias, Maria de Fatima",
       "orcid": "0000-0001-8878-1750"
-    },
-    {
-      "affiliation": "Neuroscience Program, University of Iowa",
-      "name": "Kent, James D.",
-      "orcid": "0000-0002-4892-2659"
     },
     {
       "affiliation": "Otto-von-Guericke-University Magdeburg, Germany",
@@ -695,6 +700,11 @@
       "orcid": "0000-0001-9800-4816"
     },
     {
+      "affiliation": "ARAMIS Lab, Paris Brain Institute",
+      "name": "Vaillant, Ghislain",
+      "orcid": "0000-0003-0267-3033"
+    },
+    {
       "name": "Schwabacher, Isaac"
     },
     {
@@ -775,6 +785,11 @@
       "name": "Park, Anne"
     },
     {
+      "affiliation": "Consolidated Department of Psychiatry, Harvard Medical School",
+      "name": "Frederick, Blaise",
+      "orcid": "0000-0001-5832-5279"
+    },
+    {
       "name": "Cheung, Brian"
     },
     {
@@ -838,6 +853,11 @@
     },
     {
       "name": "Urchs, Sebastian"
+    },
+    {
+      "affiliation": "Department of Psychology, Stanford University",
+      "name": "Shim, Sunjae",
+      "orcid": "0000-0003-2773-0807"
     },
     {
       "name": "Nickson, Thomas"

--- a/doc/changelog/1.X.X-changelog.rst
+++ b/doc/changelog/1.X.X-changelog.rst
@@ -1,3 +1,26 @@
+1.8.0 (May 10, 2022)
+====================
+
+New feature release in the 1.8.x series.
+
+The primary new features are a batch of PETSurfer interfaces.
+
+This release drops support for Python < 3.7 and Numpy < 1.17, triggering a minor version bump.
+Additionally, matplotlib < 2.1 will stop working with some interfaces, but more recent versions
+will start working.
+
+(`Full changelog <https://github.com/nipy/nipype/milestone/1.8.0?closed=1>`__)
+
+  * FIX: Change plt.hist() argument from deprecated 'normed' to 'density' (https://github.com/nipy/nipype/pull/3455)
+  * ENH: Add random seed option to ANTs registration (https://github.com/nipy/nipype/pull/3463)
+  * ENH: Add PETsurfer interfaces (https://github.com/nipy/nipype/pull/3437)
+  * ENH: Add Text2Vest and Vest2Text interfaces (https://github.com/nipy/nipype/pull/3447)
+  * REF: Optimize ICC_rep_anova with a memoized helper function (https://github.com/nipy/nipype/pull/3454)
+  * REF: Rearranging matmul order and using hermitian flag in ICC_rep_anova  (https://github.com/nipy/nipype/pull/3453)
+  * MNT: Drop distutils (https://github.com/nipy/nipype/pull/3458)
+  * CI: Cache test data (https://github.com/nipy/nipype/pull/3459)
+
+
 1.7.1 (April 05, 2022)
 ======================
 

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -5,7 +5,7 @@ docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 
 # nipype version information
 # Remove -dev for release
-__version__ = "1.8.0.dev0"
+__version__ = "1.8.0"
 
 
 def get_nipype_gitversion():


### PR DESCRIPTION
Preparation for the 1.8.0 release, targeting Thursday.

The main impetus is the PETSurfer interfaces (#3437) which it will help people to have released. Also, we're dropping support for Python 3.6, which is overdue.

Quick issues/PRs:

* [x] #3439 
* [x] #3463
* [x] ... (Ping me if you want something added to this list)

## Release checklist

* [x] Merge pending PRs
* [x] Update changelog
* [x] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py`
* [x] Update `doc/interfaces.rst` with previous releases
* [x] Check conda-forge feedstock build (https://github.com/conda-forge/nipype-feedstock/pull/81)
* [x] Tutorial tests (https://github.com/miykael/nipype_tutorial/pull/177)