### PR TITLE
FIX: Avoid excessive etelemetry pings

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -98,4 +98,4 @@ if config.getboolean("execution", "check_version"):
         from .interfaces.base import BaseInterface
 
         if BaseInterface._etelemetry_version_data is None:
-            BaseInterface._etelemetry_version_data = check_latest_version()
+            BaseInterface._etelemetry_version_data = check_latest_version() or "n/a"

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -186,7 +186,7 @@ class BaseInterface(Interface):
             from ... import check_latest_version
 
             if BaseInterface._etelemetry_version_data is None:
-                BaseInterface._etelemetry_version_data = check_latest_version()
+                BaseInterface._etelemetry_version_data = check_latest_version() or "n/a"
 
         if not self.input_spec:
             raise Exception("No input_spec in class: %s" % self.__class__.__name__)


### PR DESCRIPTION
In cases where `check_latest_version` returned None, each time
`BaseInterface.__init__` was called would lead to another server ping.
This avoids this loop by falling to a string, n/a, if the server fails
to produce a version.

<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3483 .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
