### PR TITLE
Fix a bug about wrong order of function arguments

### DIFF
--- a/nipype/interfaces/fsl/utils.py
+++ b/nipype/interfaces/fsl/utils.py
@@ -2584,7 +2584,7 @@ class WarpPoints(CommandLine):
         if out_file is None:
             out_file, _ = op.splitext(in_file)
 
-        np.savetxt(streamlines, out_file + ".txt")
+        np.savetxt(out_file + ".txt", streamlines)
         return out_file + ".txt"
 
     def _coords_to_trk(self, points, out_file):


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential bug about wrong order of function arguments at `nipype/interfaces/fsl/utils.py`. Please check the changes.

Best,
Jingxuan