### PR TITLE
FIX: Add tolerance parameter to ComputeDVARS

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -1011,8 +1011,8 @@ def compute_dvars(
     in_file,
     in_mask,
     remove_zerovariance=False,
-    variance_tol=0.0,
     intensity_normalization=1000,
+    variance_tol=0.0,
 ):
     """
     Compute the :abbr:`DVARS (D referring to temporal

--- a/nipype/algorithms/tests/test_auto_ComputeDVARS.py
+++ b/nipype/algorithms/tests/test_auto_ComputeDVARS.py
@@ -43,6 +43,9 @@ def test_ComputeDVARS_inputs():
             usedefault=True,
         ),
         series_tr=dict(),
+        variance_tol=dict(
+            usedefault=True,
+        ),
     )
     inputs = ComputeDVARS.input_spec()
 


### PR DESCRIPTION
Closes #3487.

Also made some changes to avoid numpy deprecation warnings, and used nibabel 3+ idioms for coercing data types.