### PR TITLE
Fixed bug for work dirs longer than 255 characters, fixes #2061

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -295,7 +295,8 @@ class Node(EngineBase):
         if self.parameterization:
             params_str = ["{}".format(p) for p in self.parameterization]
             if not str2bool(self.config["execution"]["parameterize_dirs"]):
-                params_str = [_parameterization_dir(p) for p in params_str]
+                params_str = [_parameterization_dir(p,32) for p in params_str]
+            params_str = [_parameterization_dir(p,252) for p in params_str]
             outputdir = op.join(outputdir, *params_str)
 
         self._output_dir = op.realpath(op.join(outputdir, self.name))

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -293,10 +293,8 @@ class Node(EngineBase):
         if self._hierarchy:
             outputdir = op.join(outputdir, *self._hierarchy.split("."))
         if self.parameterization:
-            params_str = ["{}".format(p) for p in self.parameterization]
-            if not str2bool(self.config["execution"]["parameterize_dirs"]):
-                params_str = [_parameterization_dir(p,32) for p in params_str]
-            params_str = [_parameterization_dir(p,252) for p in params_str]
+            maxlen = 252 if str2bool(self.config["execution"]["parameterize_dirs"]) else 32
+            params_str = [_parameterization_dir(str(p), maxlen) for p in self.parameterization]
             outputdir = op.join(outputdir, *params_str)
 
         self._output_dir = op.realpath(op.join(outputdir, self.name))

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -293,8 +293,12 @@ class Node(EngineBase):
         if self._hierarchy:
             outputdir = op.join(outputdir, *self._hierarchy.split("."))
         if self.parameterization:
-            maxlen = 252 if str2bool(self.config["execution"]["parameterize_dirs"]) else 32
-            params_str = [_parameterization_dir(str(p), maxlen) for p in self.parameterization]
+            maxlen = (
+                252 if str2bool(self.config["execution"]["parameterize_dirs"]) else 32
+            )
+            params_str = [
+                _parameterization_dir(str(p), maxlen) for p in self.parameterization
+            ]
             outputdir = op.join(outputdir, *params_str)
 
         self._output_dir = op.realpath(op.join(outputdir, self.name))

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -51,14 +51,14 @@ from inspect import signature
 logger = logging.getLogger("nipype.workflow")
 
 
-def _parameterization_dir(param):
+def _parameterization_dir(param,maxlen):
     """
     Returns the directory name for the given parameterization string as follows:
-        - If the parameterization is longer than 32 characters, then
+        - If the parameterization is longer than maxlen characters, then
           return the SHA-1 hex digest.
         - Otherwise, return the parameterization unchanged.
     """
-    if len(param) > 32:
+    if len(param) > maxlen:
         return sha1(param.encode()).hexdigest()
     return param
 

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -51,7 +51,7 @@ from inspect import signature
 logger = logging.getLogger("nipype.workflow")
 
 
-def _parameterization_dir(param,maxlen):
+def _parameterization_dir(param, maxlen):
     """
     Returns the directory name for the given parameterization string as follows:
         - If the parameterization is longer than maxlen characters, then


### PR DESCRIPTION
## Summary

This change is fully backwards compatible and will
not affect existing pipelines, but it will prevent
the pipeline engine from crashing when some parameters
are long and it was trying to create subdirectories
longer than 255 characters (a typical unix limit).

Fixes #2061 .
