### PR TITLE
MAINT: Add github action to trigger tutorials for release branches

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -1,0 +1,57 @@
+name: Test tutorials
+
+on:
+  push:
+    branches:
+      - 'rel/*'
+
+jobs:
+  tutorial:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Start time
+        id: start
+        run: echo "::set-output name=start_time::$(date +'%Y-%m-%dT%H:%M:%S%z')"
+      - name: Trigger Nipype tutorial Github Action
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.TUTORIAL_ACCESS_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/miykael/nipype_tutorial/actions/workflows/testing.yml/dispatches \
+          -d '{"nipype_branch": "'${BRANCH_NAME:4}'"}'
+      - name: Check Action was successfully dispatched
+        id: dispatched
+        run: |
+          RUN_ID=$(curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/miykael/nipype_tutorial/actions/runs?created=>${{ steps.start.outputs.start_time }}&per_page=1" \
+            | jq -r '.workflow_runs[0].id')
+
+          # fail if not extracted
+          [[ -n $RUN_ID ]] || exit 1
+          echo "::set-output name=run_id::$RUN_ID""
+      - name: Check if action completed
+        timeout-minutes: 60
+        run: |
+          while :
+          do
+            TIMESTAMP=$(date +'%Y-%m-%dT%H:%M:%S%z')
+            # check status every 5 minutes
+            STATUS=$(curl -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/miykael/nipype_tutorial/actions/runs/${{ steps.dispatched.outputs.run_id }}" \
+            | jq -r '.conclusion')
+            case $STATUS in
+            success)
+              echo "[$TIMESTAMP] Tutorial run ${{ steps.dispatched.outputs.run_id }} completed successfully."
+              exit 0
+            ;;
+            failure)
+              echo "[$TIMESTAMP] Tutorial run ${{ steps.dispatched.outputs.run_id }} failed."
+              exit 1
+            ;;
+            *)
+              echo "[$TIMESTAMP] Conclusion ($STATUS) is not yet complete"
+              sleep 300
+          done


### PR DESCRIPTION
This is an effort to remove a manual step in the release process. 

Currently, we are submitting a PR to the tutorials repo to build from the current release branch.

This proposes a new action that runs whenever an upstream `rel/*` branch is pushed to that:
1) Triggers a "manual" dispatch to the tutorial's action
1) Tracks the status of the job until it i) succeeds, ii) fails, or iii) hits the timeout (currently 1 hour)

For this to work, it will require (cc @djarecka who may have the proper permissions):

1) ~https://github.com/miykael/nipype_tutorial/pull/180 to be merged in~
1) A PAT for the nipype_tutorial repo to be created and added to this organization's secrets as `TUTORIAL_ACCESS_TOKEN`
