### PR TITLE
FIX: Provide more runtime information when node execution fails

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -750,8 +750,17 @@ Error populating the inputs of node "%s": the results file of the source node \
         )
 
         if exc_tb:
+            runtime = result.runtime
+            def _tab(field):
+                from textwrap import indent
+                return indent(field, '\t')
+
             raise NodeExecutionError(
-                f"Exception raised while executing Node {self.name}.\n\n{result.runtime.traceback}"
+                f"Exception raised while executing Node {self.name}.\n\n"
+                f"Cmdline:\n{_tab(runtime.cmdline)}\n"
+                f"Stdout:\n{_tab(runtime.stdout)}\n"
+                f"Stderr:\n{_tab(runtime.stderr)}\n"
+                f"Traceback:\n{_tab(runtime.traceback)}"
             )
 
         return result

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -754,6 +754,7 @@ Error populating the inputs of node "%s": the results file of the source node \
 
             def _tab(text):
                 from textwrap import indent
+
                 if not text:
                     return ""
                 return indent(text, '\t')

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -752,10 +752,11 @@ Error populating the inputs of node "%s": the results file of the source node \
         if exc_tb:
             runtime = result.runtime
 
-            def _tab(field):
+            def _tab(text):
                 from textwrap import indent
-
-                return indent(field, '\t')
+                if not text:
+                    return ""
+                return indent(text, '\t')
 
             msg = f"Exception raised while executing Node {self.name}.\n\n"
             if hasattr(runtime, 'cmdline'):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -751,17 +751,22 @@ Error populating the inputs of node "%s": the results file of the source node \
 
         if exc_tb:
             runtime = result.runtime
+
             def _tab(field):
                 from textwrap import indent
+
                 return indent(field, '\t')
 
-            raise NodeExecutionError(
-                f"Exception raised while executing Node {self.name}.\n\n"
-                f"Cmdline:\n{_tab(runtime.cmdline)}\n"
-                f"Stdout:\n{_tab(runtime.stdout)}\n"
-                f"Stderr:\n{_tab(runtime.stderr)}\n"
-                f"Traceback:\n{_tab(runtime.traceback)}"
-            )
+            msg = f"Exception raised while executing Node {self.name}.\n\n"
+            if hasattr(runtime, 'cmdline'):
+                msg += (
+                    f"Cmdline:\n{_tab(runtime.cmdline)}\n"
+                    f"Stdout:\n{_tab(runtime.stdout)}\n"
+                    f"Stderr:\n{_tab(runtime.stderr)}\n"
+                )
+            # Always pass along the traceback
+            msg += f"Traceback:\n{_tab(runtime.traceback)}"
+            raise NodeExecutionError(msg)
 
         return result
 

--- a/nipype/pipeline/engine/tests/test_nodes.py
+++ b/nipype/pipeline/engine/tests/test_nodes.py
@@ -346,7 +346,7 @@ class FailCommandLine(nib.CommandLine):
 def test_NodeExecutionError(tmp_path, monkeypatch):
     import stat
 
-    monkeypatch.chdir('.')
+    monkeypatch.chdir(tmp_path)
 
     # create basic executable and add to PATH
     exebin = tmp_path / 'bin'
@@ -369,6 +369,7 @@ def test_NodeExecutionError(tmp_path, monkeypatch):
     # Test with function interface
     def fail():
         raise Exception("Functions can fail too")
+
     func = pe.Node(niu.Function(function=fail), name='func-fail', base_dir='func')
     with pytest.raises(pe.nodes.NodeExecutionError) as exc:
         func.run()


### PR DESCRIPTION
Partially addresses #3492 

This adds runtime information to the error message when node execution fails.

1.8.x series:
```
220914-11:28:50,439 nipype.workflow WARNING:
	 [Node] Error on "test-fail" (/private/tmp/nipype/test-fail)
Traceback (most recent call last):
  File "/private/tmp/nipype/test-fail.py", line 21, in <module>
    eg = x.run()
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 524, in run
    result = self._run_interface(execute=True)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 642, in _run_interface
    return self._run_command(execute)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 750, in _run_command
    raise NodeExecutionError(
nipype.pipeline.engine.nodes.NodeExecutionError: Exception raised while executing Node test-fail.
```

1.5.x series:
```
220914-11:27:16,631 nipype.workflow WARNING:
	 [Node] Error on "test-fail" (/private/tmp/nipype/test-fail)
Traceback (most recent call last):
  File "/private/tmp/nipype/test-fail.py", line 21, in <module>
    eg = x.run()
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 516, in run
    result = self._run_interface(execute=True)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 635, in _run_interface
    return self._run_command(execute)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 741, in _run_command
    result = self._interface.run(cwd=outdir)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/interfaces/base/core.py", line 419, in run
    runtime = self._run_interface(runtime)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/interfaces/base/core.py", line 814, in _run_interface
    self.raise_exception(runtime)
  File "/Users/mathiasg/.pyenv/versions/nipreps/lib/python3.10/site-packages/nipype/interfaces/base/core.py", line 741, in raise_exception
    raise RuntimeError(
RuntimeError: Command:
failing-bin 123
Standard output:
Starting the binary
Using input 123...
Standard error:
Failing!
Return code: 1
```

With this PR:
```
220914-11:45:14,669 nipype.workflow WARNING:
	 [Node] Error on "test-fail" (/private/tmp/nipype/test-fail)
Traceback (most recent call last):
  File "/private/tmp/nipype/test-fail.py", line 21, in <module>
    eg = x.run()
  File "/Users/mathiasg/code/nipype/nipype/pipeline/engine/nodes.py", line 527, in run
    result = self._run_interface(execute=True)
  File "/Users/mathiasg/code/nipype/nipype/pipeline/engine/nodes.py", line 645, in _run_interface
    return self._run_command(execute)
  File "/Users/mathiasg/code/nipype/nipype/pipeline/engine/nodes.py", line 758, in _run_command
    raise NodeExecutionError(
nipype.pipeline.engine.nodes.NodeExecutionError: Exception raised while executing Node test-fail.

Cmdline:
	failing-bin 123
Stdout:
	Starting the binary
	Using input 123...
Stderr:
	Failing!
Traceback:
	RuntimeError: subprocess exited with code 1.
```