### PR TITLE
FIX: Use interpolation/method in numpy.percentile as available

### DIFF
--- a/nipype/algorithms/confounds.py
+++ b/nipype/algorithms/confounds.py
@@ -1059,10 +1059,16 @@ research/nichols/scripts/fsl/standardizeddvars.pdf>`_, 2013.
 
     # Robust standard deviation (we are using "lower" interpolation
     # because this is what FSL is doing
-    func_sd = (
-        np.percentile(mfunc, 75, axis=1, method="lower")
-        - np.percentile(mfunc, 25, axis=1, method="lower")
-    ) / 1.349
+    try:
+        func_sd = (
+            np.percentile(mfunc, 75, axis=1, method="lower")
+            - np.percentile(mfunc, 25, axis=1, method="lower")
+        ) / 1.349
+    except TypeError:  # NP < 1.22
+        func_sd = (
+            np.percentile(mfunc, 75, axis=1, interpolation="lower")
+            - np.percentile(mfunc, 25, axis=1, interpolation="lower")
+        ) / 1.349
 
     if remove_zerovariance:
         zero_variance_voxels = func_sd > variance_tol


### PR DESCRIPTION
Bug introduced in #3489. Numpy 1.22 introduced method and deprecated interpolation in a single shot. Typically, they deprecate a few versions after they introduce an alternative, so I missed this and now things that have pinned, e.g., numpy 1.21 are going to break on nipype.