### PR TITLE
FIX: Deployed Matlab applications must not call addpath()

### DIFF
--- a/nipype/interfaces/matlab.py
+++ b/nipype/interfaces/matlab.py
@@ -191,7 +191,7 @@ class MatlabCommand(CommandLine):
         else:
             prescript.insert(0, "fprintf(1,'Executing code at %s:\\n',datestr(now));")
         for path in paths:
-            prescript.append("addpath('%s');\n" % path)
+            prescript.append("if ~(ismcc || isdeployed), addpath('%s'); end;\n" % path)
 
         if not mfile:
             # clean up the code of comments and replace newlines with commas

--- a/nipype/interfaces/matlab.py
+++ b/nipype/interfaces/matlab.py
@@ -191,6 +191,9 @@ class MatlabCommand(CommandLine):
         else:
             prescript.insert(0, "fprintf(1,'Executing code at %s:\\n',datestr(now));")
         for path in paths:
+            # addpath() is not available after compliation
+            # https://www.mathworks.com/help/compiler/ismcc.html
+            # https://www.mathworks.com/help/compiler/isdeployed.html
             prescript.append("if ~(ismcc || isdeployed), addpath('%s'); end;\n" % path)
 
         if not mfile:


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

https://mathworks.com/help/compiler/isdeployed.html

> The path of a deployed application is fixed at compile time and cannot change. Use `isdeployed` to ensure that the application uses path modifying functions, such as `addpath`, before deployment.

As suggested by @servoz, this fixes the case where nipype calls SPM12 Standalone, associated to Matlab Compiler Runtime (MCR) R2019a (9.6) or later. Upcoming versions of SPM12 Standalone will most probably be compiled with Matlab R2021b, and hence will be subject to this bug.

Fixes #3507.

## List of changes proposed in this PR (pull-request)

* Do not call `addpath` in Matlab scripts called from a deployed Matlab application.