### PR TITLE
CI: Allow tutorial test cancellation

### DIFF
--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -65,3 +65,13 @@ jobs:
               sleep 300
             esac
           done
+      - name: Cancel ongoing run if cancelled or failed
+        if: ${{ failure() || cancelled() }}
+        run: |
+          set -x
+          RUN_ID=${{ steps.dispatched.outputs.run_id }}
+          echo "Something went wrong, cancelling dispatched run"
+          curl -s -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.TUTORIAL_ACCESS_TOKEN }}" \
+            https://api.github.com/repos/miykael/nipype_tutorial/actions/runs/${RUN_ID}/cancel

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Check Action was successfully dispatched
         id: dispatched
         run: |
-          set -x
           START=${{ steps.start.outputs.start_time }}
-          RUN_ID=$(curl -H "Accept: application/vnd.github+json" \
+          RUN_ID=$(curl -s -H "Accept: application/vnd.github+json" \
             'https://api.github.com/repos/miykael/nipype_tutorial/actions/runs?created=>'${START}'&per_page=1' \
             | jq -r '.workflow_runs[0].id')
 
@@ -42,13 +41,12 @@ jobs:
       - name: Check if action completed
         timeout-minutes: 120
         run: |
-          set -x
           RUN_ID=${{ steps.dispatched.outputs.run_id }}
           while :
           do
             TIMESTAMP=$(date +'%Y-%m-%dT%H:%M:%S%z')
             # check status every 5 minutes
-            STATUS=$(curl -H "Accept: application/vnd.github+json" \
+            STATUS=$(curl -s -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/miykael/nipype_tutorial/actions/runs/${RUN_ID} \
             | jq -r '.conclusion')
             case $STATUS in


### PR DESCRIPTION
Currently, after the tutorial workflow is dispatched, it runs to completion, regardless of our workflow ending early. This adds a step to cancel the workflow upon failure or cancellation, to avoid overbearing the external runners.