### PR TITLE
[CI] python-version should be a string, not a float

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: [3.8]
+        python-version: ['3.8']
         nipype-extras: ['dev']
         check: ['specs', 'style']
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04']
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         check: ['test']
         pip-flags: ['']
         depends: ['REQUIREMENTS']
@@ -99,7 +99,7 @@ jobs:
         nipype-extras: ['doc,tests,profiler']
         include:
           - os: ubuntu-20.04
-            python-version: 3.8
+            python-version: '3.8'
             check: test
             pip-flags: ''
             depends: REQUIREMENTS


### PR DESCRIPTION
## Summary

The underlying issue shows clearly with `3.10`, which is interpreted as `3.1`.

This does not fix anything that wouldn't currently work. However, for documentation purposes, I feel it is better to use explicit strings. Otherwise, other maintainers may for example trigger this error when updating a version from `3.8` to `3.10`.
