### PR TITLE
FIX: Check for non-mandatory output in DWIBiasCorrect

### DIFF
--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -256,11 +256,12 @@ class DWIBiasCorrect(MRTrix3Base):
         return super()._format_arg(name, trait_spec, value)
 
     def _list_outputs(self):
-        outputs = self.output_spec().get()
-        outputs["out_file"] = op.abspath(self.inputs.out_file)
-        if self.inputs.bias:
-            outputs["bias"] = op.abspath(self.inputs.bias)
-        return outputs
+        if self.inputs.out_file:
+            outputs = self.output_spec().get()
+            outputs["out_file"] = op.abspath(self.inputs.out_file)
+            if self.inputs.bias:
+                outputs["bias"] = op.abspath(self.inputs.bias)
+            return outputs
 
 
 class DWIPreprocInputSpec(MRTrix3BaseInputSpec):

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -256,8 +256,8 @@ class DWIBiasCorrect(MRTrix3Base):
         return super()._format_arg(name, trait_spec, value)
 
     def _list_outputs(self):
+        outputs = self.output_spec().get()
         if self.inputs.out_file:
-            outputs = self.output_spec().get()
             outputs["out_file"] = op.abspath(self.inputs.out_file)
         if self.inputs.bias:
             outputs["bias"] = op.abspath(self.inputs.bias)

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -259,9 +259,9 @@ class DWIBiasCorrect(MRTrix3Base):
         if self.inputs.out_file:
             outputs = self.output_spec().get()
             outputs["out_file"] = op.abspath(self.inputs.out_file)
-            if self.inputs.bias:
-                outputs["bias"] = op.abspath(self.inputs.bias)
-            return outputs
+        if self.inputs.bias:
+            outputs["bias"] = op.abspath(self.inputs.bias)
+        return outputs
 
 
 class DWIPreprocInputSpec(MRTrix3BaseInputSpec):


### PR DESCRIPTION
The function `_list_outputs` in `DWIBiasCorrect` doesn't take into account the fact that `output_file` is not a mandatory input, thus making any pipeline using this interface without specifying the output crash. It crashes with the following error:

![Screenshot 2022-09-27 at 14 55 19](https://user-images.githubusercontent.com/85217698/192714182-6e28a36a-c272-4f33-bf27-cb252dcb2d7a.png)
