### PR TITLE
CI: Disable nipy tests generally, re-add with max numpy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,13 @@ jobs:
             pip-flags: ''
             depends: REQUIREMENTS
             deb-depends: true
+            nipype-extras: doc,tests,profiler,duecredit,ssh
+          - os: ubuntu-20.04
+            python-version: 3.8
+            check: test
+            pip-flags: ''
+            depends: NUMPY123
+            deb-depends: true
             nipype-extras: doc,tests,nipy,profiler,duecredit,ssh
     env:
       DEPENDS: ${{ matrix.depends }}

--- a/tools/ci/env.sh
+++ b/tools/ci/env.sh
@@ -4,6 +4,7 @@ SETUP_REQUIRES="pip setuptools>=30.3.0 wheel"
 REQUIREMENTS="-r requirements.txt"
 # Minimum versions of minimum requirements
 MIN_REQUIREMENTS="-r min-requirements.txt"
+NUMPY123="numpy<1.24 -r requirements.txt"
 
 # Numpy and scipy upload nightly/weekly/intermittent wheels
 NIGHTLY_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"


### PR DESCRIPTION
## Summary
CI is broken because nipy is not being updated to deal with numpy deprecations. This removes nipy tests generally. I'm seeing if I can add a requirement config that will cap numpy for now so we don't skip these tests entirely.