### PR TITLE
Tentative `=>networkx-3.0` support

### DIFF
--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -226,7 +226,8 @@ def cmat(
     # Add node information from specified parcellation scheme
     path, name, ext = split_filename(resolution_network_file)
     if ext == ".pck":
-        gp = nx.read_gpickle(resolution_network_file)
+        with open(resolution_network_file, 'rb') as f:
+            gp = pickle.load(f)
     elif ext == ".graphml":
         gp = nx.read_graphml(resolution_network_file)
     else:
@@ -379,7 +380,8 @@ def cmat(
                 fibdev.add_edge(u, v, weight=di["fiber_length_std"])
 
     iflogger.info("Writing network as %s", matrix_name)
-    nx.write_gpickle(G, op.abspath(matrix_name))
+    with open(op.abspath(matrix_name), 'wb') as f:
+        pickle.dump(G, f, pickle.HIGHEST_PROTOCOL)
 
     numfib_mlab = nx.to_numpy_matrix(numfib, dtype=int)
     numfib_dict = {"number_of_fibers": numfib_mlab}
@@ -394,7 +396,8 @@ def cmat(
         path, name, ext = split_filename(matrix_name)
         intersection_matrix_name = op.abspath(name + "_intersections") + ext
         iflogger.info("Writing intersection network as %s", intersection_matrix_name)
-        nx.write_gpickle(I, intersection_matrix_name)
+        with open(intersection_matrix_name, 'wb') as f:
+            pickle.dump(I, f, pickle.HIGHEST_PROTOCOL)
 
     path, name, ext = split_filename(matrix_mat_name)
     if not ext == ".mat":
@@ -1070,7 +1073,8 @@ def create_nodes(roi_file, resolution_network_file, out_filename):
             )
         )
         G.nodes[int(u)]["dn_position"] = tuple([xyz[0], xyz[2], -xyz[1]])
-    nx.write_gpickle(G, out_filename)
+    with open(out_filename, 'wb') as f:
+        pickle.dump(G, f, pickle.HIGHEST_PROTOCOL)
     return out_filename
 
 

--- a/nipype/interfaces/cmtk/cmtk.py
+++ b/nipype/interfaces/cmtk/cmtk.py
@@ -263,7 +263,7 @@ def cmat(
         )
         intersection_matrix = np.matrix(intersection_matrix)
         I = G.copy()
-        H = nx.from_numpy_matrix(np.matrix(intersection_matrix))
+        H = nx.from_numpy_array(np.matrix(intersection_matrix))
         H = nx.relabel_nodes(H, lambda x: x + 1)  # relabel nodes so they start at 1
         I.add_weighted_edges_from(
             ((u, v, d["weight"]) for u, v, d in H.edges(data=True))

--- a/nipype/interfaces/cmtk/nbs.py
+++ b/nipype/interfaces/cmtk/nbs.py
@@ -6,6 +6,7 @@ import os.path as op
 
 import numpy as np
 import networkx as nx
+import pickle
 
 from ... import logging
 from ..base import (
@@ -172,12 +173,14 @@ class NetworkBasedStatistic(LibraryBaseInterface):
 
         path = op.abspath("NBS_Result_" + details)
         iflogger.info(path)
-        nx.write_gpickle(nbsgraph, path)
+        with open(path, 'wb') as f:
+            pickle.dump(nbsgraph, f, pickle.HIGHEST_PROTOCOL)
         iflogger.info("Saving output NBS edge network as %s", path)
 
         pval_path = op.abspath("NBS_P_vals_" + details)
         iflogger.info(pval_path)
-        nx.write_gpickle(nbs_pval_graph, pval_path)
+        with open(pval_path, 'wb') as f:
+            pickle.dump(nbs_pval_graph, f, pickle.HIGHEST_PROTOCOL)
         iflogger.info("Saving output p-value network as %s", pval_path)
         return runtime
 

--- a/nipype/interfaces/cmtk/nbs.py
+++ b/nipype/interfaces/cmtk/nbs.py
@@ -149,8 +149,8 @@ class NetworkBasedStatistic(LibraryBaseInterface):
             pADJ[x, y] = PVAL[idx]
 
         # Create networkx graphs from the adjacency matrix
-        nbsgraph = nx.from_numpy_matrix(ADJ)
-        nbs_pval_graph = nx.from_numpy_matrix(pADJ)
+        nbsgraph = nx.from_numpy_array(ADJ)
+        nbs_pval_graph = nx.from_numpy_array(pADJ)
 
         # Relabel nodes because they should not start at zero for our convention
         nbsgraph = nx.relabel_nodes(nbsgraph, lambda x: x + 1)

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -200,7 +200,8 @@ def average_networks(in_files, ntwk_res_file, group_id):
 
     # Writes the networks and returns the name
     network_name = group_id + "_average.pck"
-    nx.write_gpickle(avg_ntwk, op.abspath(network_name))
+    with open(op.abspath(network_name), 'wb') as f:
+        pickle.dump(avg_ntwk, f, pickle.HIGHEST_PROTOCOL)
     iflogger.info("Saving average network as %s", op.abspath(network_name))
     avg_ntwk = fix_keys_for_gexf(avg_ntwk)
     network_name = group_id + "_average.gexf"
@@ -483,7 +484,8 @@ class NetworkXMetrics(BaseInterface):
         for key in list(node_measures.keys()):
             newntwk = add_node_data(node_measures[key], ntwk)
             out_file = op.abspath(self._gen_outfilename(key, "pck"))
-            nx.write_gpickle(newntwk, out_file)
+            with open(out_file, 'wb') as f:
+                pickle.dump(newntwk, f, pickle.HIGHEST_PROTOCOL)
             nodentwks.append(out_file)
         if isdefined(self.inputs.out_node_metrics_matlab):
             node_out_file = op.abspath(self.inputs.out_node_metrics_matlab)
@@ -497,7 +499,8 @@ class NetworkXMetrics(BaseInterface):
         for key in list(edge_measures.keys()):
             newntwk = add_edge_data(edge_measures[key], ntwk)
             out_file = op.abspath(self._gen_outfilename(key, "pck"))
-            nx.write_gpickle(newntwk, out_file)
+            with open(out_file, 'wb') as f:
+                pickle.dump(newntwk, f, pickle.HIGHEST_PROTOCOL)
             edgentwks.append(out_file)
         if isdefined(self.inputs.out_edge_metrics_matlab):
             edge_out_file = op.abspath(self.inputs.out_edge_metrics_matlab)
@@ -521,7 +524,8 @@ class NetworkXMetrics(BaseInterface):
                 out_file = op.abspath(
                     self._gen_outfilename(self.inputs.out_k_crust, "pck")
                 )
-            nx.write_gpickle(ntwk_measures[key], out_file)
+            with open(out_file, 'wb') as f:
+                pickle.dump(ntwk_measures[key], f, pickle.HIGHEST_PROTOCOL)
             kntwks.append(out_file)
         gpickled.extend(kntwks)
 

--- a/nipype/interfaces/cmtk/tests/test_nbs.py
+++ b/nipype/interfaces/cmtk/tests/test_nbs.py
@@ -17,7 +17,7 @@ def creating_graphs(tmpdir):
     graphnames = ["name" + str(i) for i in range(6)]
     for idx, name in enumerate(graphnames):
         graph = np.random.rand(10, 10)
-        G = nx.from_numpy_matrix(graph)
+        G = nx.from_numpy_array(graph)
         out_file = tmpdir.strpath + graphnames[idx] + ".pck"
         # Save as pck file
         nx.write_gpickle(G, out_file)

--- a/nipype/interfaces/cmtk/tests/test_nbs.py
+++ b/nipype/interfaces/cmtk/tests/test_nbs.py
@@ -2,6 +2,7 @@ from ..nbs import NetworkBasedStatistic
 from ....utils.misc import package_check
 import numpy as np
 import networkx as nx
+import pickle
 import pytest
 
 have_cv = True
@@ -20,7 +21,8 @@ def creating_graphs(tmpdir):
         G = nx.from_numpy_array(graph)
         out_file = tmpdir.strpath + graphnames[idx] + ".pck"
         # Save as pck file
-        nx.write_gpickle(G, out_file)
+        with open(out_file, 'wb') as f:
+            pickle.dump(G, f, pickle.HIGHEST_PROTOCOL)
         graphlist.append(out_file)
     return graphlist
 

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -434,7 +434,7 @@ class DistributedPluginBase(PluginBase):
         import networkx as nx
 
         self.procs, _ = topological_sort(graph)
-        self.depidx = nx.to_scipy_sparse_matrix(
+        self.depidx = nx.to_scipy_sparse_array(
             graph, nodelist=self.procs, format="lil"
         )
         self.refidx = self.depidx.astype(int)


### PR DESCRIPTION
Closes: https://github.com/nipy/nipype/issues/3530

Well, except it doesn't really fix the issue.

Without the patch: https://ppb.chymera.eu/b4e05b.log
With the patch: https://ppb.chymera.eu/9e1476.log

Basically instead of `AttributeError: module 'networkx' has no attribute 'to_scipy_sparse_matrix'` we now get `IndexError: tuple index out of range`... which, dunno, I guess solves the issue in the most narrow and unhelpful sense.

It seems our parameter usage is still correct, at least per the documentation of the new function...  Any ideas?