### PR TITLE
[FIX] update merge_imgs input type of dcm2niix Node

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -327,8 +327,10 @@ class Dcm2niixInputSpec(CommandLineInputSpec):
         usedefault=True,
         desc="Gzip compress images - [y=pigz, i=internal, n=no, 3=no,3D]",
     )
-    merge_imgs = traits.Bool(
-        False, argstr="-m", usedefault=True, desc="merge 2D slices from same series"
+    merge_imgs = traits.Enum(
+        0, 1, 2,
+        argstr="-m %d",
+        desc="merge 2D slices from same series regardless of echo, exposure, etc. - [0=no, 1=yes, 2=auto]",
     )
     single_file = traits.Bool(
         False, argstr="-s", usedefault=True, desc="Single file mode"


### PR DESCRIPTION
from Boolean to Enum to allow value 2 (2=auto, default in new versions). No usedefault to preserve backwards compatibility.
Issue #3533 