### PR TITLE
REL: 1.8.6

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -117,13 +117,13 @@
       "name": "Yvernault, Benjamin"
     },
     {
-      "name": "Hamalainen, Carlo",
-      "orcid": "0000-0001-7655-3830"
-    },
-    {
       "affiliation": "Institute for Biomedical Engineering, ETH and University of Zurich",
       "name": "Christian, Horea",
       "orcid": "0000-0001-7037-2449"
+    },
+    {
+      "name": "Hamalainen, Carlo",
+      "orcid": "0000-0001-7655-3830"
     },
     {
       "affiliation": "Stanford University",
@@ -194,6 +194,9 @@
       "orcid": "0000-0001-8878-1750"
     },
     {
+      "name": "Moloney, Brendan"
+    },
+    {
       "affiliation": "Otto-von-Guericke-University Magdeburg, Germany",
       "name": "Hanke, Michael",
       "orcid": "0000-0001-6398-6370"
@@ -201,9 +204,6 @@
     {
       "affiliation": "Child Mind Institute",
       "name": "Giavasis, Steven"
-    },
-    {
-      "name": "Moloney, Brendan"
     },
     {
       "affiliation": "SRI International",
@@ -364,6 +364,11 @@
       "orcid": "0000-0001-6488-4739"
     },
     {
+      "affiliation": "CEA",
+      "name": "Papadopoulos Orfanos, Dimitri",
+      "orcid": "0000-0002-1242-8990"
+    },
+    {
       "affiliation": "UniversityHospital Heidelberg, Germany",
       "name": "Kleesiek, Jens"
     },
@@ -413,11 +418,6 @@
     },
     {
       "name": "Haselgrove, Christian"
-    },
-    {
-      "affiliation": "CEA",
-      "name": "Papadopoulos Orfanos, Dimitri",
-      "orcid": "0000-0002-1242-8990"
     },
     {
       "affiliation": "Department of Psychology, Stanford University; Parietal, INRIA",

--- a/doc/changelog/1.X.X-changelog.rst
+++ b/doc/changelog/1.X.X-changelog.rst
@@ -1,3 +1,20 @@
+1.8.6 (April 05, 2023)
+======================
+
+Bug-fix release in the 1.8.x series.
+
+  * FIX: Update dcmstack interface for Py3 / newer pydicom (https://github.com/nipy/nipype/pull/3541)
+  * FIX: NiBabel 5, and NetworkX 3 and DIPY 1.6 compatibility (https://github.com/nipy/nipype/pull/3538)
+  * FIX: Check for non-mandatory output in DWIBiasCorrect (https://github.com/nipy/nipype/pull/3523)
+  * FIX: Removed leftover debug print statement in FEAT class (https://github.com/nipy/nipype/pull/3521)
+  * DOC: Fix a few more typos (https://github.com/nipy/nipype/pull/3516)
+  * DOC: Fix typos found by codespell (https://github.com/nipy/nipype/pull/3512)
+  * CI: Drop nipy tests until a fixed nipy is released (https://github.com/nipy/nipype/pull/3559)
+  * CI: Disable nipy tests generally, re-add with max numpy  (https://github.com/nipy/nipype/pull/3532)
+  * CI: GitHub Workflows security hardening  (https://github.com/nipy/nipype/pull/3519)
+  * CI: Allow tutorial test cancellation (https://github.com/nipy/nipype/pull/3514)
+
+
 1.8.5 (September 21, 2022)
 ==========================
 

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -5,7 +5,7 @@ docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 
 # nipype version information
 # Remove .dev0 for release
-__version__ = "1.8.6.dev0"
+__version__ = "1.8.6"
 
 
 def get_nipype_gitversion():


### PR DESCRIPTION
Preparation for the 1.8.6 release, delayed by broken CI, but needs doing.

@MatthieuJoulot @somso2e @sashashura Please let me know if you would like to be credited in releases, and if so what name, ORCID and affiliation you would like. See https://github.com/nipy/nipype/blob/master/.zenodo.json for examples.

Quick issues/PRs:

* ... Please let me know if you want to try to merge something in. This is really intended to get things fixed for downstream projects, though.

## Release checklist

* [ ] Merge pending PRs
* [x] Update changelog
* [ ] Update .mailmap
* [x] Update .zenodo.json
* [x] Set release number in `nipype/info.py`
* [x] Update `doc/interfaces.rst` with previous releases
* [ ] Check conda-forge feedstock build (https://github.com/conda-forge/nipype-feedstock/pull/89)
* [ ] Tutorial tests (https://github.com/miykael/nipype_tutorial/pull/181)