### PR TITLE
[REF] Stop using deprecated import internally

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -13,7 +13,7 @@ Top-level module API
 """
 import os
 
-# XXX Deprecate this import
+# XXX Deprecated import. Not used internally but could be used externally.
 from looseversion import LooseVersion
 
 from .info import URL as __url__, STATUS as __status__, __version__

--- a/nipype/interfaces/afni/base.py
+++ b/nipype/interfaces/afni/base.py
@@ -6,7 +6,9 @@ import os
 from sys import platform
 import shutil
 
-from ... import logging, LooseVersion
+from looseversion import LooseVersion
+
+from ... import logging
 from ...utils.filemanip import split_filename, fname_presuffix
 from ..base import (
     CommandLine,

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -16,7 +16,9 @@ import shlex
 import simplejson as json
 from traits.trait_errors import TraitError
 
-from ... import config, logging, LooseVersion
+from looseversion import LooseVersion
+
+from ... import config, logging
 from ...utils.provenance import write_provenance
 from ...utils.misc import str2bool
 from ...utils.filemanip import (

--- a/nipype/interfaces/freesurfer/base.py
+++ b/nipype/interfaces/freesurfer/base.py
@@ -16,7 +16,8 @@ See the docstrings for the individual classes for 'working' examples.
 """
 import os
 
-from ... import LooseVersion
+from looseversion import LooseVersion
+
 from ...utils.filemanip import fname_presuffix
 from ..base import (
     CommandLine,

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -9,10 +9,11 @@ from glob import glob
 import shutil
 import sys
 
+from looseversion import LooseVersion
 import numpy as np
 from nibabel import load
 
-from ... import logging, LooseVersion
+from ... import logging
 from ...utils.filemanip import fname_presuffix, check_depends
 from ..io import FreeSurferSource
 from ..base import (

--- a/nipype/interfaces/freesurfer/tests/test_preprocess.py
+++ b/nipype/interfaces/freesurfer/tests/test_preprocess.py
@@ -4,11 +4,11 @@
 import os
 
 import pytest
-from nipype.testing.fixtures import create_files_in_directory
+from looseversion import LooseVersion
 
+from nipype.testing.fixtures import create_files_in_directory
 from nipype.interfaces import freesurfer
 from nipype.interfaces.freesurfer import Info
-from nipype import LooseVersion
 
 
 @pytest.mark.skipif(freesurfer.no_freesurfer(), reason="freesurfer is not installed")

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -11,9 +11,9 @@ from shutil import rmtree
 from string import Template
 
 import numpy as np
+from looseversion import LooseVersion
 from nibabel import load
 
-from ... import LooseVersion
 from ...utils.filemanip import simplify_list, ensure_list
 from ...utils.misc import human_order_sorted
 from ...external.due import BibTeX

--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -11,8 +11,8 @@ from warnings import warn
 
 import numpy as np
 from nibabel import load
+from looseversion import LooseVersion
 
-from ... import LooseVersion
 from ...utils.filemanip import split_filename
 from ..base import (
     TraitedSpec,

--- a/nipype/interfaces/image.py
+++ b/nipype/interfaces/image.py
@@ -4,7 +4,8 @@
 
 from ..utils.filemanip import fname_presuffix
 from .base import SimpleInterface, TraitedSpec, BaseInterfaceInputSpec, traits, File
-from .. import LooseVersion
+
+from looseversion import LooseVersion
 
 
 class RescaleInputSpec(BaseInterfaceInputSpec):

--- a/nipype/interfaces/mrtrix3/base.py
+++ b/nipype/interfaces/mrtrix3/base.py
@@ -2,7 +2,9 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 # -*- coding: utf-8 -*-
 
-from ... import logging, LooseVersion
+from looseversion import LooseVersion
+
+from ... import logging
 from ...utils.filemanip import which
 from ..base import (
     CommandLineInputSpec,

--- a/nipype/interfaces/tests/test_image.py
+++ b/nipype/interfaces/tests/test_image.py
@@ -4,10 +4,10 @@ import numpy as np
 import nibabel as nb
 import pytest
 
+from looseversion import LooseVersion
 from nibabel.orientations import axcodes2ornt, ornt_transform
 
 from ..image import _as_reoriented_backport, _orientations
-from ... import LooseVersion
 
 nibabel24 = LooseVersion(nb.__version__) >= LooseVersion("2.4.0")
 


### PR DESCRIPTION
## Summary

Remove internal imports of deprecated `nipype.LooseVersion` for `looseversion.LooseVersion`