### PR TITLE
Normalize and Normalize12 use "estimate" and not "est" as the jobtype

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1110,7 +1110,7 @@ class NormalizeInputSpec(SPMCommandInputSpec):
         copyfile=True,
     )
     jobtype = traits.Enum(
-        "estwrite", "est", "write", usedefault=True, desc="Estimate, Write or do both"
+        "estwrite", "estimate", "write", usedefault=True, desc="Estimate, Write or do both"
     )
     apply_to_files = InputMultiPath(
         traits.Either(File(exists=True), traits.List(File(exists=True))),
@@ -1318,7 +1318,7 @@ class Normalize12InputSpec(SPMCommandInputSpec):
         ),
     )
     jobtype = traits.Enum(
-        "estwrite", "est", "write", usedefault=True, desc="Estimate, Write or do Both"
+        "estwrite", "estimate", "write", usedefault=True, desc="Estimate, Write or do Both"
     )
     bias_regularization = traits.Enum(
         0,

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1110,7 +1110,11 @@ class NormalizeInputSpec(SPMCommandInputSpec):
         copyfile=True,
     )
     jobtype = traits.Enum(
-        "estwrite", "estimate", "write", usedefault=True, desc="Estimate, Write or do both"
+        "estwrite",
+        "estimate",
+        "write",
+        usedefault=True,
+        desc="Estimate, Write or do both",
     )
     apply_to_files = InputMultiPath(
         traits.Either(File(exists=True), traits.List(File(exists=True))),
@@ -1318,7 +1322,11 @@ class Normalize12InputSpec(SPMCommandInputSpec):
         ),
     )
     jobtype = traits.Enum(
-        "estwrite", "estimate", "write", usedefault=True, desc="Estimate, Write or do Both"
+        "estwrite",
+        "estimate",
+        "write",
+        usedefault=True,
+        desc="Estimate, Write or do Both",
     )
     bias_regularization = traits.Enum(
         0,


### PR DESCRIPTION
Normalize and Normalize12 of SPM use in the _list_outputs method "estimate" as jobtype and not "est". In addition, SPM uses "estimate" for the jobtype.
