### PR TITLE
FIX: update self.inputs.optimization in outputs for GTMPVC

### DIFF
--- a/nipype/interfaces/freesurfer/petsurfer.py
+++ b/nipype/interfaces/freesurfer/petsurfer.py
@@ -557,7 +557,7 @@ class GTMPVC(FSCommand):
             outputs["rbv"] = os.path.join(pvcdir, "rbv.nii.gz")
             outputs["reg_rbvpet2anat"] = os.path.join(pvcdir, "aux", "rbv2anat.lta")
             outputs["reg_anat2rbvpet"] = os.path.join(pvcdir, "aux", "anat2rbv.lta")
-        if self.inputs.opt:
+        if self.inputs.optimization_schema:
             outputs["opt_params"] = os.path.join(pvcdir, "aux", "opt.params.dat")
 
         return outputs


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
This PR fixes the output specification for 'optimization_schema' in the petsurfer interface GTMPVC.

Fixes #3570 https://github.com/nipy/nipype/issues/3570#issue-1713336530

## List of changes proposed in this PR (pull-request)
* update output to match input spec
