### PR TITLE
dcm2niix - Do consider exit 1 to be an error

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -446,8 +446,7 @@ class Dcm2niix(CommandLine):
         return super()._format_arg(opt, spec, val)
 
     def _run_interface(self, runtime):
-        # may use return code 1 despite conversion
-        runtime = super()._run_interface(runtime, correct_return_codes=(0, 1))
+        runtime = super()._run_interface(runtime)
         self._parse_files(self._parse_stdout(runtime.stdout))
         return runtime
 


### PR DESCRIPTION
Based on information in
https://github.com/rordenlab/dcm2niix/issues/733#issuecomment-1646261249

> Exit code 0 is for success, exit code 1 is the undefined error.

Handling of exit 1 as successful was added in 6ecd4a9fce3c9cf1ff23d5b895db319343ae0576 AKA `1.0.2~2^2~13`

Closes #3592 