### PR TITLE
FIX: DWIPreproc issue

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -320,7 +320,7 @@
     },
     {
       "affiliation": "Sagol School of Neuroscience, Tel Aviv University",
-      "name": "Ben-Zvi, Gal",
+      "name": "Kepler, Gal",
       "orcid": "0000-0002-5655-9423"
     },
     {

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -406,7 +406,7 @@ class DWIPreproc(MRTrix3Base):
     def _list_outputs(self):
         outputs = self.output_spec().get()
         outputs["out_file"] = op.abspath(self.inputs.out_file)
-        if self.inputs.export_grad_mrtrix:
+        if self.inputs.out_grad_mrtrix:
             outputs["out_grad_mrtrix"] = op.abspath(self.inputs.out_grad_mrtrix)
         if self.inputs.export_grad_fsl:
             outputs["out_fsl_bvec"] = op.abspath(self.inputs.out_grad_fsl[0])

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -192,9 +192,7 @@ class DWIBiasCorrectInputSpec(MRTrix3BaseInputSpec):
         mandatory=True,
         desc="input DWI image",
     )
-    in_mask = File(
-        argstr="-mask %s", desc="input mask image for bias field estimation"
-    )
+    in_mask = File(argstr="-mask %s", desc="input mask image for bias field estimation")
     use_ants = traits.Bool(
         argstr="ants",
         mandatory=True,
@@ -409,9 +407,7 @@ class DWIPreproc(MRTrix3Base):
         outputs = self.output_spec().get()
         outputs["out_file"] = op.abspath(self.inputs.out_file)
         if self.inputs.out_grad_mrtrix:
-            outputs["out_grad_mrtrix"] = op.abspath(
-                self.inputs.out_grad_mrtrix
-            )
+            outputs["out_grad_mrtrix"] = op.abspath(self.inputs.out_grad_mrtrix)
         if self.inputs.out_grad_fsl:
             outputs["out_fsl_bvec"] = op.abspath(self.inputs.out_grad_fsl[0])
             outputs["out_fsl_bval"] = op.abspath(self.inputs.out_grad_fsl[1])
@@ -445,15 +441,9 @@ class ResponseSDInputSpec(MRTrix3BaseInputSpec):
         usedefault=True,
         desc="output WM response text file",
     )
-    gm_file = File(
-        argstr="%s", position=-2, desc="output GM response text file"
-    )
-    csf_file = File(
-        argstr="%s", position=-1, desc="output CSF response text file"
-    )
-    in_mask = File(
-        exists=True, argstr="-mask %s", desc="provide initial mask image"
-    )
+    gm_file = File(argstr="%s", position=-2, desc="output GM response text file")
+    csf_file = File(argstr="%s", position=-1, desc="output CSF response text file")
+    in_mask = File(exists=True, argstr="-mask %s", desc="provide initial mask image")
     max_sh = InputMultiObject(
         traits.Int,
         argstr="-lmax %s",

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -412,7 +412,7 @@ class DWIPreproc(MRTrix3Base):
             outputs["out_grad_mrtrix"] = op.abspath(
                 self.inputs.out_grad_mrtrix
             )
-        if self.inputs.out_fsl_bvec:
+        if self.inputs.out_grad_fsl:
             outputs["out_fsl_bvec"] = op.abspath(self.inputs.out_grad_fsl[0])
             outputs["out_fsl_bval"] = op.abspath(self.inputs.out_grad_fsl[1])
 

--- a/nipype/interfaces/mrtrix3/preprocess.py
+++ b/nipype/interfaces/mrtrix3/preprocess.py
@@ -192,7 +192,9 @@ class DWIBiasCorrectInputSpec(MRTrix3BaseInputSpec):
         mandatory=True,
         desc="input DWI image",
     )
-    in_mask = File(argstr="-mask %s", desc="input mask image for bias field estimation")
+    in_mask = File(
+        argstr="-mask %s", desc="input mask image for bias field estimation"
+    )
     use_ants = traits.Bool(
         argstr="ants",
         mandatory=True,
@@ -407,8 +409,10 @@ class DWIPreproc(MRTrix3Base):
         outputs = self.output_spec().get()
         outputs["out_file"] = op.abspath(self.inputs.out_file)
         if self.inputs.out_grad_mrtrix:
-            outputs["out_grad_mrtrix"] = op.abspath(self.inputs.out_grad_mrtrix)
-        if self.inputs.export_grad_fsl:
+            outputs["out_grad_mrtrix"] = op.abspath(
+                self.inputs.out_grad_mrtrix
+            )
+        if self.inputs.out_fsl_bvec:
             outputs["out_fsl_bvec"] = op.abspath(self.inputs.out_grad_fsl[0])
             outputs["out_fsl_bval"] = op.abspath(self.inputs.out_grad_fsl[1])
 
@@ -441,9 +445,15 @@ class ResponseSDInputSpec(MRTrix3BaseInputSpec):
         usedefault=True,
         desc="output WM response text file",
     )
-    gm_file = File(argstr="%s", position=-2, desc="output GM response text file")
-    csf_file = File(argstr="%s", position=-1, desc="output CSF response text file")
-    in_mask = File(exists=True, argstr="-mask %s", desc="provide initial mask image")
+    gm_file = File(
+        argstr="%s", position=-2, desc="output GM response text file"
+    )
+    csf_file = File(
+        argstr="%s", position=-1, desc="output CSF response text file"
+    )
+    in_mask = File(
+        exists=True, argstr="-mask %s", desc="provide initial mask image"
+    )
     max_sh = InputMultiObject(
         traits.Int,
         argstr="-lmax %s",


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Just a small fix in MRtrix3's DWIPreproc class - referencing `out_grad_mrtrix` instead of `export_grad_mrtrix` in the `_list_outputs` method of the class.

Fixes #3595.

## List of changes proposed in this PR (pull-request)
* Fixed DWIPreproc class.

