### PR TITLE
Fix typo in spm.Normalize12 process

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1290,6 +1290,7 @@ class Normalize12InputSpec(SPMCommandInputSpec):
         field="subj.vol",
         desc=("file to estimate normalization parameters with"),
         xor=["deformation_file"],
+        mandatory=True,
         copyfile=True,
     )
     apply_to_files = InputMultiPath(
@@ -1302,6 +1303,7 @@ class Normalize12InputSpec(SPMCommandInputSpec):
     )
     deformation_file = ImageFileSPM(
         field="subj.def",
+        mandatory=True,
         xor=["image_to_align", "tpm"],
         copyfile=False,
         desc=(

--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1290,7 +1290,6 @@ class Normalize12InputSpec(SPMCommandInputSpec):
         field="subj.vol",
         desc=("file to estimate normalization parameters with"),
         xor=["deformation_file"],
-        mandatory=True,
         copyfile=True,
     )
     apply_to_files = InputMultiPath(
@@ -1303,7 +1302,6 @@ class Normalize12InputSpec(SPMCommandInputSpec):
     )
     deformation_file = ImageFileSPM(
         field="subj.def",
-        mandatory=True,
         xor=["image_to_align", "tpm"],
         copyfile=False,
         desc=(
@@ -1485,13 +1483,7 @@ class Normalize12(SPMCommand):
                 outputs["deformation_field"].append(fname_presuffix(imgf, prefix="y_"))
             outputs["deformation_field"] = simplify_list(outputs["deformation_field"])
 
-        if self.inputs.jobtype == "estimate":
-            if isdefined(self.inputs.apply_to_files):
-                outputs["normalized_files"] = self.inputs.apply_to_files
-            outputs["normalized_image"] = fname_presuffix(
-                self.inputs.image_to_align, prefix="w"
-            )
-        elif "write" in self.inputs.jobtype:
+        if "write" in self.inputs.jobtype:
             outputs["normalized_files"] = []
             if isdefined(self.inputs.apply_to_files):
                 filelist = ensure_list(self.inputs.apply_to_files)


### PR DESCRIPTION
Please consider this PR that will be fast to review:

1-  `deformation_file` and `image_to_align` are mutually exclusive. So we can't use the `mandatory=True` option for these two traits, as one of them will always be Undefined.
2- the `self.inputs.jobtype == "estimate"` statement is useless because the `jobtype` trait can only take values in [["est", "write", "estwrite"]](https://github.com/nipy/nipype/blob/dac6aee9a0f331c4f498f14a7ffb84abc989594a/nipype/interfaces/spm/preprocess.py#L1315).

For point 2- it's not very important, it doesn't stop the run, it's just useless.
For point 1-, it's critical because the condition for one or the other can never be met, and this blocks the use of this process in our application, which uses nipype.

