### PR TITLE
Use out_prefix instead of "w" in spm.Normalize12

### DIFF
--- a/nipype/interfaces/spm/preprocess.py
+++ b/nipype/interfaces/spm/preprocess.py
@@ -1491,13 +1491,13 @@ class Normalize12(SPMCommand):
                 filelist = ensure_list(self.inputs.apply_to_files)
                 for f in filelist:
                     if isinstance(f, list):
-                        run = [fname_presuffix(in_f, prefix="w") for in_f in f]
+                        run = [fname_presuffix(in_f, prefix=self.inputs.out_prefix) for in_f in f]
                     else:
-                        run = [fname_presuffix(f, prefix="w")]
+                        run = [fname_presuffix(f, prefix=self.inputs.out_prefix)]
                     outputs["normalized_files"].extend(run)
             if isdefined(self.inputs.image_to_align):
                 outputs["normalized_image"] = fname_presuffix(
-                    self.inputs.image_to_align, prefix="w"
+                    self.inputs.image_to_align, prefix=self.inputs.out_prefix
                 )
 
         return outputs


### PR DESCRIPTION
Please consider this PR that will be fast to review:

I think there are two solutions.
1- Remove the `out_prefix` parameter and the prefix remains always at "w" 
or
2- use the `out_prefix` parameter instead of the hard-coded "w" value.

I think the second solution is the right one. 
I propose a slight modification to this effect.

