### PR TITLE
[FIX] MRTrix3 change inputs position for MRTransform

### DIFF
--- a/nipype/interfaces/mrtrix3/tests/test_auto_MRTransform.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_MRTransform.py
@@ -12,7 +12,6 @@ def test_MRTransform_inputs():
         ),
         debug=dict(
             argstr="-debug",
-            position=1,
         ),
         environ=dict(
             nohash=True,
@@ -20,7 +19,6 @@ def test_MRTransform_inputs():
         ),
         flip_x=dict(
             argstr="-flipx",
-            position=1,
         ),
         grad_file=dict(
             argstr="-grad %s",
@@ -45,12 +43,10 @@ def test_MRTransform_inputs():
         ),
         invert=dict(
             argstr="-inverse",
-            position=1,
         ),
         linear_transform=dict(
             argstr="-linear %s",
             extensions=None,
-            position=1,
         ),
         nthreads=dict(
             argstr="-nthreads %d",
@@ -71,26 +67,21 @@ def test_MRTransform_inputs():
         ),
         quiet=dict(
             argstr="-quiet",
-            position=1,
         ),
         reference_image=dict(
             argstr="-reference %s",
             extensions=None,
-            position=1,
         ),
         replace_transform=dict(
             argstr="-replace",
-            position=1,
         ),
         template_image=dict(
             argstr="-template %s",
             extensions=None,
-            position=1,
         ),
         transformation_file=dict(
             argstr="-transform %s",
             extensions=None,
-            position=1,
         ),
     )
     inputs = MRTransform.input_spec()

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -822,13 +822,11 @@ class MRTransformInputSpec(MRTrix3BaseInputSpec):
     )
     invert = traits.Bool(
         argstr="-inverse",
-        position=1,
         desc="Invert the specified transform before using it",
     )
     linear_transform = File(
         exists=True,
         argstr="-linear %s",
-        position=1,
         desc=(
             "Specify a linear transform to apply, in the form of a 3x4 or 4x4 ascii file. "
             "Note the standard reverse convention is used, "
@@ -838,38 +836,32 @@ class MRTransformInputSpec(MRTrix3BaseInputSpec):
     )
     replace_transform = traits.Bool(
         argstr="-replace",
-        position=1,
         desc="replace the current transform by that specified, rather than applying it to the current transform",
     )
     transformation_file = File(
         exists=True,
         argstr="-transform %s",
-        position=1,
         desc="The transform to apply, in the form of a 4x4 ascii file.",
     )
     template_image = File(
         exists=True,
         argstr="-template %s",
-        position=1,
         desc="Reslice the input image to match the specified template image.",
     )
     reference_image = File(
         exists=True,
         argstr="-reference %s",
-        position=1,
         desc="in case the transform supplied maps from the input image onto a reference image, use this option to specify the reference. Note that this implicitly sets the -replace option.",
     )
     flip_x = traits.Bool(
         argstr="-flipx",
-        position=1,
         desc="assume the transform is supplied assuming a coordinate system with the x-axis reversed relative to the MRtrix convention (i.e. x increases from right to left). This is required to handle transform matrices produced by FSL's FLIRT command. This is only used in conjunction with the -reference option.",
     )
     quiet = traits.Bool(
         argstr="-quiet",
-        position=1,
         desc="Do not display information messages or progress status.",
     )
-    debug = traits.Bool(argstr="-debug", position=1, desc="Display debugging messages.")
+    debug = traits.Bool(argstr="-debug", desc="Display debugging messages.")
 
 
 class MRTransformOutputSpec(TraitedSpec):


### PR DESCRIPTION
If several arguments are used (for example invert and linear_transform) they are not all take into account (and so it is not the same behavior as the native mrtrix3 command). 
I think that it is because they are all set to `position = 1`
I think it is not necessary to precise `position` for those arguments as `argstr` is already filled with an information about position .
 

 