### PR TITLE
ENH: added 'hsvs' option to 5ttgen + mrtransform fix

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -911,6 +911,11 @@
       "name": "Wu, Jianxiao",
       "orcid": "0000-0002-4866-272X",
     },
+    {
+      "affiliation": "Lund University",
+      "name": "Anijärv, Toomas Erik",
+      "orcid": "0000-0002-3650-4230",
+    },
   ],
   "keywords": [
     "neuroimaging",

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -11,6 +11,7 @@ from ..base import (
     traits,
     TraitedSpec,
     File,
+    Directory,
     InputMultiPath,
     isdefined,
 )
@@ -230,8 +231,10 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         mandatory=True,
         desc="tissue segmentation algorithm",
     )
-    in_file = File(
-        exists=False, argstr="%s", mandatory=True, position=-2, desc="input image"
+    in_file = traits.Either(
+        File(exists=True),
+        Directory(exists=True),
+        argstr="%s", mandatory=True, position=-2, desc="input image / directory"
     )
     out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
 

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -224,13 +224,14 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         "fsl",
         "gif",
         "freesurfer",
+        "hsvs",
         argstr="%s",
         position=-3,
         mandatory=True,
         desc="tissue segmentation algorithm",
     )
     in_file = File(
-        exists=True, argstr="%s", mandatory=True, position=-2, desc="input image"
+        exists=False, argstr="%s", mandatory=True, position=-2, desc="input image"
     )
     out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
 

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -823,7 +823,7 @@ class MRTransformInputSpec(MRTrix3BaseInputSpec):
     )
     invert = traits.Bool(
         argstr="-inverse",
-        position=1,
+        position=2,
         desc="Invert the specified transform before using it",
     )
     linear_transform = File(

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -826,7 +826,7 @@ class MRTransformInputSpec(MRTrix3BaseInputSpec):
     )
     invert = traits.Bool(
         argstr="-inverse",
-        position=2,
+        position=1,
         desc="Invert the specified transform before using it",
     )
     linear_transform = File(


### PR DESCRIPTION
- added Hybrid Surface and Volume Segmentation ('hsvs') option to the 5TT image generation class
- removed the in_file existing requirement (exists=True -> exists=False) for 5ttgen because hsvs requires a directory not a file as input
- changed '-inverse' parameter location from 1 to 2 in mrtransform class (to make it possible to insert it in the command together with other parameters)
