### PR TITLE
ENH: add STC PVC to PETPVC interface

### DIFF
--- a/nipype/interfaces/petpvc.py
+++ b/nipype/interfaces/petpvc.py
@@ -37,6 +37,7 @@ pvc_methods = [
     "RBV+VC",
     "RL",
     "VC",
+    "STC",
 ]
 
 
@@ -75,6 +76,7 @@ Desired PVC method:
     * Muller Gartner -- ``MG``
     * Muller Gartner with Van-Cittert -- ``MG+VC``
     * Muller Gartner with Richardson-Lucy -- ``MG+RL``
+    * Single-target correction -- ``STC``
 
 """,
     )


### PR DESCRIPTION
## Summary
This PR adds single-target PVC correction to the PETPVC interface in Nipype. The STC is already included in PETPVC, however, the interface needs to be updated to reflect these changes.

Fixes #3633

## List of changes proposed in this PR (pull-request)
1. Add the 'STC' option to the 'pvc' flag in the PETPVC interface

