### PR TITLE
STY: Apply ruff/pyupgrade rules

### DIFF
--- a/nipype/external/fsl_imglob.py
+++ b/nipype/external/fsl_imglob.py
@@ -91,14 +91,6 @@ def main():
     if len(sys.argv) <= 1:
         usage()
 
-    if sys.version_info < (2, 4):
-        import sets
-        from sets import Set
-
-        setAvailable = False
-    else:
-        setAvailable = True
-
     deleteExtensions = True
     primaryExtensions = [".nii.gz", ".nii", ".hdr.gz", ".hdr"]
     secondaryExtensions = [".img.gz", ".img"]
@@ -131,18 +123,13 @@ def main():
             )
 
     if deleteExtensions:
-        for file in range(0, len(filelist)):
-            filelist[file] = removeImageExtension(filelist[file], allExtensions)
-    if setAvailable:
-        filelist = list(set(filelist))
-    else:
-        filelist = list(Set(filelist))
-    filelist.sort()
+        filelist = [
+            removeImageExtension(f, allExtensions)
+            for f in filelist
+        ]
+    filelist = sorted(set(filelist))
 
-    for file in range(0, len(filelist)):
-        print(filelist[file], end=" ")
-        if file < len(filelist) - 1:
-            print(" ", end=" ")
+    print(*filelist, sep= "   ", end=" ")
 
 
 if __name__ == "__main__":

--- a/nipype/external/fsl_imglob.py
+++ b/nipype/external/fsl_imglob.py
@@ -123,13 +123,10 @@ def main():
             )
 
     if deleteExtensions:
-        filelist = [
-            removeImageExtension(f, allExtensions)
-            for f in filelist
-        ]
+        filelist = [removeImageExtension(f, allExtensions) for f in filelist]
     filelist = sorted(set(filelist))
 
-    print(*filelist, sep= "   ", end=" ")
+    print(*filelist, sep="   ", end=" ")
 
 
 if __name__ == "__main__":

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -84,7 +84,7 @@ def copytree(src, dst, use_hardlink=False):
                     hashmethod="content",
                     use_hardlink=use_hardlink,
                 )
-        except (OSError, os.error) as why:
+        except OSError as why:
             errors.append((srcname, dstname, str(why)))
         # catch the Error from the recursive copytree so that we can
         # continue with other files

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -289,7 +289,7 @@ connected.
         for srcnode, dstnode, conn in connection_list:
             logger.debug("disconnect(): %s->%s %s", srcnode, dstnode, str(conn))
             if self in [srcnode, dstnode]:
-                raise IOError(
+                raise OSError(
                     "Workflow connect cannot contain itself as node: src[%s] "
                     "dest[%s] workflow[%s]"
                 ) % (srcnode, dstnode, self.name)

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -227,7 +227,7 @@ class QstatSubstitute:
                     time.mktime(time.strptime(job_time_text, "%Y-%m-%dT%H:%M:%S"))
                 )
             except:
-                job_time = float(0.0)
+                job_time = 0.0
                 # Make job entry
 
             task_id = int(job_num)

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -91,10 +91,8 @@ class QJobInfo:
             # if initializing for more than 5 minute, failure due to
             # initialization and completion before registration
             sge_debug_print(
-                "FAILURE! QJobInfo.IsPending found long running at {1} seconds"
-                "'initializing' returning False for to break loop!\n{0}".format(
-                    self, time_diff
-                )
+                f"FAILURE! QJobInfo.IsPending found long running at {time_diff} seconds "
+                f"'initializing' returning False for to break loop!\n{self}"
             )
             is_pending_status = True  # Job initialization took too long, so report!
         else:  # self.is_running() || self.is_pending():

--- a/nipype/pipeline/plugins/sgegraph.py
+++ b/nipype/pipeline/plugins/sgegraph.py
@@ -130,9 +130,7 @@ class SGEGraphPlugin(GraphPluginBase):
                                 not self._dont_resubmit_completed_jobs
                                 or not cache_doneness_per_node[jobid]
                             ):
-                                values += "${{{0}}},".format(
-                                    make_job_name(jobid, nodes)
-                                )
+                                values += f"${{{make_job_name(jobid, nodes)}}},"
                         if (
                             values != " "
                         ):  # i.e. if some jobs were added to dependency list

--- a/nipype/pipeline/plugins/slurmgraph.py
+++ b/nipype/pipeline/plugins/slurmgraph.py
@@ -130,9 +130,7 @@ class SLURMGraphPlugin(GraphPluginBase):
                                 not self._dont_resubmit_completed_jobs
                                 or not cache_doneness_per_node[jobid]
                             ):
-                                values += "${{{0}}}:".format(
-                                    make_job_name(jobid, nodes)
-                                )
+                                values += f"${{{make_job_name(jobid, nodes)}}}:"
                         if (
                             values != ""
                         ):  # i.e. if some jobs were added to dependency list


### PR DESCRIPTION
## Summary

Apply `UP` rules except `UP031` (598 errors) and `UP032` (86 errors)

## List of changes proposed in this PR (pull-request)

* Apply ruff/pyupgrade rule UP018
    UP018 Unnecessary `float` call (rewrite as a literal)
* Apply ruff/pyupgrade rule UP024
    UP024 Replace aliased errors with `OSError`
* Apply ruff/pyupgrade rule UP030
    UP030 Use implicit references for positional format fields
* Apply ruff/pyupgrade rule UP036
    UP036 Version block is outdated for minimum Python version
