### PR TITLE
STY: Apply ruff/refurb rules

### DIFF
--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -531,7 +531,7 @@ def remove_identical_paths(in_files):
         commonprefix = op.commonprefix(in_files)
         lastslash = commonprefix.rfind("/")
         commonpath = commonprefix[0 : (lastslash + 1)]
-        for fileidx, in_file in enumerate(in_files):
+        for in_file in in_files:
             path, name, ext = split_filename(in_file)
             in_file = op.join(path, name)
             name = in_file.replace(commonpath, "")

--- a/nipype/interfaces/ants/registration.py
+++ b/nipype/interfaces/ants/registration.py
@@ -1127,14 +1127,10 @@ class Registration(ANTSCommand):
         return retval
 
     def _format_transform(self, index):
-        retval = []
-        retval.append("%s[ " % self.inputs.transforms[index])
         parameters = ", ".join(
             [str(element) for element in self.inputs.transform_parameters[index]]
         )
-        retval.append("%s" % parameters)
-        retval.append(" ]")
-        return "".join(retval)
+        return f"{self.inputs.transforms[index]}[ {parameters} ]"
 
     def _format_registration(self):
         retval = []

--- a/nipype/interfaces/cmtk/nx.py
+++ b/nipype/interfaces/cmtk/nx.py
@@ -124,7 +124,7 @@ def average_networks(in_files, ntwk_res_file, group_id):
         ntwk = remove_all_edges(ntwk_res_file)
         counting_ntwk = ntwk.copy()
         # Sums all the relevant variables
-        for index, subject in enumerate(in_files):
+        for subject in in_files:
             tmp = _read_pickle(subject)
             iflogger.info("File %s has %i edges", subject, tmp.number_of_edges())
             edges = list(tmp.edges())

--- a/nipype/interfaces/cmtk/tests/test_nbs.py
+++ b/nipype/interfaces/cmtk/tests/test_nbs.py
@@ -16,7 +16,7 @@ except Exception as e:
 def creating_graphs(tmpdir):
     graphlist = []
     graphnames = ["name" + str(i) for i in range(6)]
-    for idx, name in enumerate(graphnames):
+    for idx in range(len(graphnames)):
         graph = np.random.rand(10, 10)
         G = nx.from_numpy_array(graph)
         out_file = tmpdir.strpath + graphnames[idx] + ".pck"

--- a/nipype/interfaces/dipy/reconstruction.py
+++ b/nipype/interfaces/dipy/reconstruction.py
@@ -124,7 +124,7 @@ class RESTORE(DipyDiffusionInterface):
         else:
             nodiff = np.where(~gtab.b0s_mask)
             nodiffidx = nodiff[0].tolist()
-            n = 20 if len(nodiffidx) >= 20 else len(nodiffidx)
+            n = min(20, len(nodiffidx))
             idxs = np.random.choice(nodiffidx, size=n, replace=False)
             noise_data = dsample.take(idxs, axis=-1)[noise_msk == 1, ...]
 

--- a/nipype/interfaces/elastix/registration.py
+++ b/nipype/interfaces/elastix/registration.py
@@ -82,7 +82,7 @@ class Registration(CommandLine):
             config = {}
 
             with open(params) as f:
-                for line in f.readlines():
+                for line in f:
                     line = line.strip()
                     if not line.startswith("//") and line:
                         m = regex.search(line)

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -826,7 +826,10 @@ threshold=10, results_dir='stats')
                 for line in fp:
                     if line.startswith("/NumWaves"):
                         numpes = int(line.split()[-1])
-                        files = [self._gen_fname(f"pe{i + 1}.nii", cwd=cwd) for i in range(numpes)]
+                        files = [
+                            self._gen_fname(f"pe{i + 1}.nii", cwd=cwd)
+                            for i in range(numpes)
+                        ]
                         break
         return files
 

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -822,34 +822,31 @@ threshold=10, results_dir='stats')
     def _get_pe_files(self, cwd):
         files = None
         if isdefined(self.inputs.design_file):
-            fp = open(self.inputs.design_file)
-            for line in fp.readlines():
-                if line.startswith("/NumWaves"):
-                    numpes = int(line.split()[-1])
-                    files = []
-                    for i in range(numpes):
-                        files.append(self._gen_fname("pe%d.nii" % (i + 1), cwd=cwd))
-                    break
-            fp.close()
+            with open(self.inputs.design_file) as fp:
+                for line in fp:
+                    if line.startswith("/NumWaves"):
+                        numpes = int(line.split()[-1])
+                        files = []
+                        for i in range(numpes):
+                            files.append(self._gen_fname("pe%d.nii" % (i + 1), cwd=cwd))
+                        break
         return files
 
     def _get_numcons(self):
         numtcons = 0
         numfcons = 0
         if isdefined(self.inputs.tcon_file):
-            fp = open(self.inputs.tcon_file)
-            for line in fp.readlines():
-                if line.startswith("/NumContrasts"):
-                    numtcons = int(line.split()[-1])
-                    break
-            fp.close()
+            with open(self.inputs.tcon_file) as fp:
+                for line in fp:
+                    if line.startswith("/NumContrasts"):
+                        numtcons = int(line.split()[-1])
+                        break
         if isdefined(self.inputs.fcon_file):
-            fp = open(self.inputs.fcon_file)
-            for line in fp.readlines():
-                if line.startswith("/NumContrasts"):
-                    numfcons = int(line.split()[-1])
-                    break
-            fp.close()
+            with open(self.inputs.fcon_file) as fp:
+                for line in fp:
+                    if line.startswith("/NumContrasts"):
+                        numfcons = int(line.split()[-1])
+                        break
         return numtcons, numfcons
 
     def _list_outputs(self):
@@ -1297,19 +1294,17 @@ class ContrastMgr(FSLCommand):
         numtcons = 0
         numfcons = 0
         if isdefined(self.inputs.tcon_file):
-            fp = open(self.inputs.tcon_file)
-            for line in fp.readlines():
-                if line.startswith("/NumContrasts"):
-                    numtcons = int(line.split()[-1])
-                    break
-            fp.close()
+            with open(self.inputs.tcon_file) as fp:
+                for line in fp:
+                    if line.startswith("/NumContrasts"):
+                        numtcons = int(line.split()[-1])
+                        break
         if isdefined(self.inputs.fcon_file):
-            fp = open(self.inputs.fcon_file)
-            for line in fp.readlines():
-                if line.startswith("/NumContrasts"):
-                    numfcons = int(line.split()[-1])
-                    break
-            fp.close()
+            with open(self.inputs.fcon_file) as fp:
+                for line in fp:
+                    if line.startswith("/NumContrasts"):
+                        numfcons = int(line.split()[-1])
+                        break
         return numtcons, numfcons
 
     def _list_outputs(self):

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -826,9 +826,7 @@ threshold=10, results_dir='stats')
                 for line in fp:
                     if line.startswith("/NumWaves"):
                         numpes = int(line.split()[-1])
-                        files = []
-                        for i in range(numpes):
-                            files.append(self._gen_fname("pe%d.nii" % (i + 1), cwd=cwd))
+                        files = [self._gen_fname(f"pe{i + 1}.nii", cwd=cwd) for i in range(numpes)]
                         break
         return files
 

--- a/nipype/interfaces/io.py
+++ b/nipype/interfaces/io.py
@@ -975,7 +975,7 @@ class S3DataGrabber(LibraryBaseInterface, IOBase):
                     if self.inputs.sort_filelist:
                         filelist = human_order_sorted(filelist)
                     outputs[key] = simplify_list(filelist)
-            for argnum, arglist in enumerate(args):
+            for arglist in args:
                 maxlen = 1
                 for arg in arglist:
                     if isinstance(arg, (str, bytes)) and hasattr(self.inputs, arg):
@@ -1250,7 +1250,7 @@ class DataGrabber(IOBase):
                     if self.inputs.sort_filelist:
                         filelist = human_order_sorted(filelist)
                     outputs[key] = simplify_list(filelist)
-            for argnum, arglist in enumerate(args):
+            for arglist in args:
                 maxlen = 1
                 for arg in arglist:
                     if isinstance(arg, (str, bytes)) and hasattr(self.inputs, arg):
@@ -1995,7 +1995,7 @@ class XNATSource(LibraryBaseInterface, IOBase):
                         if file_object.exists()
                     ]
                 )
-            for argnum, arglist in enumerate(args):
+            for arglist in args:
                 maxlen = 1
                 for arg in arglist:
                     if isinstance(arg, (str, bytes)) and hasattr(self.inputs, arg):
@@ -2609,7 +2609,7 @@ class SSHDataGrabber(LibraryBaseInterface, DataGrabber):
             if not args:
                 outputs[key] = self._get_files_over_ssh(template)
 
-            for argnum, arglist in enumerate(args):
+            for arglist in args:
                 maxlen = 1
                 for arg in arglist:
                     if isinstance(arg, (str, bytes)) and hasattr(self.inputs, arg):

--- a/nipype/interfaces/nipy/preprocess.py
+++ b/nipype/interfaces/nipy/preprocess.py
@@ -203,7 +203,7 @@ class SpaceTimeRealigner(NipyBaseInterface):
             # nipy does not encode euler angles. return in original form of
             # translation followed by rotation vector see:
             # http://en.wikipedia.org/wiki/Rodrigues'_rotation_formula
-            for i, mo in enumerate(motion):
+            for mo in motion:
                 params = [
                     "%.10f" % item for item in np.hstack((mo.translation, mo.rotation))
                 ]

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -486,9 +486,8 @@ connected.
         dotlist = self._get_dot(prefix="  ", colored=colored, simple_form=simple_form)
         dotstr = f"digraph {self.name}{{\n{dotlist}\n}}"
         if dotfilename:
-            fp = open(dotfilename, "w")
-            fp.writelines(dotstr)
-            fp.close()
+            with open(dotfilename, "w") as fp:
+                fp.writelines(dotstr)
         else:
             logger.info(dotstr)
 

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -528,7 +528,7 @@ connected.
             lines.append(wfdef)
             if include_config:
                 lines.append(f"{self.name}.config = {self.config}")
-            for idx, node in enumerate(nodes):
+            for node in nodes:
                 nodename = node.fullname.replace(".", "_")
                 # write nodes
                 nodelines = format_node(

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -1066,11 +1066,9 @@ connected.
                 if colored:
                     dotlist.extend(
                         (
-                            prefix
-                            + prefix
-                            + 'edge [color="%s"];' % (colorset[level + 1]),
-                            prefix + prefix + "style=filled;",
-                            prefix + prefix + 'fillcolor="%s";' % (colorset[level + 2]),
+                            f'{prefix * 2}edge [color="{colorset[level + 1]}"];',
+                            f"{prefix * 2}style=filled;",
+                            f'{prefix * 2}fillcolor="{colorset[level + 2]}";',
                         )
                     )
                 dotlist.extend(

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -483,12 +483,8 @@ connected.
     def write_hierarchical_dotfile(
         self, dotfilename=None, colored=False, simple_form=True
     ):
-        dotlist = ["digraph %s{" % self.name]
-        dotlist.append(
-            self._get_dot(prefix="  ", colored=colored, simple_form=simple_form)
-        )
-        dotlist.append("}")
-        dotstr = "\n".join(dotlist)
+        dotlist = self._get_dot(prefix="  ", colored=colored, simple_form=simple_form)
+        dotstr = f"digraph {self.name}{{\n{dotlist}\n}}"
         if dotfilename:
             fp = open(dotfilename, "w")
             fp.writelines(dotstr)
@@ -1068,23 +1064,27 @@ connected.
                 nodename = fullname.replace(".", "_")
                 dotlist.append("subgraph cluster_%s {" % nodename)
                 if colored:
-                    dotlist.append(
-                        prefix + prefix + 'edge [color="%s"];' % (colorset[level + 1])
+                    dotlist.extend(
+                        (
+                            prefix
+                            + prefix
+                            + 'edge [color="%s"];' % (colorset[level + 1]),
+                            prefix + prefix + "style=filled;",
+                            prefix + prefix + 'fillcolor="%s";' % (colorset[level + 2]),
+                        )
                     )
-                    dotlist.append(prefix + prefix + "style=filled;")
-                    dotlist.append(
-                        prefix + prefix + 'fillcolor="%s";' % (colorset[level + 2])
-                    )
-                dotlist.append(
-                    node._get_dot(
-                        prefix=prefix + prefix,
-                        hierarchy=hierarchy + [self.name],
-                        colored=colored,
-                        simple_form=simple_form,
-                        level=level + 3,
+                dotlist.extend(
+                    (
+                        node._get_dot(
+                            prefix=prefix + prefix,
+                            hierarchy=hierarchy + [self.name],
+                            colored=colored,
+                            simple_form=simple_form,
+                            level=level + 3,
+                        ),
+                        "}",
                     )
                 )
-                dotlist.append("}")
             else:
                 for subnode in self._graph.successors(node):
                     if node._hierarchy != subnode._hierarchy:

--- a/nipype/pipeline/plugins/somaflow.py
+++ b/nipype/pipeline/plugins/somaflow.py
@@ -24,7 +24,7 @@ class SomaFlowPlugin(GraphPluginBase):
     def _submit_graph(self, pyfiles, dependencies, nodes):
         jobs = []
         soma_deps = []
-        for idx, fname in enumerate(pyfiles):
+        for fname in pyfiles:
             name = os.path.splitext(os.path.split(fname)[1])[0]
             jobs.append(Job(command=[sys.executable, fname], name=name))
         for key, values in list(dependencies.items()):

--- a/nipype/sphinxext/apidoc/docstring.py
+++ b/nipype/sphinxext/apidoc/docstring.py
@@ -62,7 +62,7 @@ class InterfaceDocstring(NipypeDocstring):
     _name_rgx = re.compile(
         r"^\s*(:(?P<role>\w+):`(?P<name>[a-zA-Z0-9_.-]+)`|"
         r" (?P<name2>[a-zA-Z0-9_.-]+))\s*",
-        re.X,
+        re.VERBOSE,
     )
 
     def __init__(

--- a/nipype/sphinxext/plot_workflow.py
+++ b/nipype/sphinxext/plot_workflow.py
@@ -484,7 +484,7 @@ def contains_doctest(text):
         return False
     except SyntaxError:
         pass
-    r = re.compile(r"^\s*>>>", re.M)
+    r = re.compile(r"^\s*>>>", re.MULTILINE)
     m = r.search(text)
     return bool(m)
 

--- a/nipype/utils/docparse.py
+++ b/nipype/utils/docparse.py
@@ -166,13 +166,7 @@ def insert_doc(doc, new_items):
     # Add rest of documents
     tmpdoc.extend(doclist[2:])
     # Insert newlines
-    newdoc = []
-    for line in tmpdoc:
-        newdoc.append(line)
-        newdoc.append("\n")
-    # We add one too many newlines, remove it.
-    newdoc.pop(-1)
-    return "".join(newdoc)
+    return "\n".join(tmpdoc)
 
 
 def build_doc(doc, opts):


### PR DESCRIPTION
## Summary

Partially apply `FURB` rules, where they make sense, except `FURB101` (26 errors), `FURB103` (21 errors), `FURB113` (2 errors), `FURB118` (3 errors), `FURB140` (2 errors), `FURB171` (25 errors).

## List of changes proposed in this PR (pull-request)

* STY: Apply ruff/refurb rule FURB113
     FURB113 Use `list.extend(...)` instead of repeatedly calling `list.append()`
* STY: Apply ruff/refurb rule FURB129
     FURB129 Instead of calling `readlines()`, iterate over file object directly
* STY: Apply ruff/refurb rule FURB136
    FURB136 Replace `20 if len(nodiffidx) >= 20 else len(nodiffidx)` with `min(20, len(nodiffidx))`
* STY: Apply ruff/refurb rule FURB148
    FURB148 `enumerate` index is unused, use `for x in y` instead
* STY: Apply ruff/refurb rule FURB167
    FURB167 Use of regular expression alias `re.X`
    FURB167 Use of regular expression alias `re.M`