### PR TITLE
[FIX] mat 7.3 support for SPM.mat files

### DIFF
--- a/nipype/interfaces/tests/test_matlab.py
+++ b/nipype/interfaces/tests/test_matlab.py
@@ -102,7 +102,7 @@ def test_run_interface(tmpdir):
     # bypasses ubuntu dash issue
     mc = mlab.MatlabCommand(script="foo;", paths=[tmpdir.strpath], mfile=True)
     assert not os.path.exists(default_script_file), "scriptfile should not exist 4."
-    with pytest.raises(OSError):
+    with pytest.raises(RuntimeError):
         mc.run()
     assert os.path.exists(default_script_file), "scriptfile should exist 4."
     if os.path.exists(default_script_file):  # cleanup

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -934,24 +934,32 @@ def indirectory(path):
     finally:
         os.chdir(cwd)
 
+
 def load_spm_mat(spm_mat_file, **kwargs):
     try:
         mat = sio.loadmat(spm_mat_file, **kwargs)
     except NotImplementedError:
         import h5py
         import numpy as np
+
         mat = dict(SPM=np.array([[sio.matlab.mat_struct()]]))
 
         # Get Vbeta, Vcon, and Vspm file names
         with h5py.File(spm_mat_file, "r") as h5file:
             fnames = dict()
             try:
-                fnames["Vbeta"] = [u"".join(chr(c[0]) for c in h5file[obj_ref[0]]) for obj_ref in h5file["SPM"]["Vbeta"]["fname"]]
+                fnames["Vbeta"] = [
+                    u"".join(chr(c[0]) for c in h5file[obj_ref[0]])
+                    for obj_ref in h5file["SPM"]["Vbeta"]["fname"]
+                ]
             except Exception:
                 fnames["Vbeta"] = []
             for contr_type in ["Vcon", "Vspm"]:
                 try:
-                    fnames[contr_type] = [u"".join(chr(c[0]) for c in h5file[obj_ref[0]]["fname"]) for obj_ref in h5file["SPM"]["xCon"][contr_type]]
+                    fnames[contr_type] = [
+                        u"".join(chr(c[0]) for c in h5file[obj_ref[0]]["fname"])
+                        for obj_ref in h5file["SPM"]["xCon"][contr_type]
+                    ]
                 except Exception:
                     fnames[contr_type] = []
 


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary

Fixes #2162
Fixes #3432

## List of changes proposed in this PR (pull-request)
* Replace `sio.loadmat` with a load function specific for `SPM.mat` files, so it also supports >2 GB mat 7.3 HDR files
* Fix MATLAB's `test_run_interface` which I also encountered while running the tests
