### PR TITLE
ENH: FILMGLS gifti output support in surface mode

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -929,7 +929,7 @@
       "affiliation": "Department of Psychological and Brain Sciences, Dartmouth College",
       "name": "Petre, Bogdan",
       "orcid": "0000-0002-8437-168X"
-    },
+    }
   ],
   "keywords": [
     "neuroimaging",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -924,7 +924,12 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    }
+    },
+    {
+      "affiliation": "Department of Psychological and Brain Sciences, Dartmouth College",
+      "name": "Petre, Bogdan",
+      "orcid": "0000-0002-8437-168X"
+    },
   ],
   "keywords": [
     "neuroimaging",

--- a/nipype/interfaces/fsl/base.py
+++ b/nipype/interfaces/fsl/base.py
@@ -57,6 +57,7 @@ class Info(PackageInfo):
         "NIFTI_PAIR": ".img",
         "NIFTI_GZ": ".nii.gz",
         "NIFTI_PAIR_GZ": ".img.gz",
+        "GIFTI": ".func.gii"
     }
 
     if os.getenv("FSLDIR"):
@@ -72,8 +73,8 @@ class Info(PackageInfo):
 
         Parameters
         ----------
-        output_type : {'NIFTI', 'NIFTI_GZ', 'NIFTI_PAIR', 'NIFTI_PAIR_GZ'}
-            String specifying the output type.
+        output_type : {'NIFTI', 'NIFTI_GZ', 'NIFTI_PAIR', 'NIFTI_PAIR_GZ', 'GIFTI'}
+            String specifying the output type. Note: limited GIFTI support.
 
         Returns
         -------

--- a/nipype/interfaces/fsl/base.py
+++ b/nipype/interfaces/fsl/base.py
@@ -57,7 +57,7 @@ class Info(PackageInfo):
         "NIFTI_PAIR": ".img",
         "NIFTI_GZ": ".nii.gz",
         "NIFTI_PAIR_GZ": ".img.gz",
-        "GIFTI": ".func.gii"
+        "GIFTI": ".func.gii",
     }
 
     if os.getenv("FSLDIR"):

--- a/nipype/interfaces/fsl/model.py
+++ b/nipype/interfaces/fsl/model.py
@@ -812,11 +812,19 @@ threshold=10, results_dir='stats')
     _cmd = "film_gls"
     input_spec = FILMGLSInputSpec
     output_spec = FILMGLSOutputSpec
+
     if Info.version() and LooseVersion(Info.version()) > LooseVersion("5.0.6"):
         input_spec = FILMGLSInputSpec507
         output_spec = FILMGLSOutputSpec507
     elif Info.version() and LooseVersion(Info.version()) > LooseVersion("5.0.4"):
         input_spec = FILMGLSInputSpec505
+
+    def __init__(self, **inputs):
+        super(FILMGLS, self).__init__(**inputs)
+        if Info.version() and LooseVersion(Info.version()) > LooseVersion("5.0.6"):
+            if 'output_type' not in inputs:
+                if isdefined(self.inputs.mode) and self.inputs.mode == 'surface':
+                    self.inputs.output_type = 'GIFTI'
 
     def _get_pe_files(self, cwd):
         files = None


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes # .

FILMGLS is an interface for the FSL utility (film_gls) that fits GLM models to fMRI data. Most of FSL is only compatible with NIFTI files and NIFTI variants (e.g. NIFTI_GZ), but modern versions of film_gls in particular support gifti processing and output .func.gii files if a surface mode argument is included when invoking film_gls. Surface mode selection is supported by nipype but cannot be used in nipype workflows due to automated substitution of supported extensions for FSL outputs. With most FSL utilities the extension used to specify output files on the command line automatically selects the output format FSL uses, but film_gls in surface mode produces *.func.gii file in spite of this substitution. When workflow nodes downstream of FILMGLS then attempt to use the outputs of a FILMGLS node they're given the wrong filenames, namely files with NIFTI extensions rather than GIFTI extensions. This produces an error because such files do not exist. This enhancement addresses this issue in two ways.

* addition of GIFTI output file type to class Info of interfaces.fsl.base
* automatic assignment of GIFTI to output_type in FILMGLS constructor if (1) mode is set to 'surface' (2) no output_type is specified and (3) FSL version > 5.0.6
