### PR TITLE
FIX: evaluate_connect_function should raise error on un-nested imports

### DIFF
--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -689,7 +689,7 @@ def evaluate_connect_function(function_source, args, first_arg):
     try:
         output_value = func(first_arg, *list(args))
     except NameError as e:
-        if e.args[0].startswith("global name") and e.args[0].endswith("is not defined"):
+        if e.args[0].endswith("is not defined"):
             e.args = (
                 e.args[0],
                 (

--- a/nipype/pipeline/engine/utils.py
+++ b/nipype/pipeline/engine/utils.py
@@ -689,15 +689,10 @@ def evaluate_connect_function(function_source, args, first_arg):
     try:
         output_value = func(first_arg, *list(args))
     except NameError as e:
-        if e.args[0].endswith("is not defined"):
-            e.args = (
-                e.args[0],
-                (
-                    "Due to engine constraints all imports have to be done "
-                    "inside each function definition"
-                ),
-            )
-        raise e
+        raise NameError(
+            f"{e}: Due to engine constraints all imports have to be done inside each "
+            " function definition."
+        )
     return output_value
 
 


### PR DESCRIPTION
## Summary

if I'm understanding [evaluate_connect_function](https://github.com/nipy/nipype/blob/4d1352ade7171fd5f55eff62cee4c99a4f9cfed1/nipype/pipeline/engine/utils.py#L687) correctly, the _intent_ of the if-clause is to catch errors that arise from calling libraries/modules/functions that were imported at the module level (as opposed to nesting the imports at the function level), and raises a more informative error for those cases. 

I think https://github.com/nipreps/nibabies/pull/365 gives one example where the if-clause _should_  catch such an error, but doesn't, because the error doesn't start with `"global name"`. So I think it should be okay to make the if-clause more permissive, i.e. just check if the error message ends with `"is not defined"`, then return the extra-informative error message to the user.

What do you think?
