### PR TITLE
[ENH] Added available inputs for MRTrix3's 5ttgen

### DIFF
--- a/nipype/interfaces/mrtrix3/tests/test_auto_Generate5tt.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_Generate5tt.py
@@ -28,6 +28,10 @@ def test_Generate5tt_inputs():
             argstr="-fslgrad %s %s",
             xor=["grad_file"],
         ),
+        hippocampi=dict(
+            argstr="-hippocampi %s",
+            usedefault=False,
+        ),
         in_bval=dict(
             extensions=None,
         ),
@@ -39,6 +43,17 @@ def test_Generate5tt_inputs():
             argstr="%s",
             mandatory=True,
             position=-2,
+        ),
+        lut_file=dict(
+            argstr="-lut %s",
+            extensions=None,
+        ),
+        mask_file=dict(
+            argstr="-mask %s",
+            extensions=None,
+        ),
+        nocrop=dict(
+            argstr="-nocrop",
         ),
         nthreads=dict(
             argstr="-nthreads %d",
@@ -56,6 +71,23 @@ def test_Generate5tt_inputs():
             extensions=None,
             mandatory=True,
             position=-1,
+        ),
+        premasked=dict(
+            argstr="-premasked",
+        ),
+        sgm_amyg_hipp=dict(
+            argstr="-sgm_amyg_hipp",
+        ),
+        t2_image=dict(
+            argstr="-t2 %s",
+            extensions=None,
+        ),
+        template=dict(
+            argstr="-template %s",
+            extensions=None,
+        ),
+        white_stem=dict(
+            argstr="-white_stem",
         ),
     )
     inputs = Generate5tt.input_spec()

--- a/nipype/interfaces/mrtrix3/tests/test_auto_Generate5tt.py
+++ b/nipype/interfaces/mrtrix3/tests/test_auto_Generate5tt.py
@@ -30,7 +30,6 @@ def test_Generate5tt_inputs():
         ),
         hippocampi=dict(
             argstr="-hippocampi %s",
-            usedefault=False,
         ),
         in_bval=dict(
             extensions=None,

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -274,7 +274,6 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         "aseg",
         argstr="-hippocampi %s",
         desc="Choose the method used to segment the hippocampi. (Only for 'freesurfer' algorithm)",
-        usedefault=False,
     )
     white_stem = traits.Bool(
         argstr="-white_stem",

--- a/nipype/interfaces/mrtrix3/utils.py
+++ b/nipype/interfaces/mrtrix3/utils.py
@@ -241,6 +241,50 @@ class Generate5ttInputSpec(MRTrix3BaseInputSpec):
         desc="input image / directory",
     )
     out_file = File(argstr="%s", mandatory=True, position=-1, desc="output image")
+    t2_image = File(
+        exists=True,
+        argstr="-t2 %s",
+        desc="Provide a T2-weighted image in addition to the default T1-weighted image. (Only for 'fsl' algorithm)",
+    )
+    mask_file = File(
+        exists=True,
+        argstr="-mask %s",
+        desc="Provide a brain mask image. (Only for 'fsl' algorithm)",
+    )
+    premasked = traits.Bool(
+        argstr="-premasked",
+        desc="Assume that the input image is already brain-masked. (Only for 'fsl' algorithm)",
+    )
+    nocrop = traits.Bool(
+        argstr="-nocrop",
+        desc="Do not crop the image to the region of interest.",
+    )
+    sgm_amyg_hipp = traits.Bool(
+        argstr="-sgm_amyg_hipp",
+        desc="Include the amygdala and hippocampus in the subcortical grey matter segment.",
+    )
+    template = File(
+        exists=True,
+        argstr="-template %s",
+        desc="Provide an image that will form the template for the generated 5TT image. (Only for 'hsvs' algorithm)",
+    )
+    hippocampi = traits.Enum(
+        "subfields",
+        "first",
+        "aseg",
+        argstr="-hippocampi %s",
+        desc="Choose the method used to segment the hippocampi. (Only for 'freesurfer' algorithm)",
+        usedefault=False,
+    )
+    white_stem = traits.Bool(
+        argstr="-white_stem",
+        desc="Classify the brainstem as white matter. (Only for 'hsvs' algorithm)",
+    )
+    lut_file = File(
+        exists=True,
+        argstr="-lut %s",
+        desc="Manually provide path to the lookup table on which the input parcellation image is based. (Only for 'freesurfer' algorithm)",
+    )
 
 
 class Generate5ttOutputSpec(TraitedSpec):


### PR DESCRIPTION
## Summary
Just a small addition of inputs to match those available through the [original implementation of MRTrix3](https://mrtrix.readthedocs.io/en/dev/reference/commands/5ttgen.html).

Fixes #3657.

## List of changes proposed in this PR (pull-request)
Just some additional inputs (t2 file, mask file, etc.).
