### PR TITLE
Use regular ".now" instead of ".utcnow" with UTC zone

### DIFF
--- a/nipype/interfaces/base/support.py
+++ b/nipype/interfaces/base/support.py
@@ -11,11 +11,12 @@ from contextlib import AbstractContextManager
 from copy import deepcopy
 from textwrap import wrap
 import re
-from datetime import datetime as dt, UTC
+from datetime import datetime as dt
 from dateutil.parser import parse as parseutc
 import platform
 
 from ... import logging, config
+from ...utils.datetime import utcnow
 from ...utils.misc import is_container, rgetcwd
 from ...utils.filemanip import md5, hash_infile
 
@@ -72,7 +73,7 @@ class RuntimeContext(AbstractContextManager):
         if self._runtime.redirect_x:
             self._runtime.environ["DISPLAY"] = config.get_display()
 
-        self._runtime.startTime = dt.isoformat(dt.now(UTC))
+        self._runtime.startTime = dt.isoformat(utcnow())
         self._resmon.start()
         # TODO: Perhaps clean-up path and ensure it exists?
         os.chdir(self._runtime.cwd)
@@ -80,7 +81,7 @@ class RuntimeContext(AbstractContextManager):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         """Tear-down interface execution."""
-        self._runtime.endTime = dt.isoformat(dt.now(UTC))
+        self._runtime.endTime = dt.isoformat(utcnow())
         timediff = parseutc(self._runtime.endTime) - parseutc(self._runtime.startTime)
         self._runtime.duration = (
             timediff.days * 86400 + timediff.seconds + timediff.microseconds / 1e6

--- a/nipype/interfaces/base/support.py
+++ b/nipype/interfaces/base/support.py
@@ -11,7 +11,7 @@ from contextlib import AbstractContextManager
 from copy import deepcopy
 from textwrap import wrap
 import re
-from datetime import datetime as dt
+from datetime import datetime as dt, UTC
 from dateutil.parser import parse as parseutc
 import platform
 
@@ -72,7 +72,7 @@ class RuntimeContext(AbstractContextManager):
         if self._runtime.redirect_x:
             self._runtime.environ["DISPLAY"] = config.get_display()
 
-        self._runtime.startTime = dt.isoformat(dt.utcnow())
+        self._runtime.startTime = dt.isoformat(dt.now(UTC))
         self._resmon.start()
         # TODO: Perhaps clean-up path and ensure it exists?
         os.chdir(self._runtime.cwd)
@@ -80,7 +80,7 @@ class RuntimeContext(AbstractContextManager):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         """Tear-down interface execution."""
-        self._runtime.endTime = dt.isoformat(dt.utcnow())
+        self._runtime.endTime = dt.isoformat(dt.now(UTC))
         timediff = parseutc(self._runtime.endTime) - parseutc(self._runtime.startTime)
         self._runtime.duration = (
             timediff.days * 86400 + timediff.seconds + timediff.microseconds / 1e6

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -8,7 +8,6 @@ The `Workflow` class provides core functionality for batch processing.
 import os
 import os.path as op
 import sys
-from datetime import datetime, UTC
 from copy import deepcopy
 import pickle
 import shutil
@@ -16,6 +15,7 @@ import shutil
 import numpy as np
 
 from ... import config, logging
+from ...utils.datetime import utcnow
 from ...utils.misc import str2bool
 from ...utils.functions import getsource, create_function_from_source
 
@@ -627,7 +627,7 @@ connected.
         if str2bool(self.config["execution"]["create_report"]):
             self._write_report_info(self.base_dir, self.name, execgraph)
         runner.run(execgraph, updatehash=updatehash, config=self.config)
-        datestr = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        datestr = utcnow().strftime("%Y%m%dT%H%M%S")
         if str2bool(self.config["execution"]["write_provenance"]):
             prov_base = op.join(self.base_dir, "workflow_provenance_%s" % datestr)
             logger.info("Provenance file prefix: %s" % prov_base)

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -8,7 +8,7 @@ The `Workflow` class provides core functionality for batch processing.
 import os
 import os.path as op
 import sys
-from datetime import datetime
+from datetime import datetime, UTC
 from copy import deepcopy
 import pickle
 import shutil
@@ -627,7 +627,7 @@ connected.
         if str2bool(self.config["execution"]["create_report"]):
             self._write_report_info(self.base_dir, self.name, execgraph)
         runner.run(execgraph, updatehash=updatehash, config=self.config)
-        datestr = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        datestr = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
         if str2bool(self.config["execution"]["write_provenance"]):
             prov_base = op.join(self.base_dir, "workflow_provenance_%s" % datestr)
             logger.info("Provenance file prefix: %s" % prov_base)

--- a/nipype/utils/datetime.py
+++ b/nipype/utils/datetime.py
@@ -1,0 +1,19 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Utilities for dates and time
+"""
+
+from datetime import datetime as dt
+import sys
+
+if sys.version_info >= (3, 11):
+    from datetime import UTC
+
+    def utcnow():
+        """Adapter since 3.12 prior utcnow is deprecated,
+        but not EOLed 3.8 does not have datetime.UTC"""
+        return dt.now(UTC)
+
+else:
+    utcnow = dt.utcnow


### PR DESCRIPTION
It is mandated by starting to receive a DeprecationWarning in python 3.12

    DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)

discovered while addressing some other rot in heudiconv.
