### PR TITLE
STY: Apply ruff rules (RUF)

### DIFF
--- a/nipype/interfaces/ants/__init__.py
+++ b/nipype/interfaces/ants/__init__.py
@@ -50,9 +50,9 @@ from .utils import (
 )
 
 __all__ = [
-    "AffineInitializer",
     "AI",
     "ANTS",
+    "AffineInitializer",
     "AntsJointFusion",
     "ApplyTransforms",
     "ApplyTransformsToPoints",

--- a/nipype/interfaces/base/support.py
+++ b/nipype/interfaces/base/support.py
@@ -27,7 +27,7 @@ HELP_LINEWIDTH = 70
 class RuntimeContext(AbstractContextManager):
     """A context manager to run NiPype interfaces."""
 
-    __slots__ = ("_runtime", "_resmon", "_ignore_exc")
+    __slots__ = ("_ignore_exc", "_resmon", "_runtime")
 
     def __init__(self, resource_monitor=False, ignore_exception=False):
         """Initialize the context manager object."""

--- a/nipype/interfaces/slicer/generate_classes.py
+++ b/nipype/interfaces/slicer/generate_classes.py
@@ -431,7 +431,7 @@ def generate_class(
     output_spec = %module_name%OutputSpec
     _cmd = "%launcher% %name% "
     %output_filenames_code%\n"""
-    template += f"    _redirect_x = {str(redirect_x)}\n"
+    template += f"    _redirect_x = {redirect_x}\n"
 
     main_class = (
         template.replace("%class_str%", class_string)

--- a/nipype/interfaces/spm/base.py
+++ b/nipype/interfaces/spm/base.py
@@ -523,7 +523,7 @@ class SPMCommand(BaseInterface):
         if isinstance(contents, (str, bytes)):
             jobstring += f"{prefix} = '{contents}';\n"
             return jobstring
-        jobstring += f"{prefix} = {str(contents)};\n"
+        jobstring += f"{prefix} = {contents};\n"
         return jobstring
 
     def _make_matlab_command(self, contents, postscript=None):

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -399,7 +399,7 @@ class DistributedPluginBase(PluginBase):
         if (
             cached
             and updated
-            and (overwrite is False or overwrite is None and not always_run)
+            and (overwrite is False or (overwrite is None and not always_run))
         ):
             logger.debug(
                 "Skipping cached node %s with ID %s.", self.procs[jobid], jobid

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -618,7 +618,7 @@ class GraphPluginBase(PluginBase):
                 else:
                     tmp_value = node.plugin_args[keyword]
 
-                if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+                if node.plugin_args.get("overwrite"):
                     value = tmp_value
                 else:
                     value += tmp_value

--- a/nipype/pipeline/plugins/condor.py
+++ b/nipype/pipeline/plugins/condor.py
@@ -38,7 +38,7 @@ class CondorPlugin(SGELikeBatchManagerBase):
         """
         self._retry_timeout = 2
         self._max_tries = 2
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:
@@ -71,7 +71,7 @@ class CondorPlugin(SGELikeBatchManagerBase):
         if self._qsub_args:
             qsubargs = self._qsub_args
         if "qsub_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 qsubargs = node.plugin_args["qsub_args"]
             else:
                 qsubargs += " " + node.plugin_args["qsub_args"]

--- a/nipype/pipeline/plugins/lsf.py
+++ b/nipype/pipeline/plugins/lsf.py
@@ -31,7 +31,7 @@ class LSFPlugin(SGELikeBatchManagerBase):
         self._retry_timeout = 2
         self._max_tries = 2
         self._bsub_args = ""
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:
@@ -70,7 +70,7 @@ class LSFPlugin(SGELikeBatchManagerBase):
         if self._bsub_args:
             bsubargs = self._bsub_args
         if "bsub_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 bsubargs = node.plugin_args["bsub_args"]
             else:
                 bsubargs += " " + node.plugin_args["bsub_args"]

--- a/nipype/pipeline/plugins/oar.py
+++ b/nipype/pipeline/plugins/oar.py
@@ -38,7 +38,7 @@ class OARPlugin(SGELikeBatchManagerBase):
         self._retry_timeout = 2
         self._max_tries = 2
         self._max_jobname_length = 15
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "oarsub_args" in kwargs["plugin_args"]:
                 self._oarsub_args = kwargs["plugin_args"]["oarsub_args"]
             if "retry_timeout" in kwargs["plugin_args"]:
@@ -75,7 +75,7 @@ class OARPlugin(SGELikeBatchManagerBase):
         if self._oarsub_args:
             oarsubargs = self._oarsub_args
         if "oarsub_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 oarsubargs = node.plugin_args["oarsub_args"]
             else:
                 oarsubargs += " " + node.plugin_args["oarsub_args"]

--- a/nipype/pipeline/plugins/pbs.py
+++ b/nipype/pipeline/plugins/pbs.py
@@ -34,7 +34,7 @@ class PBSPlugin(SGELikeBatchManagerBase):
         self._retry_timeout = 2
         self._max_tries = 2
         self._max_jobname_length = 15
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:
@@ -73,7 +73,7 @@ class PBSPlugin(SGELikeBatchManagerBase):
         if self._qsub_args:
             qsubargs = self._qsub_args
         if "qsub_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 qsubargs = node.plugin_args["qsub_args"]
             else:
                 qsubargs += " " + node.plugin_args["qsub_args"]

--- a/nipype/pipeline/plugins/sge.py
+++ b/nipype/pipeline/plugins/sge.py
@@ -400,7 +400,7 @@ class SGEPlugin(SGELikeBatchManagerBase):
         instant_qstat = "qstat"
         cached_qstat = "qstat"
 
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:
@@ -428,7 +428,7 @@ class SGEPlugin(SGELikeBatchManagerBase):
         if self._qsub_args:
             qsubargs = self._qsub_args
         if "qsub_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 qsubargs = node.plugin_args["qsub_args"]
             else:
                 qsubargs += " " + node.plugin_args["qsub_args"]

--- a/nipype/pipeline/plugins/sgegraph.py
+++ b/nipype/pipeline/plugins/sgegraph.py
@@ -47,7 +47,7 @@ class SGEGraphPlugin(GraphPluginBase):
     def __init__(self, **kwargs):
         self._qsub_args = ""
         self._dont_resubmit_completed_jobs = False
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             plugin_args = kwargs["plugin_args"]
             if "template" in plugin_args:
                 self._template = plugin_args["template"]

--- a/nipype/pipeline/plugins/slurm.py
+++ b/nipype/pipeline/plugins/slurm.py
@@ -40,7 +40,7 @@ class SLURMPlugin(SGELikeBatchManagerBase):
         self._sbatch_args = None
         self._jobid_re = "Submitted batch job ([0-9]*)"
 
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:
@@ -100,7 +100,7 @@ class SLURMPlugin(SGELikeBatchManagerBase):
         if self._sbatch_args:
             sbatch_args = self._sbatch_args
         if "sbatch_args" in node.plugin_args:
-            if "overwrite" in node.plugin_args and node.plugin_args["overwrite"]:
+            if node.plugin_args.get("overwrite"):
                 sbatch_args = node.plugin_args["sbatch_args"]
             else:
                 sbatch_args += " " + node.plugin_args["sbatch_args"]

--- a/nipype/pipeline/plugins/slurmgraph.py
+++ b/nipype/pipeline/plugins/slurmgraph.py
@@ -42,7 +42,7 @@ class SLURMGraphPlugin(GraphPluginBase):
 
     def __init__(self, **kwargs):
         self._sbatch_args = ""
-        if "plugin_args" in kwargs and kwargs["plugin_args"]:
+        if kwargs.get("plugin_args"):
             if "retry_timeout" in kwargs["plugin_args"]:
                 self._retry_timeout = kwargs["plugin_args"]["retry_timeout"]
             if "max_tries" in kwargs["plugin_args"]:

--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -55,7 +55,7 @@ another exception occurred:\n\n{}.""".format(
         login_name = getpass.getuser()
     except KeyError:
         login_name = f"UID{os.getuid():d}"
-    crashfile = f"crash-{timeofcrash}-{login_name}-{name}-{str(uuid.uuid4())}"
+    crashfile = f"crash-{timeofcrash}-{login_name}-{name}-{uuid.uuid4()}"
     crashdir = node.config["execution"].get("crashdump_dir", os.getcwd())
 
     os.makedirs(crashdir, exist_ok=True)

--- a/nipype/utils/filemanip.py
+++ b/nipype/utils/filemanip.py
@@ -716,14 +716,14 @@ def write_rst_header(header, level=0):
 def write_rst_list(items, prefix=""):
     out = []
     for item in ensure_list(items):
-        out.append(f"{prefix} {str(item)}")
+        out.append(f"{prefix} {item}")
     return "\n".join(out) + "\n\n"
 
 
 def write_rst_dict(info, prefix=""):
     out = []
     for key, value in sorted(info.items()):
-        out.append(f"{prefix}* {key} : {str(value)}")
+        out.append(f"{prefix}* {key} : {value}")
     return "\n".join(out) + "\n\n"
 
 

--- a/nipype/utils/nipype_cmd.py
+++ b/nipype/utils/nipype_cmd.py
@@ -52,7 +52,7 @@ def run_instance(interface, options):
             try:
                 setattr(interface.inputs, input_name, value)
             except ValueError as e:
-                print(f"Error when setting the value of {input_name}: '{str(e)}'")
+                print(f"Error when setting the value of {input_name}: '{e}'")
 
     print(interface.inputs)
     res = interface.run()


### PR DESCRIPTION
## Summary

Apply [Ruff-specific rules (RUF)](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b), except:
* [RUF002](https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring/) (seems useless to me)
* [RUF005](https://docs.astral.sh/ruff/rules/collection-literal-concatenation/) (not sure the resulting code is more readable)
* [RUF012](https://docs.astral.sh/ruff/rules/mutable-class-default/) (only useful with MyPy)
* [RUF015](https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element/) (left for later...)
* [RUF017](https://docs.astral.sh/ruff/rules/quadratic-list-summation/) (breaks CI, left for later...)