### PR TITLE
Fix nipy#3653 and nipy#3654 in the CAT12 Interface

### DIFF
--- a/nipype/interfaces/cat12/preprocess.py
+++ b/nipype/interfaces/cat12/preprocess.py
@@ -113,9 +113,9 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
         'rhe "Optimized Shooting - superlarge ventricles" option for "Spatial registration" is ! '
         "required Values: \nnone: 0;\nlight: 1;\nfull: 2;\ndefault: 1070."
     )
-    initial_segmentation = traits.Int(
-        0, field="extopts.spm_kamap", desc=_help_initial_seg, usedefault=True
-    )
+    # initial_segmentation = traits.Int(
+    #     0, field="extopts.spm_kamap", desc=_help_initial_seg, usedefault=True
+    # )
 
     _help_las = (
         "Additionally to WM-inhomogeneities, GM intensity can vary across different regions such as the motor"
@@ -232,10 +232,8 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
     surface_measures = traits.Int(
         1,
         field="output.surf_measures",
-        # usedefault=True,
+        usedefault=True,
         desc="Extract surface measures",
-        # requires=["neuromorphometrics", "lpba40", "cobra", "hammers", "thalamus", "thalamic_nuclei", "suit", "ibsr"],
-        # xor=["noROI"],
     )
 
     # Templates
@@ -244,56 +242,56 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
         field="output.ROImenu.atlases.neuromorphometrics",
         # usedefault=True,
         desc="Extract brain measures for Neuromorphometrics template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     lpba40 = traits.Bool(
         True,
         field="output.ROImenu.atlases.lpba40",
         # usedefault=True,
         desc="Extract brain measures for LPBA40 template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     cobra = traits.Bool(
         True,
         field="output.ROImenu.atlases.hammers",
         # usedefault=True,
         desc="Extract brain measures for COBRA template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     hammers = traits.Bool(
         False,
         field="output.ROImenu.atlases.cobra",
         # usedefault=True,
         desc="Extract brain measures for Hammers template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     thalamus = traits.Bool(
         True,
         field="output.ROImenu.atlases.thalamus",
         # usedefault=True,
         desc="Extract brain measures for Thalamus template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     thalamic_nuclei = traits.Bool(
         True,
-        field="output.ROImenu.atlases.thalamaic_nuclei",
+        field="output.ROImenu.atlases.thalamic_nuclei",
         # usedefault=True,
         desc="Extract brain measures for Thalamic Nuclei template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     suit = traits.Bool(
         True,
         field="output.ROImenu.atlases.suit",
         # usedefault=True,
         desc="Extract brain measures for Suit template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     ibsr = traits.Bool(
         False,
         field="output.ROImenu.atlases.ibsr",
         # usedefault=True,
         desc="Extract brain measures for IBSR template",
-        xor=["noROI"],
+        xor=["noROI"]
     )
     own_atlas = InputMultiPath(
         ImageFileSPM(exists=True),
@@ -301,7 +299,7 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
         desc="Extract brain measures for a given template",
         mandatory=False,
         copyfile=False,
-        xor=["noROI"],
+        xor=["noROI"]
     )
     noROI = traits.Bool(
         field="output.ROImenu.noROI",
@@ -574,9 +572,10 @@ class CAT12Segment(SPMCommand):
     def _list_outputs(self):
         outputs = self._outputs().get()
         f = self.inputs.in_files[0]
-        pth, base, ext = split_filename(f)
         if '.nii.gz' in f:
             f = f[:-3]
+        pth, base, ext = split_filename(f)
+
         outputs["mri_images"] = [
             str(mri) for mri in Path(pth).glob("mri/*") if mri.is_file()
         ]
@@ -626,14 +625,17 @@ class CAT12Segment(SPMCommand):
         outputs["label_files"] = [
             str(label) for label in Path(pth).glob("label/*") if label.is_file()
         ]
-
-        if self.inputs.noROI:
-            outputs["label_rois"] = fname_presuffix(
-                f, prefix=os.path.join("label", "catROIs_"), suffix=".xml", use_ext=False
-            )
+        
+        if self.inputs.neuromorphometrics or self.inputs.lpba40 or self.inputs.cobra or self.inputs.hammers or self.inputs.thalamus or self.inputs.thalamic_nuclei or self.inputs.suit or self.inputs.ibsr:
             outputs["label_roi"] = fname_presuffix(
                 f, prefix=os.path.join("label", "catROI_"), suffix=".xml", use_ext=False
             )
+
+        if self.inputs.surface_and_thickness_estimation:
+            outputs["label_rois"] = fname_presuffix(
+                f, prefix=os.path.join("label", "catROIs_"), suffix=".xml", use_ext=False
+            )
+            
 
         return outputs
 

--- a/nipype/interfaces/cat12/preprocess.py
+++ b/nipype/interfaces/cat12/preprocess.py
@@ -525,6 +525,13 @@ class CAT12Segment(SPMCommand):
                 return scans_for_fname(val)
         elif opt in ["tpm", "shooting_tpm"]:
             return Cell2Str(val)
+        
+        if opt == "surface_measures":
+            if not self.inputs.surface_measures:
+                self.inputs.neuromorphometrics = False
+                self.inputs.lpba40 = False
+                self.inputs.cobra = False
+                self.inputs.hammers = False
 
         return super()._format_arg(opt, spec, val)
 
@@ -583,12 +590,14 @@ class CAT12Segment(SPMCommand):
             str(label) for label in Path(pth).glob("label/*") if label.is_file()
         ]
 
-        outputs["label_rois"] = fname_presuffix(
-            f, prefix=os.path.join("label", "catROIs_"), suffix=".xml", use_ext=False
-        )
-        outputs["label_roi"] = fname_presuffix(
-            f, prefix=os.path.join("label", "catROI_"), suffix=".xml", use_ext=False
-        )
+        if self.inputs.surface_measures:
+            outputs["label_rois"] = fname_presuffix(
+                f, prefix=os.path.join("label", "catROIs_"), suffix=".xml", use_ext=False
+            )
+        else:
+            outputs["label_roi"] = fname_presuffix(
+                f, prefix=os.path.join("label", "catROI_"), suffix=".xml", use_ext=False
+            )
 
         return outputs
 

--- a/nipype/interfaces/cat12/preprocess.py
+++ b/nipype/interfaces/cat12/preprocess.py
@@ -9,6 +9,7 @@ from nipype.interfaces.base import (
     isdefined,
     File,
     Str,
+    ImageFile,
 )
 from nipype.interfaces.cat12.base import Cell
 
@@ -24,7 +25,7 @@ from nipype.utils.filemanip import split_filename, fname_presuffix
 
 class CAT12SegmentInputSpec(SPMCommandInputSpec):
     in_files = InputMultiPath(
-        ImageFileSPM(exists=True),
+        ImageFile(exists=True),
         field="data",
         desc="file to segment",
         mandatory=True,
@@ -560,6 +561,8 @@ class CAT12Segment(SPMCommand):
         """Convert input to appropriate format for spm"""
         if opt == "in_files":
             if isinstance(val, list):
+                if '.nii.gz' in val[0]:
+                    return scans_for_fnames(val, keep4d=True)
                 return scans_for_fnames(val)
             else:
                 return scans_for_fname(val)
@@ -572,7 +575,8 @@ class CAT12Segment(SPMCommand):
         outputs = self._outputs().get()
         f = self.inputs.in_files[0]
         pth, base, ext = split_filename(f)
-
+        if '.nii.gz' in f:
+            f = f[:-3]
         outputs["mri_images"] = [
             str(mri) for mri in Path(pth).glob("mri/*") if mri.is_file()
         ]


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes [nipy#3653](https://github.com/nipy/nipype/issues/3653) and [nipy#3654](https://github.com/nipy/nipype/issues/3654).

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* Added input trait for the option of no surface measures (noROI) in the CAT12 Segment function.
* Added missing input traits (that were added to the Matlab GUI but not updated in Nipype's CAT12 Interface) for the templates used for surface measures (e.g. thalamus, thalamic_nuclei).
* Added option to process compressed nifti files (.nii.gz) like the latest GUI version allows.
* Corrected if statement for saving ROI and ROIs (surface measure) files.
