### PR TITLE
DOC: Patch doc/conf.py to work with latest ReadTheDocs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,14 @@ from packaging.version import Version
 import nipype
 import subprocess as sp
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # Disable etelemetry during doc builds
 os.environ["NIPYPE_NO_ET"] = "1"
 


### PR DESCRIPTION
Readthedocs builds are failing and linking us to https://about.readthedocs.com/blog/2024/07/addons-by-default/.