### PR TITLE
RF: Replace deprecated pkgutil.find_loader with importlib.util.find_spec

### DIFF
--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -1045,12 +1045,12 @@ class LibraryBaseInterface(BaseInterface):
     def __init__(self, check_import=True, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if check_import:
-            import pkgutil
+            import importlib.util
 
             failed_imports = [
                 pkg
                 for pkg in (self._pkg,) + tuple(self.imports)
-                if pkgutil.find_loader(pkg) is None
+                if importlib.util.find_spec(pkg) is None
             ]
             if failed_imports:
                 iflogger.warning(


### PR DESCRIPTION
`pkgutil.find_loader` was deprecated in 3.12, will be removed in 3.14, and its replacement has been around since 3.4.