### PR TITLE
Update to .wci.yml

### DIFF
--- a/.wci.yml
+++ b/.wci.yml
@@ -2,7 +2,7 @@
 
 name: nipype
 
-headline: Neuroimaging in Python: Pipelines and Interfaces
+headline: "Neuroimaging in Python: Pipelines and Interfaces"
 
 description: |
     Nipype, an open-source, community-developed initiative under the umbrella of NiPy, is a Python project that


### PR DESCRIPTION

## Summary
The headline information contains a colon, thus it is necessary to put the text within quotes. I will comment the nipype repo in the Workflows Community website for now as it is failing the build. Once this fix is accepted, I will enable the repository again. Thank you!
