### PR TITLE
fix: Resolve crashes when running workflows with updatehash=True

### DIFF
--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -452,7 +452,7 @@ class Node(EngineBase):
         cached, updated = self.is_cached()
 
         # If the node is cached, check on pklz files and finish
-        if cached and not force_run and (updated or (not updated and updatehash)):
+        if cached and not force_run and (updated or updatehash):
             logger.debug("Only updating node hashes or skipping execution")
             inputs_file = op.join(outdir, "_inputs.pklz")
             if not op.exists(inputs_file):

--- a/nipype/pipeline/engine/nodes.py
+++ b/nipype/pipeline/engine/nodes.py
@@ -452,7 +452,7 @@ class Node(EngineBase):
         cached, updated = self.is_cached()
 
         # If the node is cached, check on pklz files and finish
-        if not force_run and (updated or (not updated and updatehash)):
+        if cached and not force_run and (updated or (not updated and updatehash)):
             logger.debug("Only updating node hashes or skipping execution")
             inputs_file = op.join(outdir, "_inputs.pklz")
             if not op.exists(inputs_file):

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -336,8 +336,9 @@ class MultiProcPlugin(DistributedPluginBase):
             if self._local_hash_check(jobid, graph):
                 continue
 
+            cached, updated = self.procs[jobid].is_cached()
             # updatehash and run_without_submitting are also run locally
-            if updatehash or self.procs[jobid].run_without_submitting:
+            if (cached and updatehash and not updated) or self.procs[jobid].run_without_submitting:
                 logger.debug("Running node %s on master thread", self.procs[jobid])
                 try:
                     self.procs[jobid].run(updatehash=updatehash)


### PR DESCRIPTION
Any workflow running with updatehash=True will crash

That happens because in nodes.py line 457 we try to update the hashfile even if the node was never executed before, so no hashfile is found and _update_hash function raises an exception.