### PR TITLE
[FIX] Set length to 1 when np.squeeze returns a 0D array

### DIFF
--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1495,7 +1495,11 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
             for d, fname in enumerate(nii):
                 data = np.asanyarray(nb.load(fname).dataobj).reshape(-1)
                 cdata = nb.load(cname).dataobj[..., d].reshape(-1)
-                nels = len(idxs)
+                try:
+                    nels = len(idxs)
+                except TypeError:
+                    nels = 1
+
                 idata = (idxs,)
                 data[idata] = cdata[0:nels]
                 nb.Nifti1Image(data.reshape(rsh[:3]), aff, hdr).to_filename(fname)

--- a/nipype/algorithms/misc.py
+++ b/nipype/algorithms/misc.py
@@ -1490,18 +1490,13 @@ def merge_rois(in_files, in_idxs, in_ref, dtype=None, out_file=None):
 
         for cname, iname in zip(in_files, in_idxs):
             f = np.load(iname)
-            idxs = np.squeeze(f["arr_0"])
+            idxs = np.atleast_1d(np.squeeze(f["arr_0"]))
+            nels = len(idxs)
 
             for d, fname in enumerate(nii):
                 data = np.asanyarray(nb.load(fname).dataobj).reshape(-1)
                 cdata = nb.load(cname).dataobj[..., d].reshape(-1)
-                try:
-                    nels = len(idxs)
-                except TypeError:
-                    nels = 1
-
-                idata = (idxs,)
-                data[idata] = cdata[0:nels]
+                data[idxs] = cdata[:nels]
                 nb.Nifti1Image(data.reshape(rsh[:3]), aff, hdr).to_filename(fname)
 
         imgs = [nb.load(im) for im in nii]


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->

Fixes #3712 .

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- try getting the len of `idxs`
- if it fails with TypeError (which happens when `idxs` is a 0D array)
- set `nels` to 1