### PR TITLE
chore: Remove direct URL for traits on py313

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,6 @@ pass_env =
   CLICOLOR
   CLICOLOR_FORCE
   PYTHON_GIL
-deps =
-  py313: traits @ git+https://github.com/enthought/traits.git@10954eb
 extras =
   tests
   full: doc


### PR DESCRIPTION
Traits 7 is released, with Python 3.13 support.