### PR TITLE
[ENH] Add -w flag to dcm2niix interface

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -376,6 +376,14 @@ class Dcm2niixInputSpec(CommandLineInputSpec):
         argstr="-p", desc="Philips precise float (not display) scaling"
     )
     to_nrrd = traits.Bool(argstr="-e", desc="Export as NRRD instead of NIfTI")
+    name_conflicts = traits.Enum(
+        2,
+        1,
+        0,
+        argstr="-w %d",
+        usedefault=True,
+        descr="Write behavior for name conflicts - [0=skip duplicates, 1=overwrite, 2=add suffix]",
+    )
 
 
 class Dcm2niixOutputSpec(TraitedSpec):

--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -406,7 +406,7 @@ class Dcm2niix(CommandLine):
     >>> converter.inputs.compression = 5
     >>> converter.inputs.output_dir = 'ds005'
     >>> converter.cmdline
-    'dcm2niix -b y -z y -5 -x n -t n -m 0 -o ds005 -s n -v n dicomdir'
+    'dcm2niix -b y -z y -5 -x n -t n -m 0 -w 2 -o ds005 -s n -v n dicomdir'
     >>> converter.run() # doctest: +SKIP
 
     In the example below, we note that the current version of dcm2niix
@@ -419,7 +419,7 @@ class Dcm2niix(CommandLine):
     >>> converter.inputs.compression = 5
     >>> converter.inputs.output_dir = 'ds005'
     >>> converter.cmdline
-    'dcm2niix -b y -z y -5 -x n -t n -m 0 -o ds005 -s n -v n .'
+    'dcm2niix -b y -z y -5 -x n -t n -m 0 -w 2 -o ds005 -s n -v n .'
     >>> converter.run() # doctest: +SKIP
     """
 

--- a/nipype/interfaces/tests/test_auto_Dcm2niix.py
+++ b/nipype/interfaces/tests/test_auto_Dcm2niix.py
@@ -44,6 +44,11 @@ def test_Dcm2niix_inputs():
             argstr="-m %d",
             usedefault=True,
         ),
+        name_conflicts=dict(
+            argstr="-w %d",
+            descr="Write behavior for name conflicts - [0=skip duplicates, 1=overwrite, 2=add suffix]",
+            usedefault=True,
+        ),
         out_filename=dict(
             argstr="-f %s",
         ),


### PR DESCRIPTION
Add support for this:
`-w : write behavior for name conflicts (0,1,2, default 2: 0=skip duplicates, 1=overwrite, 2=add suffix)`
