### PR TITLE
fix: catch oserror from getpass.getuser

### DIFF
--- a/nipype/pipeline/plugins/tools.py
+++ b/nipype/pipeline/plugins/tools.py
@@ -47,7 +47,7 @@ another exception occurred:\n\n{}.""".format(exc).splitlines(keepends=True)
     timeofcrash = strftime("%Y%m%d-%H%M%S")
     try:
         login_name = getpass.getuser()
-    except KeyError:
+    except (KeyError, OSError):
         login_name = f"UID{os.getuid():d}"
     crashfile = f"crash-{timeofcrash}-{login_name}-{name}-{uuid.uuid4()}"
     crashdir = node.config["execution"].get("crashdump_dir", os.getcwd())


### PR DESCRIPTION
OSError is always raised as of 3.13