### PR TITLE
Fix SPM output type for version 25

### DIFF
--- a/nipype/interfaces/spm/model.py
+++ b/nipype/interfaces/spm/model.py
@@ -315,7 +315,7 @@ class EstimateModel(SPMCommand):
     def _list_outputs(self):
         outputs = self._outputs().get()
         pth = os.path.dirname(self.inputs.spm_mat_file)
-        outtype = "nii" if "12" in self.version.split(".")[0] else "img"
+        outtype = "nii" if self.version.split(".")[0] in ["12", "25"] else "img"
         spm = load_spm_mat(self.inputs.spm_mat_file, struct_as_record=False)
 
         betas = [vbeta.fname[0] for vbeta in spm["SPM"][0, 0].Vbeta[0]]


### PR DESCRIPTION
## Summary

Fixes # .

Updated the `_list_outputs` method in `nipype.interfaces.spm.base` to handle SPM version 25 correctly. Previously, the code only checked for SPM12 when determining the output file type (`nii` vs `img`). Now, both SPM12 and SPM25 are treated as using `nii` format.

## List of changes proposed in this PR (pull-request)
- [x] Modified `_list_outputs` to use:
      ```python
      outtype = "nii" if self.version.split(".")[0] in ["12", "25"] else "img"
      ```
- [x] Verified that output type defaults to `"nii"` for SPM version 25.
