### PR TITLE
fix: Properly quote file paths with spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ nipype/testing/data/von-ray_errmap.nii.gz
 nipype/testing/data/von_errmap.nii.gz
 nipype/testing/data/.proc*
 crash*.pklz
-.coverage
+.coverage*
 htmlcov/
 __pycache__/
 *~
@@ -31,7 +31,7 @@ __pycache__/
 .pytest_cache
 .vscode/
 venv/
-/nipype/_version.py
+_version.py
 uv.lock
- .venv/
- .tox/
+.venv/
+.tox/

--- a/nipype/conftest.py
+++ b/nipype/conftest.py
@@ -1,6 +1,7 @@
+import importlib
 import os
 import shutil
-from tempfile import mkdtemp
+import tempfile
 import pytest
 import numpy as np
 import py.path as pp
@@ -8,12 +9,37 @@ import py.path as pp
 NIPYPE_DATADIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), "testing/data")
 )
-temp_folder = mkdtemp()
-data_dir = os.path.join(temp_folder, "data")
-shutil.copytree(NIPYPE_DATADIR, data_dir)
+NIPYPE_TMPDIR = tempfile.mkdtemp()
+TMP_DATADIR = os.path.join(NIPYPE_TMPDIR, "data")
+
+
+def pytest_configure(config):
+    global TMP_DATADIR
+    # Pytest uses gettempdir() to construct its tmp_paths, but the logic to get
+    # `pytest-of-<user>/pytest-<n>` directories is contingent on not directly
+    # configuring the `config.option.base_temp` value.
+    # Instead of replicating that logic, inject a new directory into gettempdir()
+    #
+    # Use the discovered temp dir as a base, to respect user/system settings.
+    if ' ' not in (base_temp := tempfile.gettempdir()):
+        new_base = os.path.join(base_temp, "nipype tmp")
+        os.makedirs(new_base, exist_ok=True)
+        os.environ['TMPDIR'] = new_base
+        importlib.reload(tempfile)
+        assert tempfile.gettempdir() == new_base
+        TMP_DATADIR = os.path.join(new_base, "data")
+
+    # xdist will result in this being run multiple times
+    if not os.path.exists(TMP_DATADIR):
+        shutil.copytree(NIPYPE_DATADIR, TMP_DATADIR)
+
+
+def pytest_unconfigure(config):
+    shutil.rmtree(NIPYPE_TMPDIR)
+
 
 if "SUBJECTS_DIR" not in os.environ:
-    os.environ["SUBJECTS_DIR"] = temp_folder
+    os.environ["SUBJECTS_DIR"] = NIPYPE_TMPDIR
 
 
 @pytest.fixture(autouse=True)
@@ -21,7 +47,7 @@ def add_np(doctest_namespace):
     doctest_namespace["np"] = np
     doctest_namespace["os"] = os
     doctest_namespace["pytest"] = pytest
-    doctest_namespace["datadir"] = data_dir
+    doctest_namespace["datadir"] = TMP_DATADIR
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -36,7 +62,7 @@ def _docdir(request):
     doctest_plugin = request.config.pluginmanager.getplugin("doctest")
     if isinstance(request.node, doctest_plugin.DoctestItem):
         # Get the fixture dynamically by its name.
-        tmpdir = pp.local(data_dir)
+        tmpdir = pp.local(TMP_DATADIR)
 
         # Chdir only for the duration of the test.
         with tmpdir.as_cwd():
@@ -45,8 +71,3 @@ def _docdir(request):
     else:
         # For normal tests, we have to yield, since this is a yield-fixture.
         yield
-
-
-def pytest_unconfigure(config):
-    # Delete temp folder after session is finished
-    shutil.rmtree(temp_folder)

--- a/nipype/interfaces/afni/preprocess.py
+++ b/nipype/interfaces/afni/preprocess.py
@@ -2860,9 +2860,9 @@ class TNorm(AFNICommand):
     >>> tnorm = afni.TNorm()
     >>> tnorm.inputs.in_file = 'functional.nii'
     >>> tnorm.inputs.norm2 = True
-    >>> tnorm.inputs.out_file = 'rm.errts.unit errts+tlrc'
+    >>> tnorm.inputs.out_file = 'errts+tlrc'
     >>> tnorm.cmdline
-    '3dTnorm -norm2 -prefix rm.errts.unit errts+tlrc functional.nii'
+    '3dTnorm -norm2 -prefix errts+tlrc functional.nii'
     >>> res = tshift.run()  # doctest: +SKIP
 
     """

--- a/nipype/interfaces/ants/utils.py
+++ b/nipype/interfaces/ants/utils.py
@@ -928,7 +928,7 @@ class LabelGeometry(ANTSCommand):
     >>> label_extract.inputs.dimension = 3
     >>> label_extract.inputs.label_image = 'atlas.nii.gz'
     >>> label_extract.cmdline
-    'LabelGeometryMeasures 3 atlas.nii.gz [] atlas.csv'
+    "LabelGeometryMeasures 3 atlas.nii.gz '[]' atlas.csv"
 
     >>> label_extract.inputs.intensity_image = 'ants_Warp.nii.gz'
     >>> label_extract.cmdline

--- a/nipype/interfaces/ants/visualization.py
+++ b/nipype/interfaces/ants/visualization.py
@@ -28,7 +28,7 @@ class ConvertScalarImageToRGBInputSpec(ANTSCommandInputSpec):
     )
     mask_image = traits.Either(
         "none",
-        traits.File(exists=True),
+        File(exists=True),
         argstr="%s",
         desc="mask image",
         position=3,

--- a/nipype/interfaces/base/core.py
+++ b/nipype/interfaces/base/core.py
@@ -33,7 +33,7 @@ from ...utils.subprocess import run_command
 
 from ...external.due import due
 
-from .traits_extension import traits, isdefined, Undefined
+from .traits_extension import traits, isdefined, BasePath, Undefined
 from .specs import (
     BaseInterfaceInputSpec,
     CommandLineInputSpec,
@@ -796,6 +796,13 @@ class CommandLine(BaseInterface):
             # type-checking code here as well
             sep = trait_spec.sep if trait_spec.sep is not None else " "
 
+            if argstr == '%s':
+                inner_traits = getattr(trait_spec, "inner_traits", None)
+                if inner_traits and any(
+                    t.is_trait_type(BasePath) for t in inner_traits
+                ):
+                    values = [shlex.quote(elt) for elt in value]
+
             if argstr.endswith("..."):
                 # repeatable option
                 # --id %d... will expand to
@@ -805,6 +812,9 @@ class CommandLine(BaseInterface):
             else:
                 return argstr % sep.join(str(elt) for elt in value)
         else:
+            if trait_spec.is_trait_type(BasePath):
+                if "'%s'" not in argstr and '"%s"' not in argstr:
+                    value = shlex.quote(value)
             # Append options using format string.
             return argstr % value
 

--- a/nipype/interfaces/base/tests/test_core.py
+++ b/nipype/interfaces/base/tests/test_core.py
@@ -608,3 +608,19 @@ def test_runtime_checks():
 
     with pytest.raises(RuntimeError):
         BrokenRuntime().run()
+
+
+def test_CommandLine_escape(tmp_path):
+    test_file = tmp_path / "test file.txt"
+    test_file.write_text("content")
+
+    class InputSpec(nib.TraitedSpec):
+        in_file = nib.File(desc="a file", exists=True, argstr="%s")
+
+    class CatCommand(nib.CommandLine):
+        input_spec = InputSpec
+        _cmd = "cat"
+
+    command = CatCommand(in_file=str(test_file))
+    result = command.run()
+    assert result.runtime.stdout == "content"

--- a/nipype/interfaces/freesurfer/preprocess.py
+++ b/nipype/interfaces/freesurfer/preprocess.py
@@ -1976,7 +1976,7 @@ class BBRegister(FSCommand):
                 outputs["out_fsl_file"] = op.abspath(_in.out_fsl_file)
 
         if isdefined(_in.init_cost_file):
-            if isinstance(_in.out_fsl_file, bool):
+            if isinstance(_in.init_cost_file, bool):
                 outputs["init_cost_file"] = outputs["out_reg_file"] + ".initcost"
             else:
                 outputs["init_cost_file"] = op.abspath(_in.init_cost_file)

--- a/nipype/interfaces/freesurfer/utils.py
+++ b/nipype/interfaces/freesurfer/utils.py
@@ -321,7 +321,8 @@ class SampleToSurface(FSCommand):
     >>> sampler.inputs.sampling_range = 1
     >>> sampler.inputs.sampling_units = "frac"
     >>> sampler.cmdline  # doctest: +ELLIPSIS
-    'mri_vol2surf --hemi lh --o ...lh.cope1.mgz --reg register.dat --projfrac-avg 1.000 --mov cope1.nii.gz'
+    "mri_vol2surf --hemi lh --o '.../lh.cope1.mgz' --reg register.dat \
+    --projfrac-avg 1.000 --mov cope1.nii.gz"
     >>> res = sampler.run() # doctest: +SKIP
 
     """
@@ -478,7 +479,8 @@ class SurfaceSmooth(FSCommand):
     >>> smoother.inputs.hemi = "lh"
     >>> smoother.inputs.fwhm = 5
     >>> smoother.cmdline # doctest: +ELLIPSIS
-    'mri_surf2surf --cortex --fwhm 5.0000 --hemi lh --sval lh.cope1.mgz --tval ...lh.cope1_smooth5.mgz --s subj_1'
+    "mri_surf2surf --cortex --fwhm 5.0000 --hemi lh --sval lh.cope1.mgz \
+    --tval '.../lh.cope1_smooth5.mgz' --s subj_1"
     >>> smoother.run() # doctest: +SKIP
 
     """

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -575,8 +575,8 @@ class EddyInputSpec(FSLCommandInputSpec):
         argstr="--bvals=%s",
         desc="File containing the b-values for all volumes in --imain",
     )
-    out_base = traits.Str(
-        default_value="eddy_corrected",
+    out_base = File(
+        "eddy_corrected",
         usedefault=True,
         argstr="--out=%s",
         desc="Basename for output image",
@@ -753,7 +753,7 @@ class EddyInputSpec(FSLCommandInputSpec):
         requires=["mporder"],
         min_ver="5.0.11",
     )
-    slice_order = traits.File(
+    slice_order = File(
         exists=True,
         argstr="--slspec=%s",
         desc="Name of text file completely specifying slice/group acquisition",
@@ -761,7 +761,7 @@ class EddyInputSpec(FSLCommandInputSpec):
         xor=["json"],
         min_ver="5.0.11",
     )
-    json = traits.File(
+    json = File(
         exists=True,
         argstr="--json=%s",
         desc="Name of .json text file with information about slice timing",
@@ -1346,14 +1346,10 @@ class EPIDeWarpInputSpec(FSLCommandInputSpec):
         desc="2D spatial gaussing smoothing \
                        stdev (default = 2mm)",
     )
-    vsm = traits.String(genfile=True, desc="voxel shift map", argstr="--vsm %s")
-    exfdw = traits.String(
-        desc="dewarped example func volume", genfile=True, argstr="--exfdw %s"
-    )
-    epidw = traits.String(
-        desc="dewarped epi volume", genfile=False, argstr="--epidw %s"
-    )
-    tmpdir = traits.String(genfile=True, desc="tmpdir", argstr="--tmpdir %s")
+    vsm = File(genfile=True, desc="voxel shift map", argstr="--vsm %s")
+    exfdw = File(desc="dewarped example func volume", genfile=True, argstr="--exfdw %s")
+    epidw = File(desc="dewarped epi volume", genfile=False, argstr="--epidw %s")
+    tmpdir = File(genfile=True, desc="tmpdir", argstr="--tmpdir %s")
     nocleanup = traits.Bool(
         True, usedefault=True, desc="no cleanup", argstr="--nocleanup"
     )

--- a/nipype/interfaces/fsl/epi.py
+++ b/nipype/interfaces/fsl/epi.py
@@ -80,8 +80,7 @@ class PrepareFieldmap(FSLCommand):
     >>> prepare.inputs.in_magnitude = "magnitude.nii"
     >>> prepare.inputs.output_type = "NIFTI_GZ"
     >>> prepare.cmdline # doctest: +ELLIPSIS
-    'fsl_prepare_fieldmap SIEMENS phase.nii magnitude.nii \
-.../phase_fslprepared.nii.gz 2.460000'
+    "fsl_prepare_fieldmap SIEMENS phase.nii magnitude.nii '.../phase_fslprepared.nii.gz' 2.460000"
     >>> res = prepare.run() # doctest: +SKIP
 
 
@@ -906,20 +905,20 @@ class Eddy(FSLCommand):
     >>> eddy.inputs.in_bvec  = 'bvecs.scheme'
     >>> eddy.inputs.in_bval  = 'bvals.scheme'
     >>> eddy.cmdline          # doctest: +ELLIPSIS
-    'eddy_openmp --flm=quadratic --ff=10.0 \
+    "eddy_openmp --flm=quadratic --ff=10.0 \
 --acqp=epi_acqp.txt --bvals=bvals.scheme --bvecs=bvecs.scheme \
 --imain=epi.nii --index=epi_index.txt --mask=epi_mask.nii \
 --interp=spline --resamp=jac --niter=5 --nvoxhp=1000 \
---out=.../eddy_corrected --slm=none'
+--out='.../eddy_corrected' --slm=none"
 
     Running eddy on an Nvidia GPU using cuda:
     >>> eddy.inputs.use_cuda = True
     >>> eddy.cmdline # doctest: +ELLIPSIS
-    'eddy_cuda --flm=quadratic --ff=10.0 \
+    "eddy_cuda --flm=quadratic --ff=10.0 \
 --acqp=epi_acqp.txt --bvals=bvals.scheme --bvecs=bvecs.scheme \
 --imain=epi.nii --index=epi_index.txt --mask=epi_mask.nii \
 --interp=spline --resamp=jac --niter=5 --nvoxhp=1000 \
---out=.../eddy_corrected --slm=none'
+--out='.../eddy_corrected' --slm=none"
 
     Running eddy with slice-to-volume motion correction:
     >>> eddy.inputs.mporder = 6
@@ -928,12 +927,12 @@ class Eddy(FSLCommand):
     >>> eddy.inputs.slice2vol_interp = 'trilinear'
     >>> eddy.inputs.slice_order = 'epi_slspec.txt'
     >>> eddy.cmdline          # doctest: +ELLIPSIS
-    'eddy_cuda --flm=quadratic --ff=10.0 \
+    "eddy_cuda --flm=quadratic --ff=10.0 \
 --acqp=epi_acqp.txt --bvals=bvals.scheme --bvecs=bvecs.scheme \
 --imain=epi.nii --index=epi_index.txt --mask=epi_mask.nii \
 --interp=spline --resamp=jac --mporder=6 --niter=5 --nvoxhp=1000 \
---out=.../eddy_corrected --s2v_interp=trilinear --s2v_lambda=1 \
---s2v_niter=5 --slspec=epi_slspec.txt --slm=none'
+--out='.../eddy_corrected' --s2v_interp=trilinear --s2v_lambda=1 \
+--s2v_niter=5 --slspec=epi_slspec.txt --slm=none"
     >>> res = eddy.run()     # doctest: +SKIP
 
     """
@@ -986,11 +985,11 @@ class Eddy(FSLCommand):
 
     def _format_arg(self, name, spec, value):
         if name == "in_topup_fieldcoef":
-            return spec.argstr % value.split("_fieldcoef")[0]
-        if name == "field":
-            return spec.argstr % fname_presuffix(value, use_ext=False)
-        if name == "out_base":
-            return spec.argstr % os.path.abspath(value)
+            value = value.split("_fieldcoef")[0]
+        elif name == "field":
+            value = fname_presuffix(value, use_ext=False)
+        elif name == "out_base":
+            value = os.path.abspath(value)
         return super()._format_arg(name, spec, value)
 
     def _list_outputs(self):
@@ -1105,7 +1104,7 @@ class SigLoss(FSLCommand):
     >>> sigloss.inputs.echo_time = 0.03
     >>> sigloss.inputs.output_type = "NIFTI_GZ"
     >>> sigloss.cmdline # doctest: +ELLIPSIS
-    'sigloss --te=0.030000 -i phase.nii -s .../phase_sigloss.nii.gz'
+    "sigloss --te=0.030000 -i phase.nii -s '.../phase_sigloss.nii.gz'"
     >>> res = sigloss.run() # doctest: +SKIP
 
 
@@ -1381,9 +1380,9 @@ class EPIDeWarp(FSLCommand):
     >>> dewarp.inputs.dph_file = "phase.nii"
     >>> dewarp.inputs.output_type = "NIFTI_GZ"
     >>> dewarp.cmdline # doctest: +ELLIPSIS
-    'epidewarp.fsl --mag magnitude.nii --dph phase.nii --epi functional.nii \
---esp 0.58 --exfdw .../exfdw.nii.gz --nocleanup --sigma 2 --tediff 2.46 \
---tmpdir .../temp --vsm .../vsm.nii.gz'
+    "epidewarp.fsl --mag magnitude.nii --dph phase.nii --epi functional.nii \
+--esp 0.58 --exfdw '.../exfdw.nii.gz' --nocleanup --sigma 2 --tediff 2.46 \
+--tmpdir '.../temp' --vsm '.../vsm.nii.gz'"
     >>> res = dewarp.run() # doctest: +SKIP
 
 

--- a/nipype/interfaces/niftyreg/regutils.py
+++ b/nipype/interfaces/niftyreg/regutils.py
@@ -814,7 +814,7 @@ class RegTransform(NiftyRegCommand):
     >>> node.inputs.def_input = 'warpfield.nii'
     >>> node.inputs.omp_core_val = 4
     >>> node.cmdline  # doctest: +ELLIPSIS
-    'reg_transform -omp 4 -def warpfield.nii .../warpfield_trans.nii.gz'
+    "reg_transform -omp 4 -def warpfield.nii '.../warpfield_trans.nii.gz'"
 
     """
 

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -6,6 +6,7 @@ import sys
 from copy import deepcopy
 from glob import glob
 import os
+import shlex
 import shutil
 from time import sleep, time
 from traceback import format_exception
@@ -565,7 +566,7 @@ class SGELikeBatchManagerBase(DistributedPluginBase):
         batch_dir, name = os.path.split(pyscript)
         name = ".".join(name.split(".")[:-1])
         batchscript = "\n".join(
-            (self._template.rstrip("\n"), f"{sys.executable} {pyscript}")
+            (self._template.rstrip("\n"), shlex.join([sys.executable, pyscript]))
         )
         batchscriptfile = os.path.join(batch_dir, "batchscript_%s.sh" % name)
         with open(batchscriptfile, "w") as fp:

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ extras =
   full: ssh
   full: nipy
 setenv =
+  NO_ET=1
   FSLOUTPUTTYPE=NIFTI_GZ
   pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   pre: UV_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
## Summary
This PR aims to ensure that we handle files/directories with spaces correctly. Unfortunately, there are a number of interfaces that separately handle the problem by including quotes in their `argstr`s, some with single quotes, some with double quotes. We have to assume that there are downstream tools that do the same.

This therefore *narrowly* addresses the case where the `argstr` is a plain-as-dirt `%s` and the trait is either a `File`/`Directory` or a list of such things. 

Fixes #3604.

## List of changes proposed in this PR (pull-request)
* Add a space to the base test directory.
* Specifically test a file name with a space in it.

### Unrelated changes that I don't want to open separate PRs for
* Add lxml to dependencies so the package will install and import.
* Fix a bbregister bug that I'm not sure how I came to notice, where the `isinstance` check had been copied from the previous `if` block but not updated to match the new context.
* Add `NO_ET` to the tox environments to improve startup times for testing.
