### PR TITLE
FIX: Propagate errors from `run_without_submitting`

### DIFF
--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -215,7 +215,9 @@ class DistributedPluginBase(PluginBase):
         if self._run_errors:
             # If one or more nodes failed, re-raise first of them
             error, cause = self._run_errors[0], None
-            if isinstance(error, (str, list)):  # Error can also be a list of strings (traceback)
+            if isinstance(
+                error, (str, list)
+            ):  # Error can also be a list of strings (traceback)
                 error = RuntimeError(error)
 
             if len(self._run_errors) > 1:

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -114,7 +114,6 @@ class DistributedPluginBase(PluginBase):
         self.proc_pending = None
         self.pending_tasks = []
         self.max_jobs = self.plugin_args.get("max_jobs", np.inf)
-        self._run_errors = None
 
     def _prerun_check(self, graph):
         """Stub method to validate/massage graph and nodes before running"""
@@ -214,9 +213,9 @@ class DistributedPluginBase(PluginBase):
         self._postrun_check()
 
         if self._run_errors:
-            # If one or more nodes failed, re-rise first of them
+            # If one or more nodes failed, re-raise first of them
             error, cause = self._run_errors[0], None
-            if isinstance(error, str):
+            if isinstance(error, (str, list)):  # Error can also be a list of strings (traceback)
                 error = RuntimeError(error)
 
             if len(self._run_errors) > 1:
@@ -224,7 +223,6 @@ class DistributedPluginBase(PluginBase):
                     RuntimeError(f"{len(self._run_errors)} raised. Re-raising first."),
                     error,
                 )
-
             raise error from cause
 
     def _get_result(self, taskid):

--- a/nipype/pipeline/plugins/base.py
+++ b/nipype/pipeline/plugins/base.py
@@ -114,6 +114,7 @@ class DistributedPluginBase(PluginBase):
         self.proc_pending = None
         self.pending_tasks = []
         self.max_jobs = self.plugin_args.get("max_jobs", np.inf)
+        self._run_errors = None
 
     def _prerun_check(self, graph):
         """Stub method to validate/massage graph and nodes before running"""
@@ -125,6 +126,9 @@ class DistributedPluginBase(PluginBase):
         """
         Executes a pre-defined pipeline using distributed approaches
         """
+        # Ensure only current run errors are reported
+        self._run_errors = []
+
         logger.info("Running in parallel.")
         self._config = config
         poll_sleep_secs = float(config["execution"]["poll_sleep_duration"])
@@ -136,7 +140,6 @@ class DistributedPluginBase(PluginBase):
         self.mapnodesubids = {}
         # setup polling - TODO: change to threaded model
         notrun = []
-        errors = []
 
         old_progress_stats = None
         old_presub_stats = None
@@ -171,14 +174,14 @@ class DistributedPluginBase(PluginBase):
                     result = self._get_result(taskid)
                 except Exception as exc:
                     notrun.append(self._clean_queue(jobid, graph))
-                    errors.append(exc)
+                    self._run_errors.append(exc)
                 else:
                     if result:
                         if result["traceback"]:
                             notrun.append(
                                 self._clean_queue(jobid, graph, result=result)
                             )
-                            errors.append("".join(result["traceback"]))
+                            self._run_errors.append("".join(result["traceback"]))
                         else:
                             self._task_finished_cb(jobid)
                             self._remove_node_dirs()
@@ -210,15 +213,15 @@ class DistributedPluginBase(PluginBase):
         # close any open resources
         self._postrun_check()
 
-        if errors:
+        if self._run_errors:
             # If one or more nodes failed, re-rise first of them
-            error, cause = errors[0], None
+            error, cause = self._run_errors[0], None
             if isinstance(error, str):
                 error = RuntimeError(error)
 
-            if len(errors) > 1:
+            if len(self._run_errors) > 1:
                 error, cause = (
-                    RuntimeError(f"{len(errors)} raised. Re-raising first."),
+                    RuntimeError(f"{len(self._run_errors)} raised. Re-raising first."),
                     error,
                 )
 

--- a/nipype/pipeline/plugins/legacymultiproc.py
+++ b/nipype/pipeline/plugins/legacymultiproc.py
@@ -430,6 +430,7 @@ class LegacyMultiProcPlugin(DistributedPluginBase):
                     self.procs[jobid].run(updatehash=updatehash)
                 except Exception:
                     traceback = format_exception(*sys.exc_info())
+                    self._run_errors.append(traceback)
                     self._clean_queue(
                         jobid, graph, result={"result": None, "traceback": traceback}
                     )

--- a/nipype/pipeline/plugins/multiproc.py
+++ b/nipype/pipeline/plugins/multiproc.py
@@ -272,6 +272,7 @@ class MultiProcPlugin(DistributedPluginBase):
             free_gpu_slots,
             self.n_gpu_procs,
         )
+
         if self._stats != stats:
             tasks_list_msg = ""
 
@@ -389,6 +390,7 @@ class MultiProcPlugin(DistributedPluginBase):
                     self.procs[jobid].run(updatehash=updatehash)
                 except Exception:
                     traceback = format_exception(*sys.exc_info())
+                    self._run_errors.append(traceback)
                     self._clean_queue(
                         jobid, graph, result={"result": None, "traceback": traceback}
                     )

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -34,6 +34,11 @@ class MultiprocTestInterface(nib.BaseInterface):
         return outputs
 
 
+class ErrorInterface(MultiprocTestInterface):
+    def _run_interface(self, runtime):
+        raise RuntimeError("This is an error")
+
+
 @pytest.mark.skipif(
     sys.version_info >= (3, 8), reason="multiprocessing issues in Python 3.8"
 )
@@ -157,3 +162,19 @@ def test_hold_job_until_procs_available(tmpdir):
 
     max_threads = 2
     pipe.run(plugin="MultiProc", plugin_args={"n_procs": max_threads})
+
+
+def test_error_run_without_submitting(tmp_path):
+    wf = pe.Workflow(name='rws', base_dir=tmp_path)
+    n1 = pe.Node(MultiprocTestInterface(), name='n1')
+    n1.inputs.input1 = 1
+    n2 = pe.Node(ErrorInterface(), name='n2', run_without_submitting=True)
+    n3 = pe.Node(MultiprocTestInterface(), name='n3')
+
+    wf.connect([
+        (n1, n2, [('output1', 'input1')]),
+        (n2, n3, [('output1', 'input1')]),
+    ]),
+
+    with pytest.raises(RuntimeError):
+        wf.run(plugin='MultiProc')

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -34,11 +34,6 @@ class MultiprocTestInterface(nib.BaseInterface):
         return outputs
 
 
-class ErrorInterface(MultiprocTestInterface):
-    def _run_interface(self, runtime):
-        raise RuntimeError("This is an error")
-
-
 @pytest.mark.skipif(
     sys.version_info >= (3, 8), reason="multiprocessing issues in Python 3.8"
 )
@@ -81,6 +76,11 @@ class SingleNodeTestInterface(nib.BaseInterface):
         outputs = self._outputs().get()
         outputs["output1"] = self.inputs.input1
         return outputs
+
+
+class ErrorInterface(SingleNodeTestInterface):
+    def _run_interface(self, runtime):
+        raise RuntimeError("This is an error")
 
 
 def test_no_more_memory_than_specified(tmpdir):
@@ -164,12 +164,13 @@ def test_hold_job_until_procs_available(tmpdir):
     pipe.run(plugin="MultiProc", plugin_args={"n_procs": max_threads})
 
 
-def test_error_run_without_submitting(tmp_path):
-    wf = pe.Workflow(name='rws', base_dir=tmp_path)
-    n1 = pe.Node(MultiprocTestInterface(), name='n1')
+@pytest.mark.parametrize("plugin", ["MultiProc", "LegacyMultiProc"])
+def test_error_run_without_submitting(tmp_path, plugin):
+    wf = pe.Workflow(name='rws', base_dir=str(tmp_path))
+    n1 = pe.Node(SingleNodeTestInterface(), name='n1')
     n1.inputs.input1 = 1
     n2 = pe.Node(ErrorInterface(), name='n2', run_without_submitting=True)
-    n3 = pe.Node(MultiprocTestInterface(), name='n3')
+    n3 = pe.Node(SingleNodeTestInterface(), name='n3')
 
     wf.connect([
         (n1, n2, [('output1', 'input1')]),
@@ -177,4 +178,4 @@ def test_error_run_without_submitting(tmp_path):
     ]),
 
     with pytest.raises(RuntimeError):
-        wf.run(plugin='MultiProc')
+        wf.run(plugin=plugin)

--- a/nipype/pipeline/plugins/tests/test_multiproc.py
+++ b/nipype/pipeline/plugins/tests/test_multiproc.py
@@ -172,10 +172,12 @@ def test_error_run_without_submitting(tmp_path, plugin):
     n2 = pe.Node(ErrorInterface(), name='n2', run_without_submitting=True)
     n3 = pe.Node(SingleNodeTestInterface(), name='n3')
 
-    wf.connect([
-        (n1, n2, [('output1', 'input1')]),
-        (n2, n3, [('output1', 'input1')]),
-    ]),
+    wf.connect(
+        [
+            (n1, n2, [('output1', 'input1')]),
+            (n2, n3, [('output1', 'input1')]),
+        ]
+    ),
 
     with pytest.raises(RuntimeError):
         wf.run(plugin=plugin)


### PR DESCRIPTION
Came up in https://github.com/nipreps/fmriprep/issues/3611 , https://github.com/nipreps/nibabies/issues/392

This adds a  `_run_errors` attribute to `DistributedPluginBase` which is only utilized during the `run()` lifecycle, to ensure any encountered errors are properly reported.

Each distributed plugin may need to be updated, this only touches on `MultiProc` and `LegacyMultiProc`.