### PR TITLE
chore(ci): Split pre-release tests into cron job, open issues on failure

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -55,9 +55,11 @@ jobs:
           uv tool install --with=tox-uv --with=tox-gh-actions tox
       - name: Show tox config
         run: tox c
+      - name: Setup test suite
+        run: tox run -vv --notest
       - name: Run tox
         id: pre
-        run: tox -v --exit-and-dump-after 1200
+        run: tox -v --skip-pkg-install --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Show tox config
         run: tox c
       - name: Run tox
+        id: pre
         run: tox -v --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v5
         with:
@@ -67,3 +68,20 @@ jobs:
           name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dependencies }}
           path: test-results.xml
         if: always()
+      - name: Create issue
+        # Workflows triggered by schedule only notify the workflow creator
+        # So let's open an issue to make sure this is visible to all
+        if: ${{ steps.pre.outcome != 'success' }}
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          workflow_name: PRE-RELEASE TESTS
+        with:
+          filename: .github/workflow_failure.md
+          update_existing: true
+          search_existing: open
+      - name: Return failure
+        if: ${{ steps.pre.outcome != 'success' }}
+        run: exit 1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,69 @@
+name: Prerelease tests
+
+on:
+  push:
+    branches:
+      - ci/prerelease
+  schedule:
+    # 8am EST / 9am EDT Mondays
+    - cron: "0 13 * * 1"
+  # Allow job to be triggered manually from GitHub interface
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Force tox and pytest to use color
+  FORCE_COLOR: true
+
+
+jobs:
+  test:
+    # Check each OS, all supported Python, minimum versions and latest releases
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.12", "3.13"]
+        dependencies: [pre]
+
+    env:
+      DEPENDS: ${{ matrix.dependencies }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install tox
+        run: |
+          uv tool install --with=tox-uv --with=tox-gh-actions tox
+      - name: Show tox config
+        run: tox c
+      - name: Run tox
+        run: tox -v --exit-and-dump-after 1200
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ always() }}
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v7
+        with:
+          name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dependencies }}
+          path: test-results.xml
+        if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,8 +115,10 @@ jobs:
           uv tool install --with=tox-uv --with=tox-gh-actions tox
       - name: Show tox config
         run: tox c
+      - name: Setup test suite
+        run: tox run -vv --notest
       - name: Run tox
-        run: tox -v --exit-and-dump-after 1200
+        run: tox -v --skip-pkg-install --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -156,8 +158,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Install tox
         run: uv tool install --with=tox-uv tox
-      - name: Show tox config
-        run: tox c
       - name: Show tox config (this call)
         run: tox c -e ${{ matrix.check }}
       - name: Run check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,22 +85,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        dependencies: [none, full, pre]
+        dependencies: [none, full]
         include:
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: min
         exclude:
           # Skip some intermediate versions for full tests
-          - python-version: "3.10"
-            dependencies: full
           - python-version: "3.11"
             dependencies: full
-          # Do not test pre-releases for versions out of SPEC0
-          - python-version: "3.10"
-            dependencies: pre
-          - python-version: "3.11"
-            dependencies: pre
+          - python-version: "3.12"
+            dependencies: full
 
     env:
       DEPENDS: ${{ matrix.dependencies }}

--- a/.github/workflows/workflow_failure.md
+++ b/.github/workflows/workflow_failure.md
@@ -1,0 +1,7 @@
+---
+title: ":rotating_light: {{ env.workflow_name }}: failure"
+---
+
+The run `{{ env.run_id }}` of the workflow {{ env.workflow_name }} failed.
+
+You can view [the log](https://github.com/{{ env.repository }}/actions/runs/{{ env.run_id }})


### PR DESCRIPTION
In #3745, the pre-release tests are failing, causing other the PR to fail. This is generally not desirable, as these are rarely the fault of contributor PRs. This pulls the prerelease tests into their own workflow, run on a schedule rather than PR. The `ci/prerelease` branch can be used to debug and fix issues.

@remi-gau helped me set this up in nibabel.

Incidentally, also split the install and test tox stages. Sometimes install can fail or take a long time due to infrastructure issues, and it's nice to separate that from test failures at a glance.