### PR TITLE
FIX: cat12 - fix cobra/hammers field swap, add missing atlases and WMHstr parameter

### DIFF
--- a/nipype/interfaces/cat12/preprocess.py
+++ b/nipype/interfaces/cat12/preprocess.py
@@ -162,6 +162,15 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
         1, field="extopts.WMHC", desc=_help_wmhc, usedefault=True
     )
 
+    _help_wmhcstr = (
+        "Strength of WM hyperintensity correction. Only has an effect if wm_hyper_intensity_correction "
+        "is set to 1 or 2. Controls how aggressively WMHs are reclassified. "
+        "Values: 0 (no correction) to 1 (maximum correction); default: 0.5."
+    )
+    wm_hyper_intensity_correction_strength = traits.Float(
+        0.5, field="extopts.WMHCstr", desc=_help_wmhcstr, usedefault=True
+    )
+
     _help_vox = (
         "The (isotropic) voxel sizes of any spatially normalised written images. A non-finite value will be "
         "replaced by the average voxel size of the tissue probability maps used by the segmentation."
@@ -250,15 +259,63 @@ class CAT12SegmentInputSpec(SPMCommandInputSpec):
     )
     cobra = traits.Bool(
         True,
-        field="output.ROImenu.atlases.hammers",
+        field="output.ROImenu.atlases.cobra",
         usedefault=True,
         desc="Extract brain measures for COBRA template",
     )
     hammers = traits.Bool(
         True,
-        field="output.ROImenu.atlases.cobra",
+        field="output.ROImenu.atlases.hammers",
         usedefault=True,
         desc="Extract brain measures for Hammers template",
+    )
+    ibsr = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.ibsr",
+        usedefault=True,
+        desc="Extract brain measures for IBSR template",
+    )
+    aal3 = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.aal3",
+        usedefault=True,
+        desc="Extract brain measures for AAL3 template",
+    )
+    mori = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.mori",
+        usedefault=True,
+        desc="Extract brain measures for Mori template",
+    )
+    anatomy3 = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.anatomy3",
+        usedefault=True,
+        desc="Extract brain measures for Anatomy3 template",
+    )
+    julichbrain3 = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.julichbrain3",
+        usedefault=True,
+        desc="Extract brain measures for JulichBrain3 template",
+    )
+    thalamus = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.thalamus",
+        usedefault=True,
+        desc="Extract brain measures for Thalamus template",
+    )
+    thalamic_nuclei = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.thalamic_nuclei",
+        usedefault=True,
+        desc="Extract brain measures for Thalamic Nuclei template",
+    )
+    suit = traits.Bool(
+        False,
+        field="output.ROImenu.atlases.suit",
+        usedefault=True,
+        desc="Extract brain measures for SUIT cerebellar template",
     )
     own_atlas = InputMultiPath(
         ImageFileSPM(exists=True),

--- a/nipype/interfaces/cat12/tests/test_auto_CAT12Segment.py
+++ b/nipype/interfaces/cat12/tests/test_auto_CAT12Segment.py
@@ -4,6 +4,10 @@ from ..preprocess import CAT12Segment
 
 def test_CAT12Segment_inputs():
     input_map = dict(
+        aal3=dict(
+            field="output.ROImenu.atlases.aal3",
+            usedefault=True,
+        ),
         affine_preprocessing=dict(
             field="extopts.APP",
             usedefault=True,
@@ -12,8 +16,12 @@ def test_CAT12Segment_inputs():
             field="opts.affreg",
             usedefault=True,
         ),
+        anatomy3=dict(
+            field="output.ROImenu.atlases.anatomy3",
+            usedefault=True,
+        ),
         cobra=dict(
-            field="output.ROImenu.atlases.hammers",
+            field="output.ROImenu.atlases.cobra",
             usedefault=True,
         ),
         csf_output_dartel=dict(
@@ -41,7 +49,11 @@ def test_CAT12Segment_inputs():
             usedefault=True,
         ),
         hammers=dict(
-            field="output.ROImenu.atlases.cobra",
+            field="output.ROImenu.atlases.hammers",
+            usedefault=True,
+        ),
+        ibsr=dict(
+            field="output.ROImenu.atlases.ibsr",
             usedefault=True,
         ),
         ignore_errors=dict(
@@ -65,6 +77,10 @@ def test_CAT12Segment_inputs():
         ),
         jacobianwarped=dict(
             field="output.jacobianwarped",
+            usedefault=True,
+        ),
+        julichbrain3=dict(
+            field="output.ROImenu.atlases.julichbrain3",
             usedefault=True,
         ),
         label_dartel=dict(
@@ -101,6 +117,10 @@ def test_CAT12Segment_inputs():
         ),
         matlab_cmd=dict(),
         mfile=dict(
+            usedefault=True,
+        ),
+        mori=dict(
+            field="output.ROImenu.atlases.mori",
             usedefault=True,
         ),
         n_jobs=dict(
@@ -160,12 +180,24 @@ def test_CAT12Segment_inputs():
             field="extopts.gcutstr",
             usedefault=True,
         ),
+        suit=dict(
+            field="output.ROImenu.atlases.suit",
+            usedefault=True,
+        ),
         surface_and_thickness_estimation=dict(
             field="surface",
             usedefault=True,
         ),
         surface_measures=dict(
             field="output.surf_measures",
+            usedefault=True,
+        ),
+        thalamic_nuclei=dict(
+            field="output.ROImenu.atlases.thalamic_nuclei",
+            usedefault=True,
+        ),
+        thalamus=dict(
+            field="output.ROImenu.atlases.thalamus",
             usedefault=True,
         ),
         tpm=dict(
@@ -190,6 +222,10 @@ def test_CAT12Segment_inputs():
         ),
         wm_hyper_intensity_correction=dict(
             field="extopts.WMHC",
+            usedefault=True,
+        ),
+        wm_hyper_intensity_correction_strength=dict(
+            field="extopts.WMHCstr",
             usedefault=True,
         ),
         wm_output_dartel=dict(


### PR DESCRIPTION
- Fix swapped field paths for cobra and hammers ROI atlases: cobra was pointing to 'output.ROImenu.atlases.hammers' and vice versa
- Add 9 new atlas inputs present in current CAT12 but missing from the interface: ibsr, aal3, mori, anatomy3, julichbrain3, thalamus, thalamic_nuclei, suit (all default False as they require optional atlas files to be installed)
- Add wm_hyper_intensity_correction_strength (extopts.WMHCstr, default 0.5) to control the strength of WMH reclassification when WMHC is 1 or 2
