### PR TITLE
fix: Make a copy of connection tuples to avoid mutating wf.connect() arguments

### DIFF
--- a/nipype/pipeline/engine/tests/test_workflows.py
+++ b/nipype/pipeline/engine/tests/test_workflows.py
@@ -2,6 +2,7 @@
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Tests for the engine workflows module"""
 
+from copy import deepcopy
 from glob import glob
 import os
 from shutil import rmtree
@@ -32,6 +33,31 @@ def test_connect():
     assert mod1 in pipe._graph.nodes()
     assert mod2 in pipe._graph.nodes()
     assert pipe._graph.get_edge_data(mod1, mod2) == {"connect": [("output1", "input1")]}
+
+
+def _add_one(x):
+    return x + 1
+
+
+def test_connect_preserves_input_list():
+    """Regression test for connection list mutation.
+
+    This only occurs when the connection contains an inline function node.
+    """
+    pipe = pe.Workflow(name="pipe")
+    pipe.config["execution"]["poll_sleep_duration"] = 0.01
+    mod1 = pe.Node(EngineTestInterface(input1=2), name="mod1")
+    mod2 = pe.MapNode(EngineTestInterface(), iterfield="input1", name="mod2")
+
+    connection_list = [(mod1, mod2, [(('output1', _add_one), 'input1')])]
+    expected = [
+        (in_node, out_node, deepcopy(connections))
+        for in_node, out_node, connections in connection_list
+    ]
+    assert connection_list == expected
+
+    pipe.connect(connection_list)
+    assert connection_list == expected
 
 
 def test_add_nodes():

--- a/nipype/pipeline/engine/workflows.py
+++ b/nipype/pipeline/engine/workflows.py
@@ -127,7 +127,8 @@ class Workflow(EngineBase):
              and execute it remotely
         """
         if len(args) == 1:
-            connection_list = args[0]
+            # Connections can be modified in-place, so make a copy
+            connection_list = [(src, dst, list(conns)) for src, dst, conns in args[0]]
         elif len(args) == 4:
             connection_list = [(args[0], args[2], [(args[1], args[3])])]
         else:


### PR DESCRIPTION
Uncovered in nipreps/fmriprep#3668. Passing a list to `workflow.connect()` mutates the list if any of the connections uses an inline function. Regression test fails without fix:

```
============================================= FAILURES =============================================
________________________________ test_connect_preserves_input_list _________________________________

    def test_connect_preserves_input_list():
        """Regression test for connection list mutation.
    
        This only occurs when the connection contains an inline function node.
        """
        pipe = pe.Workflow(name="pipe")
        pipe.config["execution"]["poll_sleep_duration"] = 0.01
        mod1 = pe.Node(EngineTestInterface(input1=2), name="mod1")
        mod2 = pe.MapNode(EngineTestInterface(), iterfield="input1", name="mod2")
    
        connection_list = [(mod1, mod2, [(('output1', _add_one), 'input1')])]
        expected = [
            (in_node, out_node, deepcopy(connections))
            for in_node, out_node, connections in connection_list
        ]
        assert connection_list == expected
    
        pipe.connect(connection_list)
>       assert connection_list == expected
E       AssertionError: assert [(pipe.mod1, ..., 'input1')])] == [(pipe.mod1, ..., 'input1')])]
E         
E         At index 0 diff: (pipe.mod1, pipe.mod2, [(('output1', 'def _add_one(x):\n    return x + 1\n', ()), 'input1')]) != (pipe.mod1, pipe.mod2, [(('output1', <function _add_one at 0x7f3e059abab0>), 'input1')])
E         
E         Full diff:
E          
E         
E         ...Full output truncated (18 lines hidden), use '-vv' to show

nipype/pipeline/engine/tests/test_workflows.py:60: AssertionError
```